### PR TITLE
Fixed the update process by also complete places before updating

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -246,8 +246,10 @@ public class NominatimConnector {
         this.importer = importer;
     }
 
-    public PhotonDoc getByPlaceId(long placeId) {
-        return template.queryForObject("SELECT " + selectColsPlaceX + " FROM placex WHERE place_id = ?", new Object[]{placeId}, placeRowMapper).getBaseDoc();
+    public List<PhotonDoc> getByPlaceId(long placeId) {
+        NominatimResult result = template.queryForObject("SELECT " + selectColsPlaceX + " FROM placex WHERE place_id = ?", new Object[]{placeId}, placeRowMapper);
+        completePlace(result.getBaseDoc());
+        return result.getDocsWithHousenumber();
     }
 
     List<AddressRow> getAddresses(PhotonDoc doc) {

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -39,8 +39,13 @@ public class NominatimUpdater {
                 for (UpdateRow place : getIndexSectorPlaces(rank, (Integer) sector.get("geometry_sector"))) {
 
                     template.update("update placex set indexed_status = 0 where place_id = ?", place.getPlaceId());
-                    final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
 
+                    if (place.getIndexdStatus() == 100) {
+                        updater.delete(place.getPlaceId());
+                        continue;
+                    }
+
+                    final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
                     for (PhotonDoc updatedDoc : updatedDocs) {
                         switch (place.getIndexdStatus()) {
                             case 1:
@@ -53,9 +58,6 @@ public class NominatimUpdater {
                                     break;
                                 }
                                 updater.updateOrCreate(updatedDoc);
-                                break;
-                            case 100:
-                                updater.delete(place.getPlaceId());
                                 break;
                             default:
                                 LOGGER.error(String.format("Unknown index status %d", place.getIndexdStatus()));


### PR DESCRIPTION
Currently updates aren't correctly processed. Places are incomplete, and a lot warning are given because a place can be deleted and also tried to updateOrCreate afterwards.

This fixes both issues.