### PR TITLE
Remove street duplicates for NL postcodes

### DIFF
--- a/src/main/java/de/komoot/photon/importer/elasticsearch/Searcher.java
+++ b/src/main/java/de/komoot/photon/importer/elasticsearch/Searcher.java
@@ -84,47 +84,19 @@ public class Searcher {
 				if(properties.has(OSMTags.KEY_POSTCODE) && properties.has(OSMTags.KEY_NAME)) {
 					// street has a postcode and name
 					String postcode = properties.getString(OSMTags.KEY_POSTCODE);
+                                        String onlyDigitsPostcode = Utils.stripNonDigits(postcode);
 					String name = properties.getString(OSMTags.KEY_NAME);
-					String key = postcode + ":" + name;                                                                   
+					String key;
+                                        if(lang.equals("nl")) {
+                                                key = onlyDigitsPostcode + ":" + name;
+                                        }
+                                        else {
+                                                key = postcode + ":" + name;
+                                        }
 
 					if(keys.contains(key)) {
 						// a street with this name + postcode is already part of the result list
-						continue;
-					} else if (lang.equals("nl")) {
-                                                // check for dutch postcodes (i.e. 6532RA). If a street has the same name and the same 4 numbers in the postcode, 
-                                                // we can assume it is part of the same street, so only use the first
-                                                String letterlessPostcode = Utils.stripNonDigits(postcode);
-                                                int postcodeNumbers;
-                                                try {                                                        
-                                                        postcodeNumbers = Integer.parseInt(letterlessPostcode);                                                        
-                                                } catch (NumberFormatException e) {
-                                                        // Bad OSM data
-                                                        continue;
-                                                }
-                                                boolean foundMatch = false;
-                                                        
-                                                for (String keyString : keys) {
-                                                        String letterlessKey = Utils.stripNonDigits(keyString);    
-                                                        int keyPostcode;
-                                                        try {
-                                                                keyPostcode = Integer.parseInt(letterlessKey);
-                                                        } catch (NumberFormatException e) {
-                                                                // Bad OSM data
-                                                                continue;
-                                                        }
-                                                        
-                                                        // also check if name equals, 
-                                                        // which is a safety check for streets that partially match and have the same postcode numbers
-                                                        String keyName = keyString.split(":")[1];
-                                                        if (postcodeNumbers == keyPostcode && keyName.equals(name)) {
-                                                                foundMatch = true;
-                                                                break;
-                                                        }
-                                                }
-
-                                                if (foundMatch) {
-                                                        continue;
-                                                }
+						continue;					 
                                         }
 					keys.add(key);
 				}


### PR DESCRIPTION
Hi, 

This PR could help people who use Photon to search for Dutch addresses. It has a specific check for NL postcodes, that results in removing duplicate street names. Doing so solves this problem:

![image](https://cloud.githubusercontent.com/assets/7554912/5522146/6b5649cc-89b3-11e4-85cc-0fceac5a2075.png)

Here we get 5 of the same results for the query "veldsingel", which could block other queries called "veldsingel" in another town/city. These are all part of the same street, but don't get filtered automatically by the `removeStreetDuplicates` function. This is because it assumes a postcode only consists of numbers, while in The Netherlands, it consists of 4 numbers and 2 letters. The same street can have the same numbers but different letters. 

This extra check, ensures we only get one street result per street, effectively removing the duplicates based on it having the same 4 numbers and having the same streetname.
