### PR TITLE
word delimiter should come before lowercase

### DIFF
--- a/es_config/__init__.py
+++ b/es_config/__init__.py
@@ -110,13 +110,13 @@ def init_elasticsearch(index, force=False):
             "analyzer": {
                 "stringanalyser": {
                     "tokenizer": "standard",
-                    "filter": ["lowercase", "asciifolding", "word_delimiter", "photonngram"],
-                    "char_filter": ["punctuationgreedy", ]
+                    "filter": ["word_delimiter", "lowercase", "asciifolding", "photonngram"],
+                    "char_filter": ["punctuationgreedy"]
                 },
                 "raw_stringanalyser": {
                     "tokenizer": "standard",
-                    "filter": ["lowercase", "asciifolding", "word_delimiter"],
-                    "char_filter": ["punctuationgreedy", ]
+                    "filter": ["word_delimiter", "lowercase", "asciifolding"],
+                    "char_filter": ["punctuationgreedy"]
                 },
             },
             "filter": {


### PR DESCRIPTION
World delimiter finds separate words also via case so it has to be before lowercase filter. Here is the test:
curl -XGET 'localhost:9200/photon/_analyze?analyzer=raw_stringanalyser' -d 'wichtigStraße'

Probably only important for POIs
