### PR TITLE
Fix #328: Set distance_sort default to true for ReverseRequest

### DIFF
--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -66,7 +66,7 @@ public class ReverseRequestFactory {
 
         Boolean locationDistanceSort;
         try {
-            locationDistanceSort = Boolean.valueOf(webRequest.queryParamOrDefault("distance_sort", "false"));
+            locationDistanceSort = Boolean.valueOf(webRequest.queryParamOrDefault("distance_sort", "true"));
         } catch (Exception nfe) {
             throw new BadRequestException(400, "invalid parameter 'distance_sort', can only be true or false");
         }

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -21,6 +21,7 @@ public class ReverseRequestFactoryTest {
     public void requestWithLongitudeLatitude(Request mockRequest, Double longitude, Double latitude) {
         Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn(longitude.toString());
         Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn(latitude.toString());
+        Mockito.when(mockRequest.queryParamOrDefault("distance_sort", "true")).thenReturn("true");
     }
 
     @Test
@@ -160,5 +161,15 @@ public class ReverseRequestFactoryTest {
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(reverseRequest.getLimit().longValue(), 50);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("limit");
+    }
+    
+    @Test
+    public void testDistanceSortDefault() throws Exception {
+        Request mockRequest = Mockito.mock(Request.class);
+        requestWithLongitudeLatitude(mockRequest, -87d, 41d);
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableSet.of("en"));
+        reverseRequest = reverseRequestFactory.create(mockRequest);
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("distance_sort", "true");
+        Assert.assertEquals(true, reverseRequest.getLocationDistanceSort());
     }
 }


### PR DESCRIPTION
For ReverseRequest, distance_sort should by true by default.

To be honest, I can't imagine a scenario, where distance_sort=false would make sense for reverse geocoding(?). Shouldn't this parameter be removed completely for reverse requests?