### PR TITLE
Fix issue 221 (partially)

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -40,6 +40,16 @@
 					"unique"
 				],
 				"tokenizer": "standard"
+			},
+			"index_housenumber": {
+				"char_filter": [
+					"punctuationgreedy",
+					"remove_ws_hnr_suffix"
+				],
+				"filter": [
+					"lowercase",
+					"preserving_word_delimiter"],
+				"tokenizer": "standard" 
 			}
 		},
 		"tokenizer": {
@@ -58,12 +68,21 @@
 				"type": "pattern_replace",
 				"pattern": "[\\.,]",
 				"replacement": " "
+			},
+			"remove_ws_hnr_suffix": {
+				"type": "pattern_replace",
+				"pattern": "(\\d+)\\s(?=\\p{L}\\b)",
+				"replacement": "$1"
 			}
 		},
 		"filter": {
 			"photonlength": {
 				"min": "2",
 				"type": "length"
+			},
+			"preserving_word_delimiter": { 
+				"type": "word_delimiter",
+				"preserve_original": "true"
 			}
 		}
 	}

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -3,6 +3,7 @@
 		"analyzer": {
 			"index_ngram": {
 				"char_filter": [
+					"punctuationgreedy",
 					"remove_ws_hnr_suffix"
 				],
 				"tokenizer": "edge_ngram",
@@ -13,6 +14,9 @@
 				]
 			},
 			"search_ngram": {
+				"char_filter": [
+					"punctuationgreedy"
+				],
 				"tokenizer": "standard",
 				"filter": [
 					"lowercase",

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -10,7 +10,8 @@
 				"filter": [
 					"preserving_word_delimiter",
 					"lowercase",
-					"german_normalization"
+					"german_normalization",
+					"unique"
 				]
 			},
 			"search_ngram": {

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -56,7 +56,8 @@
 		"char_filter": {
 			"punctuationgreedy": {
 				"type": "pattern_replace",
-				"pattern": "[\\.,]"
+				"pattern": "[\\.,]",
+				"replacement": " "
 			}
 		},
 		"filter": {

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -2,8 +2,12 @@
 	"analysis": {
 		"analyzer": {
 			"index_ngram": {
+				"char_filter": [
+					"remove_ws_hnr_suffix"
+				],
 				"tokenizer": "edge_ngram",
 				"filter": [
+					"preserving_word_delimiter",
 					"lowercase",
 					"german_normalization"
 				]

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -219,6 +219,8 @@
 			"housenumber": {
 				"type": "text",
 				"index": true,
+				"analyzer": "index_housenumber",
+				"search_analyzer": "standard",
 				"copy_to": [
 					"collector.default"
 				]

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -217,7 +217,7 @@
 				}
 			},
 			"housenumber": {
-				"type": "keyword",
+				"type": "text",
 				"index": true,
 				"copy_to": [
 					"collector.default"


### PR DESCRIPTION
Fix #221 (partially). This PR improves housenumber matching, especially in cases where the OSM housenumber suffix 
* is in uppercase as in [Malplaquetstraße 5A, 13347 Berlin, Germany](http://photon.komoot.de/api?q=Malplaquetstraße%205A,%2013347%20Berlin,%20Germany) (see #221) or
* is separated via whitespace as in [Osterstr. 42 A Hannover, Germany](http://photon.komoot.de/api?q=Osterstr.%2042%20A%20Hannover,%20germany&lang=de).

Tests are provided via geocoders/geocoder-tester#28 which highlight the improvements as well as further existing issues.

Still open:
* Missing fallback in case a housenumber suffix not existing in the data is requested (e.g. [Lister Meile 29D, Hannover](http://photon.komoot.de/api?q=Lister%20Meile%2029D%20Hannover))
* instead of the exactly matching housenumber a match with a name attribute and matching numeral ngram might be returned ([Anderter Straße 1 Hannover](http://photon.komoot.de/api?q=Anderter%20Straße%201%20Hannover))

