### PR TITLE
Fix #266

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>5.5.0</version>
+			<version>${elasticsearch.version}</version>
 			<exclusions><!-- gives a bad error -->
 				<exclusion>
 					<groupId>org.elasticsearch</groupId>
@@ -22,22 +22,17 @@
 		<dependency><!-- required by elasticsearch -->
 			<groupId>org.elasticsearch.plugin</groupId>
 			<artifactId>transport-netty4-client</artifactId>
-			<version>5.5.0</version>
-		</dependency>
-		<dependency><!-- required by elasticsearch -->
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.7</version>
+			<version>${elasticsearch.version}</version>
 		</dependency>
 		<dependency><!-- required by elasticsearch -->
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.7</version>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>transport</artifactId>
-			<version>5.5.0</version>
+			<version>${elasticsearch.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>postgresql</groupId>
@@ -47,17 +42,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.3</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.3</version>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.beust</groupId>
@@ -265,6 +255,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+
+        <elasticsearch.version>5.5.0</elasticsearch.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <log4j.version>2.8.2</log4j.version>
 
 		<additionalparam>-Xdoclint:none</additionalparam>
 	</properties>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error">
+	<Appenders>
+		<Console name="stdout" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
+		</Console>
+		<Async name="ASYNC" bufferSize="500">
+        	<AppenderRef ref="stdout"/>
+    	</Async>   
+	</Appenders>
+	<Loggers>
+	    <Logger name="de.komoot.photon" level="info"/>
+		<Root level="warn">
+			<AppenderRef ref="ASYNC" />
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
This PR fixes the log configuration warning on startup.
Former dependency to log4j 1.2.7 is replaced by dependency to log4j-2.8.2 (as used by eleasticsearch 5.5.0).
photon itself uses slf4j which now delegates to the log4j implementation via the slf4j-log4j bridge.

The patternLayout now prints date and time and async appenders are used. Exceptions during export are logged.

I tried to use log4j2's AsyncLoggers without success. Possibly some the slf4j-log4j integration does not yet work with AsyncLoggers.  