### PR TITLE
Add polygon delimiter for imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ command line arguments
  - ```-p``` database port, optional default value is 5432
  - ```-f``` path of xml output file, e.g. _/Users/christoph/berlin.sorl.xml.gz_
  - ```-l``` languages to import, e.g. _de en es_
+ - ```-o``` optional polygon delimiter to import, in WKT format, e.g _-71.1 42.3,-71.1 42.3,-71.1 42.3_
 
 A complete example:
 
@@ -49,9 +50,9 @@ A complete example:
 mvn compile exec:java -Dexec.mainClass=de.komoot.photon.importer.NominatimImporter -Dexec.args="-h localhost -d nominatim_island -u christoph -P christoph -f /Users/christoph/iceland.solr.xml.gz -l en de es" > /home/christoph/island_import.log
 ```
 
-This will take some time (Europe ~ 12 hours). 
+This will take some time (Europe ~ 12 hours).
 
-If you just want to check out _photon_ you can use our example dump of Iceland too: [src/main/solrindex/iceland.solr.xml.gz](src/main/solrindex/iceland.solr.xml.gz) (©&nbsp;[OpenStreetMap contributors](http://www.openstreetmap.org/copyright)). 
+If you just want to check out _photon_ you can use our example dump of Iceland too: [src/main/solrindex/iceland.solr.xml.gz](src/main/solrindex/iceland.solr.xml.gz) (©&nbsp;[OpenStreetMap contributors](http://www.openstreetmap.org/copyright)).
 
 ### Setup Solr
 You need to install Apache Solr (tested with version 4.4). Using Mac OS X and homebrew you can type:

--- a/src/main/java/de/komoot/photon/importer/IndexCrawler.java
+++ b/src/main/java/de/komoot/photon/importer/IndexCrawler.java
@@ -132,10 +132,11 @@ public class IndexCrawler {
 	/**
 	 * get all records for xml conversions
 	 *
+         * @param polygon
 	 * @return
 	 * @throws SQLException
 	 */
-	public ResultSet getAllRecords() throws SQLException {
+	public ResultSet getAllRecords(String polygon) throws SQLException {
 		PreparedStatement statementAll;
 
 		StringBuilder sqlSelectNames = new StringBuilder(SQL_TEMPLATE_HSTORE_NAME);
@@ -145,6 +146,9 @@ public class IndexCrawler {
 
 		String sql = String.format(SQL_TEMPLATE, sqlSelectNames.toString());
 		sql += " WHERE osm_type <> 'P' AND (name IS NOT NULL OR housenumber IS NOT NULL OR street IS NOT NULL OR postcode IS NOT NULL) AND centroid IS NOT NULL ";
+                if (polygon != null) {
+                    sql += String.format("AND st_contains(ST_GeomFromText('POLYGON ((%s))', 4326), centroid) ", polygon);
+                }
 
 		sql += " ORDER BY st_x(ST_SnapToGrid(centroid, 0.1)), st_y(ST_SnapToGrid(centroid, 0.1)) "; // for performance reasons, ~15% faster
 

--- a/src/main/java/de/komoot/photon/importer/NominatimImporter.java
+++ b/src/main/java/de/komoot/photon/importer/NominatimImporter.java
@@ -58,13 +58,13 @@ public class NominatimImporter {
 	/**
 	 * starting reading nominatim database
 	 */
-	public void run() throws Exception {
+	public void run(String polygon) throws Exception {
 		long startTime = System.currentTimeMillis();
 
 		Exporter exporter = new XMLExporter(new FileOutputStream(targetFile));
 
 		LOGGER.info("retrieving all items from nominatim database");
-		ResultSet resultSet = indexCrawler.getAllRecords();
+		ResultSet resultSet = indexCrawler.getAllRecords(polygon);
 		long counter = 0;
 		long time = System.currentTimeMillis();
 
@@ -105,6 +105,6 @@ public class NominatimImporter {
 		new JCommander(options, args);
 
 		NominatimImporter nominatimImporter = new NominatimImporter(options.host, options.port, options.database, options.username, options.password, options.outputFile, Collections.unmodifiableList(options.languages));
-		nominatimImporter.run();
+		nominatimImporter.run(options.polygon);
 	}
 }

--- a/src/main/java/de/komoot/photon/importer/model/CommandLineOptions.java
+++ b/src/main/java/de/komoot/photon/importer/model/CommandLineOptions.java
@@ -28,8 +28,8 @@ public class CommandLineOptions {
 	@Parameter(names = "-p", description = "database port", required = false)
 	public Integer port = 5432;
 
-	@Parameter(names = "-b", description = "limit the import to extent of berlin", required = false)
-	public boolean onlyBerlin = false;
+    @Parameter(names = "-o",  description = "limit the import to extent of specified polygon (WKT format)", required = false)
+	public String polygon = null;
 
 	@Parameter(names = "-l", variableArity = true)
 	public List<String> languages = new ArrayList<>();


### PR DESCRIPTION
This replaces the previous `berlinOnly` option in the importer, so now it is possible to limit the extraction to an arbitrary area.
