### PR TITLE
Fix ES startup warnings

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -13,36 +13,36 @@
 			"city": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.de"
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.en"
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.fr"
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.it"
 						]
@@ -52,16 +52,16 @@
 			"collector": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -70,26 +70,26 @@
 						]
 					},
 					"default": {
-						"type": "string",
+						"type": "text",
 						"analyzer": "index_ngram",
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						}
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -98,16 +98,16 @@
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -116,16 +116,16 @@
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -138,36 +138,36 @@
 			"context": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.de"
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.en"
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.fr"
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.it"
 						]
@@ -180,36 +180,36 @@
 			"country": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.de"
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.en"
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.fr"
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.it"
 						]
@@ -217,8 +217,8 @@
 				}
 			},
 			"housenumber": {
-				"type": "string",
-				"index": "not_analyzed",
+				"type": "keyword",
+				"index": true,
 				"copy_to": [
 					"collector.default"
 				]
@@ -229,11 +229,11 @@
 			"name": {
 				"properties": {
 					"alt": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -242,16 +242,16 @@
 						]
 					},
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -260,8 +260,8 @@
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default",
 							"name.en",
@@ -271,16 +271,16 @@
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -289,16 +289,16 @@
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -307,11 +307,11 @@
 						]
 					},
 					"int": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -320,16 +320,16 @@
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"ngrams": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_ngram",
 								"search_analyzer": "search_ngram"
 							},
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -338,11 +338,11 @@
 						]
 					},
 					"loc": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -351,11 +351,11 @@
 						]
 					},
 					"old": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -364,11 +364,11 @@
 						]
 					},
 					"reg": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"fields": {
 							"raw": {
-								"type": "string",
+								"type": "text",
 								"analyzer": "index_raw"
 							}
 						},
@@ -382,20 +382,20 @@
 				"type": "long"
 			},
 			"osm_key": {
-				"type": "string",
-				"index": "not_analyzed"
+				"type": "keyword",
+				"index": true
 			},
 			"osm_type": {
-				"type": "string",
-				"index": "no"
+				"type": "text",
+				"index": false
 			},
 			"osm_value": {
-				"type": "string",
-				"index": "not_analyzed"
+				"type": "keyword",
+				"index": true
 			},
 			"postcode": {
-				"type": "string",
-				"index": "no",
+				"type": "text",
+				"index": false,
 				"copy_to": [
 					"collector.default"
 				]
@@ -403,36 +403,36 @@
 			"state": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.de"
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.en"
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.fr"
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.it"
 						]
@@ -442,36 +442,36 @@
 			"street": {
 				"properties": {
 					"de": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.de"
 						]
 					},
 					"default": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
 					},
 					"en": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.en"
 						]
 					},
 					"fr": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.fr"
 						]
 					},
 					"it": {
-						"type": "string",
-						"index": "no",
+						"type": "text",
+						"index": false,
 						"copy_to": [
 							"collector.it"
 						]

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
 			<artifactId>transport</artifactId>
 			<version>${elasticsearch.version}</version>
 		</dependency>
+		<dependency><!-- required by elasticsearch to avoid warning on startup,
+		    see https://github.com/elastic/elasticsearch/issues/13245 -->
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>jna</artifactId>
+			<version>4.4.0</version>
+		</dependency>
 		<dependency>
 			<groupId>postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -215,9 +215,9 @@ public class Server {
 
     private JSONObject addLangsToMapping(JSONObject mappingsObject) {
 	// define collector json strings
-	String copyToCollectorString = "{\"type\":\"string\",\"index\":\"no\",\"copy_to\":[\"collector.{lang}\"]}";
-	String nameToCollectorString = "{\"type\":\"string\",\"index\":\"no\",\"fields\":{\"ngrams\":{\"type\":\"string\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"string\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
-	String collectorString = "{\"type\":\"string\",\"index\":\"no\",\"fields\":{\"ngrams\":{\"type\":\"string\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"string\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}}},\"street\":{\"type\":\"object\",\"properties\":{\"default\":{\"index\":\"no\",\"type\":\"string\",\"copy_to\":[\"collector.default\"]}";
+	String copyToCollectorString = "{\"type\":\"text\",\"index\":false,\"copy_to\":[\"collector.{lang}\"]}";
+	String nameToCollectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
+	String collectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}}},\"street\":{\"type\":\"object\",\"properties\":{\"default\":{\"text\":false,\"type\":\"text\",\"copy_to\":[\"collector.default\"]}";
 
 	JSONObject placeObject = mappingsObject.optJSONObject("place");
 	JSONObject propertiesObject = placeObject == null ? null : placeObject.optJSONObject("properties");


### PR DESCRIPTION
On startup, the following warnings are logged:

```
2017-12-22 18:09:22,783 [main] WARN  org.elasticsearch.bootstrap.Natives - JNA not found. native methods will be disabled.
java.lang.ClassNotFoundException: com.sun.jna.Native
	at java.net.URLClassLoader$1.run(URLClassLoader.java:372) ~[?:1.8.0_25]
...
2017-12-22 18:09:28,527 [elasticsearch[VXqt2Bb][clusterService#updateTask][T#1]] WARN  org.elasticsearch.deprecation.index.mapper.StringFieldMapper$TypeParser - The [string] field is deprecated, please use [text] or [keyword] instead on [de]
...
```

This PR fixes the by
1) adding JNA dependency, which in elasticsearch release 5.5.0 still was optional (see https://github.com/elastic/elasticsearch/issues/13245)
2) switching from deprecated ES mapping type "string" to "text"/"keyword".

Note: With the type migration I switched the type of the field housenumber from string/not_analyzed to text/indexed. This should fix #221 (unmatched uppercase housenumbers).   
  