### PR TITLE
avoid falling through catch and improve logs a bit

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -121,11 +121,7 @@ public class App {
         de.komoot.photon.elasticsearch.Importer importer = new de.komoot.photon.elasticsearch.Importer(esNodeClient, args.getLanguages());
         NominatimConnector nominatimConnector = new NominatimConnector(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword());
         nominatimConnector.setImporter(importer);
-        try {
-            nominatimConnector.readEntireDatabase();
-        } catch (Exception e) {
-            throw new RuntimeException("error importing from nominatim: " + e.getMessage());
-        }
+        nominatimConnector.readEntireDatabase();
 
         log.info("imported data from nominatim to photon with languages: " + args.getLanguages());
     }

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -77,8 +77,7 @@ public class App {
         try {
             esServer.recreateIndex();
         } catch (IOException e) {
-            log.error("cannot setup index, elastic search config files not readable", e);
-            return;
+            throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
         }
 
         log.info("deleted photon index and created an empty new one.");
@@ -115,8 +114,7 @@ public class App {
         try {
             esServer.recreateIndex(); // dump previous data
         } catch (IOException e) {
-            log.error("cannot setup index, elastic search config files not readable", e);
-            return;
+            throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
         }
 
         log.info("starting import from nominatim to photon with languages: " + args.getLanguages());
@@ -126,7 +124,7 @@ public class App {
         try {
             nominatimConnector.readEntireDatabase();
         } catch (Exception e) {
-            log.info("error importing from nominatim: " + e.getMessage());
+            throw new RuntimeException("error importing from nominatim: " + e.getMessage());
         }
 
         log.info("imported data from nominatim to photon with languages: " + args.getLanguages());

--- a/src/main/java/de/komoot/photon/elasticsearch/Importer.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Importer.java
@@ -38,7 +38,8 @@ public class Importer implements de.komoot.photon.Importer {
             this.bulkRequest.add(this.esClient.prepareIndex(indexName, indexType).
                     setSource(Utils.convert(doc, languages)).setId(doc.getUid()));
         } catch (IOException e) {
-            log.error("could not ", e);
+            log.error("could not bulk add document " + doc.getUid(), e);
+            return;
         }
         this.documentCount += 1;
         if (this.documentCount > 0 && this.documentCount % 10000 == 0) {

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -72,8 +72,7 @@ public class Server {
                 setupDirectories(new URL("file://" + mainDirectory));
             }
         } catch (Exception e) {
-            log.error("Can't create directories: ", e);
-            throw e;
+            throw new RuntimeException("Can't create directories: ", e);
         }
         this.clusterName = clusterName;
         this.languages = languages.split(",");
@@ -123,7 +122,7 @@ public class Server {
                 esClient = esNode.client();
 
             } catch (NodeValidationException e) {
-                log.error("Error while starting elasticsearch server", e);
+                throw new RuntimeException("Error while starting elasticsearch server", e);
             }
 
         }
@@ -140,7 +139,7 @@ public class Server {
 
             esClient.close();
         } catch (IOException e) {
-            log.error("Error during elasticsearch server shutdown", e);
+            throw new RuntimeException("Error during elasticsearch server shutdown", e);
         }
     }
 
@@ -207,8 +206,7 @@ public class Server {
         try {
             return this.getClient().admin().indices().prepareDelete("photon").execute().actionGet();
         } catch (IndexNotFoundException e) {
-            // index did not exist
-            return null;
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -60,7 +60,7 @@ public class Server {
         this(args.getCluster(), args.getDataDirectory(), args.getLanguages(), args.getTransportAddresses());
     }
 
-    public Server(String clusterName, String mainDirectory, String languages, String transportAddresses) throws Exception {
+    public Server(String clusterName, String mainDirectory, String languages, String transportAddresses) {
         try {
             if (SystemUtils.IS_OS_WINDOWS) {
                 setupDirectories(new URL("file:///" + mainDirectory));

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -295,7 +295,9 @@ public class NominatimConnector {
                     if (doc == FINAL_DOCUMENT)
                         break;
                     importer.add(doc);
-                } catch (InterruptedException e) { /* safe to ignore? */ }
+                } catch (InterruptedException e) {
+                    log.info("interrupted exception ", e);
+                }
             }
             importer.finish();
         }

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -37,19 +37,17 @@ public class ReverseRequestFactory {
 
         Point location;
         try {
-            Double lon = Double.valueOf(webRequest.queryParams("lon"));
+            Double lon = Double.valueOf(webRequest.queryParamOrDefault("lon", ""));
             if (lon > 180.0 || lon < -180.00) {
                 throw new BadRequestException(400, "invalid search term 'lon', expected number >= -180.0 and <= 180.0");
             }
-            Double lat = Double.valueOf(webRequest.queryParams("lat"));
+            Double lat = Double.valueOf(webRequest.queryParamOrDefault("lat", ""));
             if (lat > 90.0 || lat < -90.00) {
                 throw new BadRequestException(400, "invalid search term 'lat', expected number >= -90.0 and <= 90.0");
             }
             location = geometryFactory.createPoint(new Coordinate(lon, lat));
         } catch (NumberFormatException nfe) {
-            throw new BadRequestException(400, "invalid search term 'lat' and/or 'lon': /?lat=51.5&lon=8.0");
-        } catch (NullPointerException nfe) {
-            throw new BadRequestException(400, "missing search term 'lat' and/or 'lon': /?lat=51.5&lon=8.0");
+            throw new BadRequestException(400, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
         }
 
         Double radius = 1d;

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -24,12 +24,10 @@ public class ReverseRequestFactory {
     }
 
     public <R extends ReverseRequest> R create(Request webRequest) throws BadRequestException {
-
-
-        for (String queryParam : webRequest.queryParams())
+        for (String queryParam : webRequest.queryParams()) {
             if (!m_hsRequestQueryParams.contains(queryParam))
                 throw new BadRequestException(400, "unknown query parameter '" + queryParam + "'.  Allowed parameters are: " + m_hsRequestQueryParams);
-
+        }
 
         String language = webRequest.queryParams("lang");
         language = language == null ? "en" : language;

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -21,7 +21,8 @@ public class ESBaseTester {
     }
 
     public void setUpES() throws Exception {
-        server = new Server("photon", new File("./target/es_photon").getAbsolutePath(), "en", "", true).start();
+        server = new Server("photon", new File("./target/es_photon").getAbsolutePath(), "en", "").
+                start();
         server.recreateIndex();
         refresh();
     }
@@ -41,7 +42,8 @@ public class ESBaseTester {
     }
 
     public void shutdownES() {
-        server.shutdown();
+        if (server != null)
+            server.shutdown();
     }
 
     public void deleteIndex() {

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -19,8 +19,8 @@ public class ReverseRequestFactoryTest {
     private ReverseRequest reverseRequest;
 
     public void requestWithLongitudeLatitude(Request mockRequest, Double longitude, Double latitude) {
-        Mockito.when(mockRequest.queryParams("lon")).thenReturn(longitude.toString());
-        Mockito.when(mockRequest.queryParams("lat")).thenReturn(latitude.toString());
+        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn(longitude.toString());
+        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn(latitude.toString());
     }
 
     @Test
@@ -31,8 +31,8 @@ public class ReverseRequestFactoryTest {
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(-87, reverseRequest.getLocation().getX(), 0);
         Assert.assertEquals(41, reverseRequest.getLocation().getY(), 0);
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lat", "");
     }
 
     public void assertBadRequest(Request mockRequest, String expectedMessage) {
@@ -48,11 +48,11 @@ public class ReverseRequestFactoryTest {
     @Test
     public void testWithBadLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
-        Mockito.when(mockRequest.queryParams("lon")).thenReturn("bad");
-        Mockito.when(mockRequest.queryParams("lat")).thenReturn("bad");
-        assertBadRequest(mockRequest, "invalid search term 'lat' and/or 'lon': /?lat=51.5&lon=8.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.never()).queryParams("lat");
+        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn("bad");
+        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn("bad");
+        assertBadRequest(mockRequest, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
+        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
     }
 
 
@@ -60,8 +60,8 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, (high) ? 180.01 : -180.01, 0.0);
         assertBadRequest(mockRequest, "invalid search term 'lon', expected number >= -180.0 and <= 180.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.never()).queryParams("lat");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
+        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
     }
 
     @Test
@@ -78,8 +78,8 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, 0.0, (high) ? 90.01 : -90.01);
         assertBadRequest(mockRequest, "invalid search term 'lat', expected number >= -90.0 and <= 90.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lat", "");
     }
 
     @Test
@@ -95,11 +95,11 @@ public class ReverseRequestFactoryTest {
     @Test
     public void testWithNoLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
-        Mockito.when(mockRequest.queryParams("lon")).thenReturn(null);
-        Mockito.when(mockRequest.queryParams("lat")).thenReturn(null);
-        assertBadRequest(mockRequest, "missing search term 'lat' and/or 'lon': /?lat=51.5&lon=8.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.never()).queryParams("lat");
+        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn("");
+        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn("");
+        assertBadRequest(mockRequest, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
+        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
     }
 
     public void testWithBadParam(String paramName, String paramValue, String expectedMessage) throws Exception {

--- a/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderSearchTest.java
@@ -34,7 +34,6 @@ public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
     private Client client;
     private List<PhotonDoc> testData;
 
-
     @Before
     public void setUp() throws Exception {
         setUpES();


### PR DESCRIPTION
Fixes #267

A few "falling through" catches were not fixed, e.g. when adding a document failed. I'm not sure if this is good, but I thought it might be that a single document fails and aborting the import process that takes hours seems ugly. But this way we silently accept potential bugs.