### PR TITLE
Respect -cluster setting also when running standalone

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -79,11 +79,9 @@ public class Server {
         Settings.Builder sBuilder = Settings.builder();
         sBuilder.put("path.home", this.esDirectory.toString());
         sBuilder.put("network.host", "127.0.0.1"); // http://stackoverflow.com/a/15509589/1245622
+        sBuilder.put("cluster.name", clusterName);
 
         if (transportAddresses != null && !transportAddresses.isEmpty()) {
-
-            sBuilder.put("cluster.name", clusterName);
-
             TransportClient trClient = new PreBuiltTransportClient(sBuilder.build());
             List<String> addresses = Arrays.asList(transportAddresses.split(","));
             for (String tAddr : addresses) {


### PR DESCRIPTION
Not sure if setting `-cluster` is the most proper way to go but it allows me to easily run multiple instances for comparison on the same machine.