### PR TITLE
(WIP) Add option to import json dump file (#291)

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -4,6 +4,7 @@ package de.komoot.photon;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import de.komoot.photon.elasticsearch.Server;
+import de.komoot.photon.json.JsonDumpConnector;
 import de.komoot.photon.nominatim.NominatimConnector;
 import de.komoot.photon.nominatim.NominatimUpdater;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,7 @@ public class App {
             return;
         }
 
-        if (args.getJsonDump() != null) {
+        if (args.getJsonDump() != null && !args.isJsonImport()) {
             startJsonDump(args);
             return;
         }
@@ -57,6 +58,12 @@ public class App {
             if (args.isNominatimImport()) {
                 shutdownES = true;
                 startNominatimImport(args, esServer, esClient);
+                return;
+            }
+
+            if (args.isJsonImport()) {
+                shutdownES = true;
+                startJsonDumpImport(args, esServer, esClient);
                 return;
             }
 
@@ -101,6 +108,35 @@ public class App {
         } catch (FileNotFoundException e) {
             log.error("cannot create dump", e);
         }
+    }
+
+    /**
+     * take json dump to fill elastic search index
+     *
+     * @param args
+     * @param esServer
+     * @param esNodeClient
+     */
+    private static void startJsonDumpImport(CommandLineArgs args, Server esServer, Client esNodeClient) {
+        try {
+            esServer.recreateIndex(); // delete previous data
+        } catch (IOException e) {
+            log.error("cannot setup index, elastic search config files not readable", e);
+            return;
+        }
+
+        log.info("starting import from json dump to photon with languages: " + args.getLanguages());
+        log.info("note: languages should be supplied as contained in the dump.");
+        de.komoot.photon.elasticsearch.Importer importer = new de.komoot.photon.elasticsearch.Importer(esNodeClient, args.getLanguages());
+        JsonDumpConnector jsonDumpConnector = new JsonDumpConnector(args.getJsonDump());
+        jsonDumpConnector.setImporter(importer);
+        try {
+            jsonDumpConnector.readEntireDatabase();
+        } catch (Exception e) {
+            log.info("error importing from json dump: " + e.getMessage());
+        }
+
+        log.info("imported data from json dump to photon with languages: " + args.getLanguages());
     }
 
 

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -20,6 +20,9 @@ public class CommandLineArgs {
     @Parameter(names = "-nominatim-import", description = "import nominatim database into photon (this will delete previous index)")
     private boolean nominatimImport = false;
 
+    @Parameter(names = "-json-import", description = "import json dump into photon (this will delete previous index)")
+    private boolean jsonImport = false;
+
     @Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default is 'en,fr,de,it')")
     private String languages = "en,fr,de,it";
 

--- a/src/main/java/de/komoot/photon/Connector.java
+++ b/src/main/java/de/komoot/photon/Connector.java
@@ -1,0 +1,25 @@
+package de.komoot.photon;
+
+import de.komoot.photon.Importer;
+
+/**
+ * Connects to a datasource and imports all documents.
+ * 
+ * @author holger
+ */
+public interface Connector {
+
+    /**
+     * sets the importer which is called for every document to be imported.
+     * 
+     * @param importer
+     */
+    public void setImporter(Importer importer);
+
+    /**
+     * reads every document from database and must call the {@link #importer}
+     * for every document
+     */
+    public void readEntireDatabase();
+
+}

--- a/src/main/java/de/komoot/photon/ImportProgressMonitor.java
+++ b/src/main/java/de/komoot/photon/ImportProgressMonitor.java
@@ -1,0 +1,41 @@
+package de.komoot.photon;
+
+import java.text.MessageFormat;
+import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Report import progress.
+ *
+ * @author holger
+ */
+@Slf4j
+public class ImportProgressMonitor {
+
+    private static final int PROGRESS_INTERVAL = 50000;
+    
+    private final AtomicLong counter = new AtomicLong();
+    private long startMillis;
+
+    public void start() {
+        startMillis = System.currentTimeMillis();
+    }
+
+    public void progressByOne() {
+        if (counter.incrementAndGet() % PROGRESS_INTERVAL == 0) {
+            reportProgress();
+        }
+    }
+
+    public void finish() {
+        reportProgress();
+    }
+
+    private void reportProgress() {
+        final double documentsPerSecond = 1000d * counter.longValue()
+                        / (System.currentTimeMillis() - startMillis);
+        log.info(String.format("imported %s documents [%.1f/second]",
+                        MessageFormat.format("{0}", counter.longValue()), documentsPerSecond));
+    }
+}

--- a/src/main/java/de/komoot/photon/elasticsearch/Importer.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Importer.java
@@ -7,6 +7,9 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
@@ -35,11 +38,24 @@ public class Importer implements de.komoot.photon.Importer {
     @Override
     public void add(PhotonDoc doc) {
         try {
-            this.bulkRequest.add(this.esClient.prepareIndex(indexName, indexType).
-                    setSource(Utils.convert(doc, languages)).setId(doc.getUid()));
+            add(Utils.convert(doc, languages).bytes(), doc.getUid());
         } catch (IOException e) {
             log.error("could not ", e);
         }
+    }
+
+    /**
+     * add a json formatted photon document. 
+     * @param source json formatted photon document
+     * @param uid optional uid, will be generated if empty
+     */
+    public void add(String source, String uid) {
+        add(new BytesArray(source), uid);
+    }
+
+    private void add(BytesReference sourceBytes, String uid) {
+        this.bulkRequest.add(this.esClient.prepareIndex(indexName, indexType)
+                        .setSource(sourceBytes, XContentType.JSON).setId(uid));
         this.documentCount += 1;
         if (this.documentCount > 0 && this.documentCount % 10000 == 0) {
             this.saveDocuments();

--- a/src/main/java/de/komoot/photon/json/JsonDumpConnector.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumpConnector.java
@@ -1,0 +1,66 @@
+package de.komoot.photon.json;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+import de.komoot.photon.Connector;
+import de.komoot.photon.ImportProgressMonitor;
+import de.komoot.photon.elasticsearch.Importer;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Import json dump data.
+ *
+ * @author holger
+ */
+@Slf4j
+public class JsonDumpConnector implements Connector {
+
+    private BufferedReader reader;
+    private Importer importer;
+
+    public JsonDumpConnector(String filename) {
+        try {
+            this.reader = new BufferedReader(new FileReader(filename));
+        } catch (FileNotFoundException e) {
+            log.error("Json dump file '%1' not found", filename);
+        }
+    }
+
+    public void setImporter(de.komoot.photon.Importer importer) {
+        if (importer instanceof Importer) {
+            this.importer = (Importer) importer;
+        } else {
+            throw new IllegalArgumentException(String.format(
+                            "Only importer of type %1 is supported.", Importer.class.getName()));
+        }
+    }
+
+    public void readEntireDatabase() {
+        if (reader == null) {
+            throw new IllegalStateException("Reader was not initialized");
+        }
+
+        final ImportProgressMonitor progressMonitor = new ImportProgressMonitor();
+        progressMonitor.start();
+
+        String sourceLine = null;
+        try {
+            while ((reader.readLine()) != null) {
+                // first line is action line, currently we assume / support only
+                // indexing
+                sourceLine = reader.readLine();
+                if (sourceLine != null) {
+                    // TODO uid currently is not contained in the export
+                    importer.add(sourceLine, null);
+                }
+                progressMonitor.progressByOne();
+            }
+            progressMonitor.finish();
+        } catch (IOException e) {
+            log.error("Error importing from json dump file", e);
+        }
+    }
+}


### PR DESCRIPTION
This is a first attempt to provide a json dump import (see #291). Importing a json dump on my machine was about 10x faster than importing from nominatim. 

However, there are some points I'd like to receive feedback on before doing a PR for merge:
* currently, no sanity checking is done on import, neither of the action line, nor the source line, should it?
* the JsonDumper does not export the PhotonDoc.uid. It should either be exported or the PhotonDoc should be restored from json so it can be recalculated from source
* JsonDumpConnector does not convert a source line into a PhotonDoc but bypasses the public Importer interface to add the source string. This is ugly, but avoids (unnecessary?) parsing and formatting of the source (but would require uid handling, see above)
* the elasticsearcg.Importer uses BulkRequestBuilder. Using [BulkProcessor](https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/java-docs-bulk-processor.html) would provide concurrent updates, as well as retries with exponential backup in case of failures  (this should be another PR, I think)