### PR TITLE
Update python requirements list for website

### DIFF
--- a/website/Readme.md
+++ b/website/Readme.md
@@ -15,7 +15,7 @@ It has been developed with python3.4 (but should work with python2.x). We sugges
 * Install dependencies:
  ```
  cd website/photon
- pip install -r requirements.txt
+ pip install -r ../requirements.txt
  ```
 * Run the server
  ```

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,8 +1,8 @@
-Flask==0.10.1
-itsdangerous==0.23
-Jinja2==2.7.1
-MarkupSafe==0.18
-requests==2.0.0
-simplejson==3.3.1
-Werkzeug==0.9.4
-elasticsearch==1.0.0
+Flask==1.0.2
+itsdangerous==0.24
+Jinja2==2.10
+MarkupSafe==1.0
+requests==2.20.0
+simplejson==3.16.0
+Werkzeug==0.14.1
+elasticsearch==6.3.1


### PR DESCRIPTION
I've updated all requirements in the list to the newest available version. Website still shows as before. I couldn't really test the search function but I think that depends only on the leaflet plugin, which was not updated.