### PR TITLE
Let photon connect via transport client too

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -42,7 +42,7 @@ public class App {
 			return;
 		}
 
-		final Server esServer = new Server(args.getCluster(), args.getDataDirectory(), args.getLanguages()).start();
+		final Server esServer = new Server(args).start();
 		Client esClient = esServer.getClient();
 
 		if(args.isRecreateIndex()) {

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -14,7 +14,7 @@ public class CommandLineArgs {
 	@Parameter(names = "-cluster", description = "name of elasticsearch cluster to put the server into (default is 'photon')")
 	private String cluster = "photon";
         
-        @Parameter(names = "-transport-addresses", description = "the addresses of external elasticsearch nodes the client can connect to (default is an empty string which forces an internal node to start)")
+        @Parameter(names = "-transport-addresses", description = "the comma separated addresses of external elasticsearch nodes where the client can connect to (default is an empty string which forces an internal node to start)")
 	private String transportAddresses = "";
 
 	@Parameter(names = "-nominatim-import", description = "import nominatim database into photon (this will delete previous index)")

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -11,13 +11,16 @@ import java.io.File;
 
 @Data
 public class CommandLineArgs {
-	@Parameter(names = "-cluster", description = "name of elasticsearch cluster to put the server into (default: photon)")
+	@Parameter(names = "-cluster", description = "name of elasticsearch cluster to put the server into (default is 'photon')")
 	private String cluster = "photon";
+        
+        @Parameter(names = "-transport-addresses", description = "the addresses of external elasticsearch nodes the client can connect to (default is an empty string which forces an internal node to start)")
+	private String transportAddresses = "";
 
 	@Parameter(names = "-nominatim-import", description = "import nominatim database into photon (this will delete previous index)")
 	private boolean nominatimImport = false;
 
-	@Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default: 'en,fr,de,it')")
+	@Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default is 'en,fr,de,it')")
 	private String languages = "en,fr,de,it";
 
 	@Parameter(names = "-json", description = "import nominatim database and dump it to a json like files in (useful for developing)")

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -24,7 +24,7 @@ public class ESBaseTester {
 	}
 
 	public void setUpES() throws IOException {
-		server = new Server("photon", new File("./target/es_photon").getAbsolutePath(), "en", true).start();
+		server = new Server("photon", new File("./target/es_photon").getAbsolutePath(), "en", "", true).start();
 		server.recreateIndex();
 	}
 


### PR DESCRIPTION
This allows to connect to external elasticsearch nodes. Beneficial if you change something in photon and don't want to restart elasticsearch nodes. There is now a new command line parameter which can be used like:
`java -Xms200m -Xmx200m -jar target/photon-0.2.2-SNAPSHOT.jar -transport-addresses 136.243.16.13:9300[,...] -other-options example`

Of course it is required to have the `photon` index and install the plugin(s) on those nodes.

BTW: the description '(default is xy)' should be removed in another issue as it is already printed from the tool when getting the help
BTW2: I removed the default clusterName="photon_v0.2.1" because it was actually never used and was misleading IMO