### PR TITLE
Housenumber interpolation

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -3,6 +3,7 @@ package de.komoot.photon;
 import com.neovisionaries.i18n.CountryCode;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,14 +25,12 @@ public class PhotonDoc {
 	final private String tagKey;
 	final private String tagValue;
 	final private Map<String, String> name;
-	final private String houseNumber;
 	private String postcode;
 	final private Map<String, String> extratags;
 	final private Envelope bbox;
 	final private long parentPlaceId; // 0 if unset
 	final private double importance;
 	final private CountryCode countryCode;
-	final private Point centroid;
 	final private long linkedPlaceId; // 0 if unset
 	final private int rankSearch;
 
@@ -40,6 +39,8 @@ public class PhotonDoc {
 	private Set<Map<String, String>> context = new HashSet<Map<String, String>>();
 	private Map<String, String> country;
 	private Map<String, String> state;
+	private String houseNumber;
+	private Point centroid;
 
 	public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankSearch) {
 		String place = extratags != null ? extratags.get("place") : null;
@@ -64,6 +65,38 @@ public class PhotonDoc {
 		this.centroid = centroid;
 		this.linkedPlaceId = linkedPlaceId;
 		this.rankSearch = rankSearch;
+	}
+
+	public PhotonDoc(PhotonDoc other) {
+		this.placeId = other.placeId;
+		this.osmType = other.osmType;
+		this.osmId = other.osmId;
+		this.tagKey = other.tagKey;
+		this.tagValue = other.tagValue;
+		this.name = other.name;
+		this.houseNumber = other.houseNumber;
+		this.postcode = other.postcode;
+		this.extratags = other.extratags;
+		this.bbox = other.bbox;
+		this.parentPlaceId = other.parentPlaceId;
+		this.importance = other.importance;
+		this.countryCode = other.countryCode;
+		this.centroid = other.centroid;
+		this.linkedPlaceId = other.linkedPlaceId;
+		this.rankSearch = other.rankSearch;
+		this.street = other.street;
+		this.city = other.city;
+		this.context = other.context;
+		this.country = other.country;
+		this.state = other.state;
+	}
+
+	public String getUid()
+	{
+		if (houseNumber == null || houseNumber.isEmpty())
+			return String.valueOf(placeId);
+		else
+			return String.valueOf(placeId) + "." + houseNumber;
 	}
 
 	/**

--- a/src/main/java/de/komoot/photon/elasticsearch/Importer.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Importer.java
@@ -35,7 +35,7 @@ public class Importer implements de.komoot.photon.Importer {
 	public void add(PhotonDoc doc) {
 		try {
 			this.bulkRequest.add(this.esClient.prepareIndex(indexName, indexType).
-					setSource(Utils.convert(doc, languages)).setId(String.valueOf(doc.getPlaceId())));
+					setSource(Utils.convert(doc, languages)).setId(doc.getUid()));
 		} catch(IOException e) {
 			log.error("could not ", e);
 		}


### PR DESCRIPTION
Fixes #139: house numbers with semicolons are split and a document is added for each part separately.
And fixes #237: scans location_property_osmline table for address interpolations, expands them and adds a document for each expanded house number.

The second part requires a recent Nominatim from git. Should we actually check if the table exists to remain compatible with older versions?

It turns out that elastic search was using the place_id as document key. Naturally that doesn't work with multiple house numbers for the same nominatim place object. So I've extended the key to <place_id>.<house number> when the document has a house number. I hope that doesn't cause any trouble.

I've only tested this on a Bremen extract so far. I will run it on a planet as well later this week.