### PR TITLE
Tag query using filter. This improves caching for the same tags 

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -51,7 +51,7 @@ public class PhotonQueryBuilder implements TagFilterQueryBuilder {
 
     private MatchQueryBuilder languageMatchQueryBuilder;
 
-    private QueryBuilder m_finalQueryBuilder;
+    private BoolQueryBuilder m_finalQueryBuilder;
 
     protected ArrayList<FilterFunctionBuilder> m_alFilterFunction4QueryBuilder = new ArrayList<>(1);
 
@@ -306,18 +306,16 @@ public class PhotonQueryBuilder implements TagFilterQueryBuilder {
     public QueryBuilder buildQuery() {
         if (state.equals(State.FINISHED)) return m_finalQueryBuilder;
 
-        if (state.equals(State.FILTERED)) {
-
-            if (orQueryBuilderForIncludeTagFiltering != null)
-                m_queryBuilderForTopLevelFilter.must(orQueryBuilderForIncludeTagFiltering);
-            if (andQueryBuilderForExcludeTagFiltering != null)
-                m_queryBuilderForTopLevelFilter.must(andQueryBuilderForExcludeTagFiltering);
-
-        }
-
-        state = State.FINISHED;
-
         m_finalQueryBuilder = QueryBuilders.boolQuery().must(m_finalQueryWithoutTagFilterBuilder).filter(m_queryBuilderForTopLevelFilter);
+
+        if (state.equals(State.FILTERED)) {
+            BoolQueryBuilder tagFilters = QueryBuilders.boolQuery();
+            if (orQueryBuilderForIncludeTagFiltering != null)
+                tagFilters.must(orQueryBuilderForIncludeTagFiltering);
+            if (andQueryBuilderForExcludeTagFiltering != null)
+                tagFilters.must(andQueryBuilderForExcludeTagFiltering);
+            m_finalQueryBuilder.filter(tagFilters);
+        }
 
         return m_finalQueryBuilder;
     }

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -317,6 +317,8 @@ public class PhotonQueryBuilder implements TagFilterQueryBuilder {
             m_finalQueryBuilder.filter(tagFilters);
         }
 
+        state = State.FINISHED;
+
         return m_finalQueryBuilder;
     }
 


### PR DESCRIPTION
There is only one filter (That can be used for caching) which included filtering on housenumber based on query. For every query, it's a different filter, so not useful for caching.

If you create a filter with only the list of tags, these may get cached and reused in every query. 
See https://www.elastic.co/guide/en/elasticsearch/guide/current/filter-caching.html

(No tests added, because nothing really changed. Only caching should be improved)