### PR TITLE
fixed snapshotting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>postgresql</groupId>

--- a/src/main/java/de/komoot/photon/importer/App.java
+++ b/src/main/java/de/komoot/photon/importer/App.java
@@ -19,6 +19,8 @@ import spark.Response;
 import spark.Route;
 
 import java.io.FileNotFoundException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -69,7 +71,8 @@ public class App {
 
 		if(args.getImportSnapshot() != null) {
 			esServer.deleteIndex();
-			esServer.importSnapshot(args.getImportSnapshot(), "photon_snapshot_2014_05");
+                        String dumpName = "photon_snapshot_" + new SimpleDateFormat("MM_dd").format(new Date());
+			esServer.importSnapshot(args.getImportSnapshot(), dumpName);
 			//esServer.importSnapshot(args.getImportSnapshot());
 		}
 

--- a/src/main/java/de/komoot/photon/importer/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/importer/elasticsearch/Server.java
@@ -7,9 +7,6 @@ import net.lingala.zip4j.model.ZipParameters;
 import net.lingala.zip4j.util.Zip4jConstants;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -21,15 +18,21 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.PluginManager;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 
 import org.elasticsearch.node.NodeBuilder;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+import org.elasticsearch.repositories.RepositoryMissingException;
 
 /**
  * Helper class to start/stop elasticserach node and get elasticsearch clients
@@ -38,7 +41,7 @@ import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
  */
 @Slf4j
 public class Server {
-
+    
 	private Node esNode;
 	private static final String clusterName = "photon";        
         private File esDirectory;        
@@ -107,116 +110,97 @@ public class Server {
 		this.esNode.close();
 	}
 
-	public void createSnapshot(String dumpName) {
-		log.info(String.format("Create snapshot '%s' in %s", dumpName, this.dumpDirectory.getAbsolutePath()));
+        public void createSnapshot(String dumpName) {
+            log.info(String.format("Create snapshot '%s' in %s", dumpName, this.dumpDirectory.getAbsolutePath()));
 
-		final File dumpLocation = new File(this.dumpDirectory, dumpName);
-		dumpLocation.mkdir();
-		this.esNode.client().admin().cluster().putRepository(this.getClient().admin().cluster().preparePutRepository(dumpName)
-				.setSettings(ImmutableSettings.settingsBuilder().put("compress", "true")
-						.put("location", dumpLocation.getAbsolutePath())).setType("fs").request()).actionGet();
+            final File dumpLocation = new File(this.dumpDirectory, dumpName);
+            dumpLocation.mkdir();
+            PutRepositoryRequest putRepoRequest = this.getClient().admin().cluster().preparePutRepository(dumpName)
+                    .setSettings(ImmutableSettings.settingsBuilder()
+                            .put("location", dumpLocation.getAbsolutePath()))
+                    .setType("fs").request();
+            this.esNode.client().admin().cluster().putRepository(putRepoRequest).actionGet();
 
-		this.getClient().admin().cluster().createSnapshot(this.getClient().admin().cluster().
-				prepareCreateSnapshot(dumpName, dumpName).setIndices("photon").request(), new ActionListener<CreateSnapshotResponse>() {
-			@Override
-			public void onResponse(CreateSnapshotResponse createSnapshotResponse) {
-				try {
-					ZipFile zipFile = new ZipFile(dumpLocation + ".zip");
-					ZipParameters parameters = new ZipParameters();
-					parameters.setCompressionMethod(Zip4jConstants.COMP_DEFLATE);
-					parameters.setCompressionLevel(Zip4jConstants.DEFLATE_LEVEL_NORMAL);
-					zipFile.addFolder(dumpLocation, parameters);
-					dumpLocation.delete();
+            try {
+                String repoName = dumpName;
+                CreateSnapshotRequest snapRequest = this.getClient().admin().cluster().
+                        prepareCreateSnapshot(repoName, dumpName).
+                        setIndices("photon").
+                        setIncludeGlobalState(true).
+                        setWaitForCompletion(true).
+                        request();
+                this.getClient().admin().cluster().createSnapshot(snapRequest).actionGet();
+                ZipFile zipFile = new ZipFile(dumpLocation + ".zip");
+                ZipParameters parameters = new ZipParameters();
+                parameters.setCompressionMethod(Zip4jConstants.COMP_DEFLATE);
+                parameters.setCompressionLevel(Zip4jConstants.DEFLATE_LEVEL_NORMAL);
+                zipFile.addFolder(dumpLocation, parameters);
+                
+                removeDir(dumpLocation);
 
-					log.info(String.format("Created snapshot: %s.zip", dumpLocation));
-				} catch(ZipException e) {
-					log.error("error creating zip file of snapshot", e);
-				}
-			}
+                log.info(String.format("Created snapshot: %s.zip", dumpLocation));
+            } catch (ZipException e) {
+                throw new RuntimeException("error creating zip file of snapshot", e);
+            }
+        }
 
-			@Override
-			public void onFailure(Throwable e) {
-				log.error("error creating snapshot", e);
-			}
-		});
-	}
+        public File getDumpDirectory() {
+            return dumpDirectory;
+        }
 
-	public void importSnapshot(String dumpUrl, String dumpName) {
-		File dump = new File(this.tempDirectory, dumpName + ".zip");
-		String dumpLocation = "";
-		try {
-			FileUtils.copyFile(new File(new URL(dumpUrl).toURI()), dump);
-		} catch(Exception e) {
-			log.error("Error while loading dump (Is this the correct dump location?)", e);
-		}
+        public static boolean removeDir( File file )
+        {
+            if (!file.exists())            
+                return true;            
 
-		try {
-			ZipFile dumpZip = new ZipFile(dump);
-			dumpLocation = this.importDirectory.getAbsolutePath() + dumpName;
-			dumpZip.extractAll(dumpLocation);
-		} catch(ZipException e) {
+            if (file.isDirectory())            
+                for (File f : file.listFiles())
+                {
+                    removeDir(f);
+                }            
 
-			log.error("Can´t unzip dump", e);
-		}
-		this.getClient().admin().cluster().getSnapshots(this.getClient().admin().cluster().prepareGetSnapshots(dumpLocation).setSnapshots(dumpName).request(), new ActionListener<GetSnapshotsResponse>() {
-			@Override
-			public void onResponse(GetSnapshotsResponse getSnapshotsResponse) {
-				log.info("Import done!");
-			}
+            return file.delete();
+        }
+        
+        /**
+         * Restores snapshot from specified dumpUrl.
+         */
+        public void importSnapshot(String dumpUrl, String dumpName) {
+            File tempZip = new File(this.tempDirectory, dumpName + ".zip");
+            try {
+                // hmmh, if no shared file system we need to replicate it to other servers too
+                FileUtils.copyFile(new File(new URL(dumpUrl).toURI()), tempZip);
+            } catch (Exception e) {
+                throw new RuntimeException("Error while loading dump. Is dumpUrl " + dumpUrl + " and dumpName " + dumpName + " correct?", e);
+            }
 
-			@Override
-			public void onFailure(Throwable e) {
-				log.error("error creating snapshot", e);
-			}
-		});
-	}
+            try {                
+                ZipFile dumpZip = new ZipFile(tempZip);
+                String dumpDir = this.dumpDirectory.getAbsolutePath();
+                dumpZip.extractAll(dumpDir);
+            } catch (ZipException e) {
+                throw new RuntimeException(e);
+            }            
+            
+            // repository can only load snapshot from configured dumpDir
+            String repoName = dumpName;
+            this.getClient().admin().cluster().
+                    prepareRestoreSnapshot(repoName, dumpName).
+                    setIndices("photon").
+                    setWaitForCompletion(true).
+                    get();
+            log.info(String.format("imported snapshot "  + dumpName + " from " + getDumpDirectory()));
+        }
 
-	public void importSnapshot(String urlString) {
-		URL url = null;
-		try {
-			url = new URL(urlString);
-		} catch(MalformedURLException e) {
-			throw new RuntimeException("invalid snapshot url", e);
-		}
-		File file;
-		try {
-			file = new File(url.toURI());
-		} catch(Exception e) {
-			// url did not refer to a local file, download it first to unzip
-			try {
-				file = File.createTempFile("temp-file-name", ".tmp");
-				IOUtils.copyLarge(url.openStream(), new FileOutputStream(file));
-			} catch(IOException ioe) {
-				throw new RuntimeException("cannot create temp file for snapshot", ioe);
-			}
-		}
-
-		String dumpLocation;
-		String dumpName = "photon_snapshot_2014_05";
-		try {
-			ZipFile dumpZip = new ZipFile(file);
-			dumpLocation = this.importDirectory.getAbsolutePath();
-			dumpZip.extractAll(dumpLocation);
-		} catch(ZipException e) {
-			throw new RuntimeException("error unzipping snapshot", e);
-		}
-
-		String repository = dumpLocation + "/" + dumpName;
-		String snapshot = dumpName;
-
-		this.getClient().admin().cluster().getSnapshots(this.getClient().admin().cluster().prepareGetSnapshots(repository).setSnapshots(snapshot).request(), new ActionListener<GetSnapshotsResponse>() {
-			@Override
-			public void onResponse(GetSnapshotsResponse getSnapshotsResponse) {
-				log.info("Import done!");
-			}
-
-			@Override
-			public void onFailure(Throwable e) {
-				log.error("error creating snapshot", e);
-			}
-		});
-	}
-
+        public void deleteSnapshot(String dumpName) {
+            try {
+                String repoName = dumpName;
+                getClient().admin().cluster().deleteSnapshot(
+                        new DeleteSnapshotRequest(repoName, dumpName)).actionGet();
+            } catch(RepositoryMissingException ex) {
+                // ignore
+            }
+        }
 	/**
 	 * returns an elasticsearch client
 	 */
@@ -256,8 +240,8 @@ public class Server {
 		final InputStream index_settings = Thread.currentThread().getContextClassLoader().getResourceAsStream("index_settings.json");
 
 		try {
-			client.admin().indices().prepareCreate("photon").setSettings(IOUtils.toString(index_settings)).execute().actionGet();
-			client.admin().indices().preparePutMapping("photon").setType("place").setSource(IOUtils.toString(mappings)).execute().actionGet();
+			client.admin().indices().prepareCreate("photon").setSettings(IOUtils.toString(index_settings)).get();
+			client.admin().indices().preparePutMapping("photon").setType("place").setSource(IOUtils.toString(mappings)).get();
 		} catch(IOException e) {
 			log.error("cannot setup index, elastic search config files not readable", e);
 		}
@@ -265,10 +249,24 @@ public class Server {
 
 	public DeleteIndexResponse deleteIndex() {
 		try {
-			return this.getClient().admin().indices().prepareDelete("photon").execute().actionGet();
+			return this.getClient().admin().indices().prepareDelete("photon").get();
 		} catch(IndexMissingException e) {
 			// index did not exist
 			return null;
 		}
+	}
+        
+        public CloseIndexResponse closeIndex() {
+		try {
+			return this.getClient().admin().indices().prepareClose("photon").get();
+		} catch(IndexMissingException e) {
+			// index did not exist
+			return null;
+		}
+	}
+        
+        public void waitForYellow() {
+		this.getClient().admin().cluster().
+                        health(new ClusterHealthRequest("photon").waitForYellowStatus()).actionGet();
 	}
 }

--- a/src/test/java/de/komoot/photon/importer/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/importer/elasticsearch/ImporterTest.java
@@ -28,10 +28,10 @@ public class ImporterTest extends ESBaseTester {
         Importer instance = new Importer(getClient());
         instance.add(doc);
         instance.finish();
-        
+
         refresh();
+
         assertEquals(1L, instance.count());
-        
         assertEquals(1, new Searcher(getClient()).search("testing", "en", null, null, 10, true).size());
     }
 }

--- a/src/test/java/de/komoot/photon/importer/elasticsearch/ServerTest.java
+++ b/src/test/java/de/komoot/photon/importer/elasticsearch/ServerTest.java
@@ -1,0 +1,52 @@
+package de.komoot.photon.importer.elasticsearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.importer.model.PhotonDoc;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class ServerTest extends ESBaseTester {
+
+    @Before
+    public void setUp() {
+        setUpES();
+        deleteAll();
+    }
+
+    @Test
+    public void testCreateSnapshot() {
+        Map<String, String> nameMap = new HashMap<String, String>();
+        nameMap.put("name", "testing");
+        PhotonDoc doc = PhotonDoc.create(1, "way", 1, nameMap);
+        Importer instance = new Importer(getClient());
+        instance.add(doc);
+        instance.finish();
+        refresh();
+        assertEquals(1L, instance.count());
+
+        try {
+            getApiServer().createSnapshot("test");
+            deleteAll();
+            assertEquals(0L, instance.count());
+
+            // ... an existing index can be only restored if it’s closed.
+            // The restore operation automatically opens restored indices if they were closed 
+            // and creates new indices if they didn’t exist in the cluster.            
+            getApiServer().closeIndex();
+            getApiServer().importSnapshot(getApiServer().getDumpDirectory().toURI().toString() + "/test.zip", "test");
+            // getApiServer().waitForYellow();
+            
+            assertEquals(1L, instance.count());        
+            // assertEquals(1, new Searcher(getClient()).search("testing", "en", null, null, 10, true).size());
+        } finally {
+            getApiServer().deleteSnapshot("test");
+        }
+    }
+}


### PR DESCRIPTION
There were several issues with the current snapshotting like GetSnapshot vs. RestoreSnapshot - some of them only jumped to my eyes when looking at the [ES tests](https://github.com/elasticsearch/elasticsearch/blob/master/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java#L126). Also moved some log.error statements into exceptions as it does not make sense to continue in those cases.

There is an additional test for it now but the whole test suite does not execute properly - depends on #65

Upgraded to elasticsearch as ES docs say: *Before version 1.2.0 the snapshot operation fails if cluster has any relocating or initializing primaries of indices participating in the snapshot. Starting with version 1.2.0, Elasticsearch waits for are relocating or initializing shards to start before snapshotting them.*
