### PR TITLE
Fix #350: Add lat/lon validation for forward geocoding locationBias

### DIFF
--- a/src/main/java/de/komoot/photon/query/LocationParamConverter.java
+++ b/src/main/java/de/komoot/photon/query/LocationParamConverter.java
@@ -1,0 +1,49 @@
+package de.komoot.photon.query;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.PrecisionModel;
+
+import de.komoot.photon.utils.Function;
+import spark.Request;
+
+import java.util.Set;
+
+/**
+ * Converts lon/lat parameter into location and validates the given coordinates.
+ * Created by Holger Bruch on 10/13/2018.
+ */
+public class LocationParamConverter implements Function<Request, Point, BadRequestException> {
+    private final static GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+    private boolean mandatory;
+
+    public LocationParamConverter(boolean mandatory) {
+        this.mandatory = mandatory;
+    }
+    
+    @Override
+    public Point apply(Request webRequest) throws BadRequestException {
+        Point location;
+        String lonParam = webRequest.queryParams("lon");
+        String latParam = webRequest.queryParams("lat");
+        if (!mandatory && lonParam == null && latParam == null) {
+            return null;
+        }
+        
+        try {
+            Double lon = Double.valueOf(lonParam);
+            if (lon > 180.0 || lon < -180.00) {
+                throw new BadRequestException(400, "invalid search term 'lon', expected number >= -180.0 and <= 180.0");
+            }
+            Double lat = Double.valueOf(latParam);
+            if (lat > 90.0 || lat < -90.00) {
+                throw new BadRequestException(400, "invalid search term 'lat', expected number >= -90.0 and <= 90.0");
+            }
+            location = geometryFactory.createPoint(new Coordinate(lon, lat));
+        } catch (NullPointerException | NumberFormatException e) {
+            throw new BadRequestException(400, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
+        }
+        return location;
+    }
+}

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -1,9 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
 import spark.QueryParamsMap;
 import spark.Request;
 
@@ -17,7 +14,7 @@ import java.util.Set;
  */
 public class PhotonRequestFactory {
     private final LanguageChecker languageChecker;
-    private final static GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+    private final static LocationParamConverter optionalLocationParamConverter = new LocationParamConverter(false);
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
             "limit", "osm_tag", "location_bias_scale"));
@@ -45,14 +42,7 @@ public class PhotonRequestFactory {
         } catch (NumberFormatException e) {
             limit = 15;
         }
-        Point locationForBias = null;
-        try {
-            Double lon = Double.valueOf(webRequest.queryParams("lon"));
-            Double lat = Double.valueOf(webRequest.queryParams("lat"));
-            locationForBias = geometryFactory.createPoint(new Coordinate(lon, lat));
-        } catch (Exception nfe) {
-            //ignore
-        }
+        Point locationForBias = optionalLocationParamConverter.apply(webRequest);
 
         // don't use too high default value, see #306
         double scale = 1.6;

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -49,7 +49,7 @@ public class PhotonRequestFactoryTest {
         Assert.assertNull(photonRequest.getLocationForBias());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.never()).queryParams("lat");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     @Test
@@ -58,15 +58,20 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
         Mockito.when(mockRequest.queryParams("lon")).thenReturn("bad");
         Mockito.when(mockRequest.queryParams("lat")).thenReturn("bad");
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableSet.of("en"));
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
-        photonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", photonRequest.getQuery());
-        Assert.assertNull(photonRequest.getLocationForBias());
+        
+        try {
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableSet.of("en"));
+            photonRequest = photonRequestFactory.create(mockRequest);
+            Assert.fail();
+        } catch (BadRequestException e) {
+            Assert.assertEquals("invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0", e.getMessage());
+        }
+        
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
-        Mockito.verify(mockRequest, Mockito.never()).queryParams("lat");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -19,8 +19,8 @@ public class ReverseRequestFactoryTest {
     private ReverseRequest reverseRequest;
 
     public void requestWithLongitudeLatitude(Request mockRequest, Double longitude, Double latitude) {
-        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn(longitude.toString());
-        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn(latitude.toString());
+        Mockito.when(mockRequest.queryParams("lon")).thenReturn(longitude.toString());
+        Mockito.when(mockRequest.queryParams("lat")).thenReturn(latitude.toString());
         Mockito.when(mockRequest.queryParamOrDefault("distance_sort", "true")).thenReturn("true");
     }
 
@@ -32,8 +32,8 @@ public class ReverseRequestFactoryTest {
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(-87, reverseRequest.getLocation().getX(), 0);
         Assert.assertEquals(41, reverseRequest.getLocation().getY(), 0);
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lat", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     public void assertBadRequest(Request mockRequest, String expectedMessage) {
@@ -49,11 +49,11 @@ public class ReverseRequestFactoryTest {
     @Test
     public void testWithBadLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
-        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn("bad");
-        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn("bad");
+        Mockito.when(mockRequest.queryParams("lon")).thenReturn("bad");
+        Mockito.when(mockRequest.queryParams("lat")).thenReturn("bad");
         assertBadRequest(mockRequest, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
-        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
 
@@ -61,8 +61,8 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, (high) ? 180.01 : -180.01, 0.0);
         assertBadRequest(mockRequest, "invalid search term 'lon', expected number >= -180.0 and <= 180.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
-        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     @Test
@@ -79,8 +79,8 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, 0.0, (high) ? 90.01 : -90.01);
         assertBadRequest(mockRequest, "invalid search term 'lat', expected number >= -90.0 and <= 90.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lat", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     @Test
@@ -96,11 +96,11 @@ public class ReverseRequestFactoryTest {
     @Test
     public void testWithNoLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
-        Mockito.when(mockRequest.queryParamOrDefault("lon", "")).thenReturn("");
-        Mockito.when(mockRequest.queryParamOrDefault("lat", "")).thenReturn("");
+        Mockito.when(mockRequest.queryParams("lon")).thenReturn("");
+        Mockito.when(mockRequest.queryParams("lat")).thenReturn("");
         assertBadRequest(mockRequest, "invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0");
-        Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("lon", "");
-        Mockito.verify(mockRequest, Mockito.never()).queryParamOrDefault("lat", "");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
 
     public void testWithBadParam(String paramName, String paramValue, String expectedMessage) throws Exception {


### PR DESCRIPTION
Note that now ill-formatted location bias lat/lon is no longer silently ignored but results in an 400 BAD_REQUEST.