### PR TITLE
upgrade sparkjava to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>com.sparkjava</groupId>
 			<artifactId>spark-core</artifactId>
-			<version>2.7.1</version>
+			<version>2.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
There is a security problem with an old spark version. Although the usual photon installation is not intended to be exposed in the public we should fix it: https://nvd.nist.gov/vuln/detail/CVE-2018-9159