### PR TITLE
Filter punctuation for search_ngram analyzer

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -75,7 +75,7 @@
 		"char_filter": {
 			"punctuationgreedy": {
 				"type": "pattern_replace",
-				"pattern": "[\\.,]",
+				"pattern": "[\\.,']",
 				"replacement": " "
 			},
 			"remove_ws_hnr_suffix": {


### PR DESCRIPTION
This PR provides a fix for #308. 

Already existing, but currently failing geocoder-tester testcases, especially for France like e.g.
rue du mont d'or Saint-Didier-au-Mont-d'Or

should succeed with this change.