### PR TITLE
Enable running on Windows

### DIFF
--- a/src/main/java/de/komoot/photon/importer/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/importer/elasticsearch/Server.java
@@ -52,6 +52,13 @@ public class Server {
 			setupDirectories(new URL("file://" + mainDirectory));
 		} catch(MalformedURLException e) {
 			log.error("Can´t create directories");
+		} catch(Exception ex)
+		{
+			try {
+				setupDirectories(new URL("file:///" + mainDirectory)); //Enable running on windows.
+			} catch(MalformedURLException e) {
+				log.error("Can´t create directories");
+			}
 		}
 	}
 


### PR DESCRIPTION
Try to setupDirectories using "file:///" protocol when "file://" fails on windows system due to missing authoritative component of the URI.
