### PR TITLE
Fix logged LinkageError when running tests

### DIFF
--- a/src/test/java/de/komoot/photon/ReverseSearchRequestHandlerTest.java
+++ b/src/test/java/de/komoot/photon/ReverseSearchRequestHandlerTest.java
@@ -20,11 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import spark.Request;
 import spark.Response;
-import spark.Route;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -39,6 +39,7 @@ import spark.RouteImpl;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(SimpleReverseRequestHandler.class)
+@PowerMockIgnore({"javax.management.*"})
 public class ReverseSearchRequestHandlerTest {
     @Test
     public void testConstructor() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {

--- a/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
+++ b/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import spark.Request;
@@ -29,6 +30,7 @@ import spark.RouteImpl;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(SimplePhotonRequestHandler.class)
+@PowerMockIgnore({"javax.management.*"})
 public class SearchRequestHandlerTest {
     @Test
     public void testConstructor() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {


### PR DESCRIPTION
When running the tests, though the tests pass, the following error is logged multiple times:
```
main ERROR Could not reconfigure JMX java.lang.LinkageError: loader constraint violation: loader (instance of org/powermock/core/classloader/MockClassLoader) previously initiated loading for a different type with name "javax/management/MBeanServer"
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
	at org.powermock.core.classloader.MockClassLoader.loadUnmockedClass(MockClassLoader.java:238)
	at org.powermock.core.classloader.MockClassLoader.loadModifiedClass(MockClassLoader.java:182)
	at org.powermock.core.classloader.DeferSupportingClassLoader.loadClass(DeferSupportingClassLoader.java:70)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.logging.log4j.core.jmx.Server.unregisterAllMatching(Server.java:335)
...
```

This fix prevents PowerMock from mocking javax.management.* classes to avoid this error.