### PR TITLE
Remove diacritics from words

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -11,6 +11,7 @@
 					"preserving_word_delimiter",
 					"lowercase",
 					"german_normalization",
+					"asciifolding",
 					"unique"
 				]
 			},
@@ -21,7 +22,8 @@
 				"tokenizer": "standard",
 				"filter": [
 					"lowercase",
-					"german_normalization"
+					"german_normalization",
+					"asciifolding"
 				]
 			},
 			"index_raw": {


### PR DESCRIPTION
Should fix #326. https://www.elastic.co/guide/en/elasticsearch/guide/current/asciifolding-token-filter.html explains the Elasticsearch behaviour.