### PR TITLE
Fix #302: Read address attributes from nominatim

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -484,7 +484,7 @@
 					}
 				}
 			},
-			"suburb": {
+			"district": {
 				"properties": {
 					"de": {
 						"type": "text",
@@ -523,7 +523,7 @@
 					}
 				}
 			},
-	  	"neighbourhood": {
+	  		"locality": {
 				"properties": {
 					"de": {
 						"type": "text",

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -483,7 +483,85 @@
 						]
 					}
 				}
-			}
+			},
+			"suburb": {
+				"properties": {
+					"de": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.de"
+						]
+					},
+					"default": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.default"
+						]
+					},
+					"en": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.en"
+						]
+					},
+					"fr": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.fr"
+						]
+					},
+					"it": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.it"
+						]
+					}
+				}
+			},
+	  	"neighbourhood": {
+				"properties": {
+					"de": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.de"
+						]
+					},
+					"default": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.default"
+						]
+					},
+					"en": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.en"
+						]
+					},
+					"fr": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.fr"
+						]
+					},
+					"it": {
+						"type": "text",
+						"index": false,
+						"copy_to": [
+							"collector.it"
+						]
+					}
+				}
+			}		
 		}
 	}
 }

--- a/src/main/java/de/komoot/photon/Constants.java
+++ b/src/main/java/de/komoot/photon/Constants.java
@@ -12,8 +12,8 @@ public class Constants {
     public static final String COUNTRY = "country";
     public static final String COUNTRYCODE = "countrycode";
     public static final String CITY = "city";
-    public static final String SUBURB = "suburb";
-    public static final String NEIGHBOURHOOD = "neighbourhood";
+    public static final String DISTRICT = "district";
+    public static final String LOCALITY = "locality";
     public static final String STREET = "street";
     public static final String STATE = "state";
     public static final String TYPE = "type";

--- a/src/main/java/de/komoot/photon/Constants.java
+++ b/src/main/java/de/komoot/photon/Constants.java
@@ -12,6 +12,8 @@ public class Constants {
     public static final String COUNTRY = "country";
     public static final String COUNTRYCODE = "countrycode";
     public static final String CITY = "city";
+    public static final String SUBURB = "suburb";
+    public static final String NEIGHBOURHOOD = "neighbourhood";
     public static final String STREET = "street";
     public static final String STATE = "state";
     public static final String TYPE = "type";

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -5,6 +5,7 @@ import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,6 +19,7 @@ import java.util.Set;
  */
 @Getter
 @Setter
+@Slf4j
 public class PhotonDoc {
     final private long placeId;
     final private String osmType;
@@ -36,6 +38,8 @@ public class PhotonDoc {
     final private int rankSearch;
 
     private Map<String, String> street;
+    private Map<String, String> neighbourhood;
+    private Map<String, String> suburb;
     private Map<String, String> city;
     private Set<Map<String, String>> context = new HashSet<Map<String, String>>();
     private Map<String, String> country;
@@ -88,6 +92,8 @@ public class PhotonDoc {
         this.linkedPlaceId = other.linkedPlaceId;
         this.rankSearch = other.rankSearch;
         this.street = other.street;
+        this.neighbourhood = other.neighbourhood;
+        this.suburb = other.suburb;
         this.city = other.city;
         this.context = other.context;
         this.country = other.country;
@@ -127,10 +133,53 @@ public class PhotonDoc {
     public void completeFromAddress() {
         String addressStreet = address != null ? address.get("street") : null;
         if (addressStreet != null) {
-            if (street == null) {
-                street = new HashMap<>();
+            if (this.street == null) {
+                this.street = new HashMap<>();
             }
-            street.put("name", addressStreet);
+            setOrReplace(addressStreet, this.street, "street");
+        }
+        
+        String addressCity = address != null ? address.get("city") : null;
+        if (addressCity != null) {
+            if (this.city == null) {
+                this.city = new HashMap<>();
+            }
+            setOrReplace(addressCity, this.city, "city");
+        }
+        
+        String addressSuburb = address != null ? address.get("suburb") : null;
+        if (addressSuburb != null) {
+            if (this.suburb == null) {
+                this.suburb = new HashMap<>();
+            }
+            setOrReplace(addressSuburb, this.suburb, "suburb");
+        }
+        
+        String addressNeighbourhood = address != null ? address.get("neighbourhood") : null;
+        if (addressNeighbourhood != null) {
+            if (this.neighbourhood == null) {
+                this.neighbourhood = new HashMap<>();
+            }
+            setOrReplace(addressNeighbourhood, this.neighbourhood, "neighbourhood");
+        }
+        
+        String addressPostCode = address != null ? address.get("postcode") : null;
+        if (addressPostCode != null && !addressPostCode.equals(this.postcode)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Replacing postcode "+this.postcode+" with "+ addressPostCode+ " for osmId #" + osmId);
+            }
+            this.postcode = addressPostCode;
+        }
+    }
+
+    private void setOrReplace(String name, Map<String, String> namesMap, String field) {
+        String existingName = namesMap.get("name");
+        if (!name.equals(existingName)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Replacing "+ field +" name '"+existingName+"' with '"+ name+ "' for osmId #" + osmId);
+            }
+            // TODO: do we need to add former name to context or better not, as it might have been wrong?
+            namesMap.put("name", name);
         }
     }
 }

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -38,8 +38,8 @@ public class PhotonDoc {
     final private int rankSearch;
 
     private Map<String, String> street;
-    private Map<String, String> neighbourhood;
-    private Map<String, String> suburb;
+    private Map<String, String> locality;
+    private Map<String, String> district;
     private Map<String, String> city;
     private Set<Map<String, String>> context = new HashSet<Map<String, String>>();
     private Map<String, String> country;
@@ -92,8 +92,8 @@ public class PhotonDoc {
         this.linkedPlaceId = other.linkedPlaceId;
         this.rankSearch = other.rankSearch;
         this.street = other.street;
-        this.neighbourhood = other.neighbourhood;
-        this.suburb = other.suburb;
+        this.locality = other.locality;
+        this.district = other.district;
         this.city = other.city;
         this.context = other.context;
         this.country = other.country;
@@ -149,20 +149,20 @@ public class PhotonDoc {
             setOrReplace(addressCity, this.city, "city");
         }
         
-        String addressSuburb = address != null ? address.get("suburb") : null;
-        if (addressSuburb != null) {
-            if (this.suburb == null) {
-                this.suburb = new HashMap<>();
+        String addressDistrict = address != null ? address.get("suburb") : null;
+        if (addressDistrict != null) {
+            if (this.district == null) {
+                this.district = new HashMap<>();
             }
-            setOrReplace(addressSuburb, this.suburb, "suburb");
+            setOrReplace(addressDistrict, this.district, "suburb");
         }
         
-        String addressNeighbourhood = address != null ? address.get("neighbourhood") : null;
-        if (addressNeighbourhood != null) {
-            if (this.neighbourhood == null) {
-                this.neighbourhood = new HashMap<>();
+        String addressLocality = address != null ? address.get("neighbourhood") : null;
+        if (addressLocality != null) {
+            if (this.locality == null) {
+                this.locality = new HashMap<>();
             }
-            setOrReplace(addressNeighbourhood, this.neighbourhood, "neighbourhood");
+            setOrReplace(addressLocality, this.locality, "neighbourhood");
         }
         
         String addressPostCode = address != null ? address.get("postcode") : null;
@@ -180,7 +180,7 @@ public class PhotonDoc {
             if (log.isDebugEnabled()) {
                 log.debug("Replacing "+ field +" name '"+existingName+"' with '"+ name+ "' for osmId #" + osmId);
             }
-            // TODO: do we need to add former name to context or better not, as it might have been wrong?
+            namesMap.put("formerName", existingName);
             namesMap.put("name", name);
         }
     }

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -133,33 +133,25 @@ public class PhotonDoc {
 
         String addressStreet = address.get("street");
         if (addressStreet != null) {
-            if (this.street == null) {
-                this.street = new HashMap<>();
-            }
+            this.street = nullToEmptyMap(this.street);
             setOrReplace(addressStreet, this.street, "street");
         }
         
         String addressCity = address.get("city");
         if (addressCity != null) {
-            if (this.city == null) {
-                this.city = new HashMap<>();
-            }
+            this.city = nullToEmptyMap(this.city);
             setOrReplace(addressCity, this.city, "city");
         }
         
         String addressDistrict = address.get("suburb");
         if (addressDistrict != null) {
-            if (this.district == null) {
-                this.district = new HashMap<>();
-            }
+            this.district = nullToEmptyMap(this.district);
             setOrReplace(addressDistrict, this.district, "suburb");
         }
         
         String addressLocality = address.get("neighbourhood");
         if (addressLocality != null) {
-            if (this.locality == null) {
-                this.locality = new HashMap<>();
-            }
+            this.locality = nullToEmptyMap(this.locality);
             setOrReplace(addressLocality, this.locality, "neighbourhood");
         }
         
@@ -170,6 +162,12 @@ public class PhotonDoc {
             }
             this.postcode = addressPostCode;
         }
+    }
+
+    private static Map<String, String> nullToEmptyMap(Map<String, String> map) {
+        if (map == null) {
+            return new HashMap<>();
+        } else return map;
     }
 
     private void setOrReplace(String name, Map<String, String> namesMap, String field) {

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -139,7 +139,7 @@ public class PhotonDoc {
             setOrReplace(addressStreet, this.street, "street");
         }
         
-        String addressCity = address != null ? address.get("city") : null;
+        String addressCity = address.get("city");
         if (addressCity != null) {
             if (this.city == null) {
                 this.city = new HashMap<>();
@@ -147,7 +147,7 @@ public class PhotonDoc {
             setOrReplace(addressCity, this.city, "city");
         }
         
-        String addressDistrict = address != null ? address.get("suburb") : null;
+        String addressDistrict = address.get("suburb");
         if (addressDistrict != null) {
             if (this.district == null) {
                 this.district = new HashMap<>();
@@ -155,7 +155,7 @@ public class PhotonDoc {
             setOrReplace(addressDistrict, this.district, "suburb");
         }
         
-        String addressLocality = address != null ? address.get("neighbourhood") : null;
+        String addressLocality = address.get("neighbourhood");
         if (addressLocality != null) {
             if (this.locality == null) {
                 this.locality = new HashMap<>();
@@ -163,7 +163,7 @@ public class PhotonDoc {
             setOrReplace(addressLocality, this.locality, "neighbourhood");
         }
         
-        String addressPostCode = address != null ? address.get("postcode") : null;
+        String addressPostCode = address.get("postcode");
         if (addressPostCode != null && !addressPostCode.equals(this.postcode)) {
             if (log.isDebugEnabled()) {
                 log.debug("Replacing postcode "+this.postcode+" with "+ addressPostCode+ " for osmId #" + osmId);

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -1,5 +1,6 @@
 package de.komoot.photon;
 
+import com.google.common.collect.ImmutableMap;
 import com.neovisionaries.i18n.CountryCode;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
@@ -7,10 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * denormalized doc with all information needed be dumped to elasticsearch
@@ -180,7 +178,10 @@ public class PhotonDoc {
             if (log.isDebugEnabled()) {
                 log.debug("Replacing "+ field +" name '"+existingName+"' with '"+ name+ "' for osmId #" + osmId);
             }
-            namesMap.put("formerName", existingName);
+            // we keep the former name in the context as it might be helpful when looking up typos
+            if(!Objects.isNull(existingName)) {
+                context.add(ImmutableMap.of("formerName", existingName));
+            }
             namesMap.put("name", name);
         }
     }

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -6,6 +6,7 @@ import com.vividsolutions.jts.geom.Point;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +26,7 @@ public class PhotonDoc {
     final private String tagValue;
     final private Map<String, String> name;
     private String postcode;
+    final private Map<String, String> address;
     final private Map<String, String> extratags;
     final private Envelope bbox;
     final private long parentPlaceId; // 0 if unset
@@ -41,7 +43,7 @@ public class PhotonDoc {
     private String houseNumber;
     private Point centroid;
 
-    public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankSearch) {
+    public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> address, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankSearch) {
         String place = extratags != null ? extratags.get("place") : null;
         if (place != null) {
             // take more specific extra tag information
@@ -56,6 +58,7 @@ public class PhotonDoc {
         this.tagValue = tagValue;
         this.name = name;
         this.houseNumber = houseNumber;
+        this.address = address;
         this.extratags = extratags;
         this.bbox = bbox;
         this.parentPlaceId = parentPlaceId;
@@ -75,6 +78,7 @@ public class PhotonDoc {
         this.name = other.name;
         this.houseNumber = other.houseNumber;
         this.postcode = other.postcode;
+        this.address = other.address;
         this.extratags = other.extratags;
         this.bbox = other.bbox;
         this.parentPlaceId = other.parentPlaceId;
@@ -102,7 +106,7 @@ public class PhotonDoc {
      */
     public static PhotonDoc create(long placeId, String osmType, long osmId, Map<String, String> nameMap) {
         return new PhotonDoc(placeId, osmType, osmId, "", "", nameMap,
-                "", null, null, 0, 0, null, null, 0, 0);
+                "", null, null, null, 0, 0, null, null, 0, 0);
     }
 
     public boolean isUsefulForIndex() {
@@ -115,5 +119,18 @@ public class PhotonDoc {
         if (linkedPlaceId > 0) return false;
 
         return true;
+    }
+    
+    /**
+     * Complete doc from nominatim address information.
+     */
+    public void completeFromAddress() {
+        String addressStreet = address != null ? address.get("street") : null;
+        if (addressStreet != null) {
+            if (street == null) {
+                street = new HashMap<>();
+            }
+            street.put("name", addressStreet);
+        }
     }
 }

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -131,7 +131,9 @@ public class PhotonDoc {
      * Complete doc from nominatim address information.
      */
     public void completeFromAddress() {
-        String addressStreet = address != null ? address.get("street") : null;
+        if (address == null) return;
+
+        String addressStreet = address.get("street");
         if (addressStreet != null) {
             if (this.street == null) {
                 this.street = new HashMap<>();

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -53,8 +53,8 @@ public class Utils {
             builder.field(Constants.COUNTRYCODE, countryCode.getAlpha2());
         writeIntlNames(builder, doc.getState(), "state", languages);
         writeIntlNames(builder, doc.getStreet(), "street", languages);
-        writeIntlNames(builder, doc.getNeighbourhood(), "neighbourhood", languages);
-        writeIntlNames(builder, doc.getSuburb(), "suburb", languages);
+        writeIntlNames(builder, doc.getLocality(), "locality", languages);
+        writeIntlNames(builder, doc.getDistrict(), "district", languages);
         writeContext(builder, doc.getContext(), languages);
         writeExtent(builder, doc.getBbox());
 

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -53,6 +53,8 @@ public class Utils {
             builder.field(Constants.COUNTRYCODE, countryCode.getAlpha2());
         writeIntlNames(builder, doc.getState(), "state", languages);
         writeIntlNames(builder, doc.getStreet(), "street", languages);
+        writeIntlNames(builder, doc.getNeighbourhood(), "neighbourhood", languages);
+        writeIntlNames(builder, doc.getSuburb(), "suburb", languages);
         writeContext(builder, doc.getContext(), languages);
         writeExtent(builder, doc.getBbox());
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -233,6 +233,8 @@ public class Server {
                 propertiesObject = addToCollector("country", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("state", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("street", propertiesObject, copyToCollectorObject, lang);
+                propertiesObject = addToCollector("suburb", propertiesObject, copyToCollectorObject, lang);
+                propertiesObject = addToCollector("neighbourhood", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("name", propertiesObject, nameToCollectorObject, lang);
 
                 // add language specific collector to default for name

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -233,7 +233,7 @@ public class Server {
                 propertiesObject = addToCollector("country", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("state", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("street", propertiesObject, copyToCollectorObject, lang);
-                propertiesObject = addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
+                propertiesObject = addToCollector("district", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("name", propertiesObject, nameToCollectorObject, lang);
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -233,8 +233,8 @@ public class Server {
                 propertiesObject = addToCollector("country", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("state", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("street", propertiesObject, copyToCollectorObject, lang);
-                propertiesObject = addToCollector("suburb", propertiesObject, copyToCollectorObject, lang);
-                propertiesObject = addToCollector("neighbourhood", propertiesObject, copyToCollectorObject, lang);
+                propertiesObject = addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
+                propertiesObject = addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
                 propertiesObject = addToCollector("name", propertiesObject, nameToCollectorObject, lang);
 
                 // add language specific collector to default for name

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -489,6 +489,16 @@ public class NominatimConnector {
                 continue;
             }
 
+            if (address.isNeighbourhood() && doc.getNeighbourhood() == null) {
+                doc.setNeighbourhood(address.getName());
+                continue;
+            }
+
+            if (address.isSuburb() && doc.getSuburb() == null) {
+                doc.setSuburb(address.getName());
+                continue;
+            }
+
             if (address.isState() && doc.getState() == null) {
                 doc.setState(address.getName());
                 continue;

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -489,13 +489,13 @@ public class NominatimConnector {
                 continue;
             }
 
-            if (address.isNeighbourhood() && doc.getNeighbourhood() == null) {
-                doc.setNeighbourhood(address.getName());
+            if (address.isLocality() && doc.getLocality() == null) {
+                doc.setLocality(address.getName());
                 continue;
             }
 
-            if (address.isSuburb() && doc.getSuburb() == null) {
-                doc.setSuburb(address.getName());
+            if (address.isDistrict() && doc.getDistrict() == null) {
+                doc.setDistrict(address.getName());
                 continue;
             }
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -143,6 +143,7 @@ public class NominatimConnector {
                     "house_number",
                     Collections.<String, String>emptyMap(), // no name
                     (String) null,
+                    Collections.<String, String>emptyMap(), // no address
                     Collections.<String, String>emptyMap(), // no extratags
                     (Envelope) null,
                     rs.getLong("parent_place_id"),
@@ -186,6 +187,7 @@ public class NominatimConnector {
                     rs.getString("type"),
                     DBUtils.getMap(rs, "name"),
                     (String) null,
+                    DBUtils.getMap(rs, "address"),
                     DBUtils.getMap(rs, "extratags"),
                     envelope,
                     rs.getLong("parent_place_id"),
@@ -205,7 +207,7 @@ public class NominatimConnector {
             return result;
         }
     };
-    private final String selectColsPlaceX = "place_id, osm_type, osm_id, class, type, name, housenumber, postcode, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_search, importance, country_code, centroid";
+    private final String selectColsPlaceX = "place_id, osm_type, osm_id, class, type, name, housenumber, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_search, importance, country_code, centroid";
     private final String selectColsOsmline = "place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
     private final String selectColsAddress = "p.place_id, p.osm_type, p.osm_id, p.name, p.class, p.type, p.rank_address, p.admin_level, p.postcode, p.extratags->'place' as place";
     private Importer importer;
@@ -297,7 +299,7 @@ public class NominatimConnector {
         return terms;
     }
 
-    private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null, null, null, null, null, 0, 0, null, null, 0, 0);
+    private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null, null, null, null, null, null, 0, 0, null, null, 0, 0);
 
     private class ImportThread implements Runnable {
         private final BlockingQueue<PhotonDoc> documents;
@@ -497,5 +499,8 @@ public class NominatimConnector {
                 doc.getContext().add(address.getName());
             }
         }
+        // finally, overwrite gathered information with higher prio
+        // address info from nominatim which should have precedence
+        doc.completeFromAddress();
     }
 }

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -32,20 +32,12 @@ public class AddressRow {
         return 26 <= rankAddress && rankAddress < 28;
     }
 
-    public boolean isNeighbourhood() {
-        if ("place".equals(osmKey) && "neighbourhood".equals(osmValue)) {
-            return true;
-        }
-        // TODO admin?
-        return false;
+    public boolean isLocality() {
+        return 22 <= rankAddress && rankAddress < 25;
     }
     
-    public boolean isSuburb() {
-        if ("place".equals(osmKey) && "suburb".equals(osmValue)) {
-            return true;
-        }
-        // TODO admin?
-        return false;
+    public boolean isDistrict() {
+        return 17 <= rankAddress && rankAddress < 21;
     }
     public boolean isCity() {
         return 13 <= rankAddress && rankAddress <= 16;

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -33,11 +33,11 @@ public class AddressRow {
     }
 
     public boolean isLocality() {
-        return 22 <= rankAddress && rankAddress < 25;
+        return 22 <= rankAddress && rankAddress < 26;
     }
     
     public boolean isDistrict() {
-        return 17 <= rankAddress && rankAddress < 21;
+        return 17 <= rankAddress && rankAddress < 22;
     }
     public boolean isCity() {
         return 13 <= rankAddress && rankAddress <= 16;

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -32,10 +32,16 @@ public class AddressRow {
         return 26 <= rankAddress && rankAddress < 28;
     }
 
+    /**
+     * @return whether nominatim thinks this place is a locality (=neighbourhood)
+     */
     public boolean isLocality() {
         return 22 <= rankAddress && rankAddress < 26;
     }
-    
+
+    /**
+     * @return whether nominatim thinks this place is a district (=suburb)
+     */
     public boolean isDistrict() {
         return 17 <= rankAddress && rankAddress < 22;
     }

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -32,6 +32,21 @@ public class AddressRow {
         return 26 <= rankAddress && rankAddress < 28;
     }
 
+    public boolean isNeighbourhood() {
+        if ("place".equals(osmKey) && "neighbourhood".equals(osmValue)) {
+            return true;
+        }
+        // TODO admin?
+        return false;
+    }
+    
+    public boolean isSuburb() {
+        if ("place".equals(osmKey) && "suburb".equals(osmValue)) {
+            return true;
+        }
+        // TODO admin?
+        return false;
+    }
     public boolean isCity() {
         return 13 <= rankAddress && rankAddress <= 16;
     }

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -19,7 +19,8 @@ import java.util.Map;
 @Slf4j
 public class ConvertToJson {
     private final static String[] KEYS_LANG_UNSPEC = {Constants.OSM_ID, Constants.OSM_VALUE, Constants.OSM_KEY, Constants.POSTCODE, Constants.HOUSENUMBER, Constants.COUNTRYCODE, Constants.OSM_TYPE};
-    private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.STREET, Constants.STATE};
+    private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.SUBURB, Constants.NEIGHBOURHOOD, Constants.STREET, Constants.STATE};
+
     private final String lang;
 
     public ConvertToJson(String lang) {
@@ -27,7 +28,7 @@ public class ConvertToJson {
     }
 
     public List<JSONObject> convert(SearchResponse searchResponse) {
-        SearchHit[] hits = searchResponse.getHits().hits();
+        SearchHit[] hits = searchResponse.getHits().getHits();
         final List<JSONObject> list = Lists.newArrayListWithExpectedSize(hits.length);
         for (SearchHit hit : hits) {
             final Map<String, Object> source = hit.getSource();

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @Slf4j
 public class ConvertToJson {
     private final static String[] KEYS_LANG_UNSPEC = {Constants.OSM_ID, Constants.OSM_VALUE, Constants.OSM_KEY, Constants.POSTCODE, Constants.HOUSENUMBER, Constants.COUNTRYCODE, Constants.OSM_TYPE};
-    private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.SUBURB, Constants.NEIGHBOURHOOD, Constants.STREET, Constants.STATE};
+    private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.DISTRICT, Constants.LOCALITY, Constants.STREET, Constants.STATE};
 
     private final String lang;
 

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -37,7 +37,7 @@ public class ESBaseTester {
     private PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
         ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
         Point location = FACTORY.createPoint(new Coordinate(lon, lat));
-        return new PhotonDoc(id, "way", osmId, key, value, nameMap, null, null, null, 0, 0.5, null, location, 0, 0);
+        return new PhotonDoc(id, "way", osmId, key, value, nameMap, null, null, null, null, 0, 0.5, null, location, 0, 0);
     }
 
     @Before

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -1,0 +1,39 @@
+package de.komoot.photon;
+
+import java.util.HashMap;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PhotonDocTest {
+
+    @Test
+    public void testCompleteAddressOverwritesStreet() {
+        HashMap<String, String> address = new HashMap<>();
+        address.put("street", "test street");
+        PhotonDoc doc = createPhotonDocWithAddress(address);
+        
+        HashMap<String, String> streetNames = new HashMap<>();
+        streetNames.put("name", "parent place street");
+        doc.setStreet(streetNames);
+        
+        doc.completeFromAddress();
+        Assert.assertThat(doc.getStreet().get("name"), IsEqual.equalTo("test street"));    
+    }
+
+    @Test
+    public void testCompleteAddressCreatesStreetIfNonExistantBefore() {
+        HashMap<String, String> address = new HashMap<>();
+        address.put("street", "test street");
+        PhotonDoc doc = createPhotonDocWithAddress(address);
+        
+        doc.completeFromAddress();
+        Assert.assertThat(doc.getStreet().get("name"), IsEqual.equalTo("test street"));    
+    }
+
+    private PhotonDoc createPhotonDocWithAddress(HashMap<String, String> address) {
+        return new PhotonDoc(1, "W", 2, "highway", "residential", null, "4", address, null, null, 0, 30, null, null, 0, 30);
+    }
+
+}


### PR DESCRIPTION
With this PR, the address key/values are read from nominatim and if it contains a street attribute, this is copied to via `street.put("name", addressStreet)`.

It fixes tests added with geocoders/geocoder-tester#38

