### PR TITLE
Improvements to updating code

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/Updater.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Updater.java
@@ -61,6 +61,10 @@ public class Updater implements de.komoot.photon.Updater {
     }
 
     private void updateDocuments() {
+        if (this.bulkRequest.numberOfActions() == 0) {
+            log.warn("Update empty");
+            return;
+        }
         BulkResponse bulkResponse = bulkRequest.execute().actionGet();
         if (bulkResponse.hasFailures()) {
             log.error("error while bulk update: " + bulkResponse.buildFailureMessage());

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -207,6 +207,7 @@ public class NominatimConnector {
     };
     private final String selectColsPlaceX = "place_id, osm_type, osm_id, class, type, name, housenumber, postcode, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_search, importance, country_code, centroid";
     private final String selectColsOsmline = "place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
+    private final String selectColsAddress = "p.place_id, p.osm_type, p.osm_id, p.name, p.class, p.type, p.rank_address, p.admin_level, p.postcode, p.extratags->'place' as place";
     private Importer importer;
 
     private Map<String, String> getCountryNames(String countrycode) {
@@ -261,10 +262,7 @@ public class NominatimConnector {
     }
 
     List<AddressRow> getAddresses(PhotonDoc doc) {
-        long placeId = doc.getPlaceId();
-        if (doc.getRankSearch() > 28)
-            placeId = doc.getParentPlaceId();
-        return template.query("SELECT p.place_id, p.osm_type, p.osm_id, p.name, p.class, p.type, p.rank_address, p.admin_level, p.postcode, p.extratags->'place' as place FROM placex p, place_addressline pa WHERE p.place_id = pa.address_place_id and pa.place_id = ? and pa.cached_rank_address > 4 and pa.address_place_id != ? and pa.isaddress order by rank_address desc,fromarea desc,distance asc,rank_search desc", new Object[]{placeId, doc.getPlaceId()}, new RowMapper<AddressRow>() {
+        RowMapper<AddressRow> rowMapper = new RowMapper<AddressRow>() {
             @Override
             public AddressRow mapRow(ResultSet rs, int rowNum) throws SQLException {
                 Integer adminLevel = rs.getInt("admin_level");
@@ -284,7 +282,19 @@ public class NominatimConnector {
                         rs.getLong("osm_id")
                 );
             }
-        });
+        };
+
+        boolean isPoi = doc.getRankSearch() > 28;
+        long placeId = (isPoi) ? doc.getParentPlaceId() : doc.getPlaceId();
+
+        List<AddressRow> terms = template.query("SELECT " + selectColsAddress + " FROM placex p, place_addressline pa WHERE p.place_id = pa.address_place_id and pa.place_id = ? and pa.cached_rank_address > 4 and pa.address_place_id != ? and pa.isaddress order by rank_address desc,fromarea desc,distance asc,rank_search desc", new Object[]{placeId, placeId}, rowMapper);
+
+        if (isPoi) {
+            // need to add the term for the parent place ID itself
+            terms.addAll(0, template.query("SELECT " + selectColsAddress + " FROM placex p WHERE p.place_id = ?", new Object[]{placeId}, rowMapper));
+        }
+
+        return terms;
     }
 
     private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null, null, null, null, null, 0, 0, null, null, 0, 0);

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -12,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Nominatim update logic
@@ -29,135 +30,148 @@ public class NominatimUpdater {
     private static final int MIN_RANK = 1;
     private static final int MAX_RANK = 30;
 
-    private final JdbcTemplate template;
+    private final JdbcTemplate       template;
     private final NominatimConnector exporter;
 
     private Updater updater;
+
+    /**
+     * when updating lockout other threads
+     */
+    private ReentrantLock updateLock = new ReentrantLock();
 
     public void setUpdater(Updater updater) {
         this.updater = updater;
     }
 
     public void update() {
-        int updatedPlaces = 0;
-        int deletedPlaces = 0;
-        for (int rank = MIN_RANK; rank <= MAX_RANK; rank++) {
-            LOGGER.info(String.format("Starting rank %d", rank));
-            for (Map<String, Object> sector : getIndexSectors(rank)) {
-                for (UpdateRow place : getIndexSectorPlaces(rank, (Integer) sector.get("geometry_sector"))) {
-                    long placeId = place.getPlaceId();
-                    template.update("update placex set indexed_status = 0 where place_id = ?;", placeId);
-                    
-                    Integer indexedStatus = place.getIndexdStatus();
-                    if (indexedStatus == DELETE || (indexedStatus == UPDATE && rank == MAX_RANK)) {
-                        updater.delete(placeId);
-                        if (indexedStatus == DELETE) {
-                            deletedPlaces++;
-                            continue;
-                        } 
-                        indexedStatus = CREATE; // always create
-                    } 
-                    updatedPlaces++;
+        if (updateLock.tryLock()) {
+            try {
+                int updatedPlaces = 0;
+                int deletedPlaces = 0;
+                for (int rank = MIN_RANK; rank <= MAX_RANK; rank++) {
+                    LOGGER.info(String.format("Starting rank %d", rank));
+                    for (Map<String, Object> sector : getIndexSectors(rank)) {
+                        for (UpdateRow place : getIndexSectorPlaces(rank, (Integer) sector.get("geometry_sector"))) {
+                            long placeId = place.getPlaceId();
+                            template.update("update placex set indexed_status = 0 where place_id = ?;", placeId);
 
-                    final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
-                    boolean wasUseful = false;
-                    for (PhotonDoc updatedDoc : updatedDocs) {
-                        switch (indexedStatus) {
-                        case CREATE:
-                            if (updatedDoc.isUsefulForIndex()) {
-                                updater.create(updatedDoc);
+                            Integer indexedStatus = place.getIndexdStatus();
+                            if (indexedStatus == DELETE || (indexedStatus == UPDATE && rank == MAX_RANK)) {
+                                updater.delete(placeId);
+                                if (indexedStatus == DELETE) {
+                                    deletedPlaces++;
+                                    continue;
+                                }
+                                indexedStatus = CREATE; // always create
                             }
-                            break;
-                        case UPDATE:
-                            if (updatedDoc.isUsefulForIndex()) {
-                                updater.updateOrCreate(updatedDoc);
-                                wasUseful = true;
+                            updatedPlaces++;
+
+                            final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
+                            boolean wasUseful = false;
+                            for (PhotonDoc updatedDoc : updatedDocs) {
+                                switch (indexedStatus) {
+                                case CREATE:
+                                    if (updatedDoc.isUsefulForIndex()) {
+                                        updater.create(updatedDoc);
+                                    }
+                                    break;
+                                case UPDATE:
+                                    if (updatedDoc.isUsefulForIndex()) {
+                                        updater.updateOrCreate(updatedDoc);
+                                        wasUseful = true;
+                                    }
+                                    break;
+                                default:
+                                    LOGGER.error(String.format("Unknown index status %d", indexedStatus));
+                                    break;
+                                }
                             }
-                            break;
-                        default:
-                            LOGGER.error(String.format("Unknown index status %d", indexedStatus));
-                            break;
+                            if (indexedStatus == UPDATE && !wasUseful) {
+                                // only true when rank != 30
+                                // if no documents for the place id exist this will likely cause moaning
+                                updater.delete(placeId);
+                                updatedPlaces--;
+                            }
                         }
                     }
-                    if (indexedStatus == UPDATE && !wasUseful) { 
-                        // only true when rank != 30
-                        // if no documents for the place id exist this will likely cause moaning
-                        updater.delete(placeId); 
-                        updatedPlaces--;
+                }
+
+                LOGGER.info(String.format("%d places created or updated, %d deleted", updatedPlaces, deletedPlaces));
+
+                // update documents generated from address interpolations
+                // .isUsefulForIndex() should always return true for documents
+                // created from interpolations so no need to check them
+                LOGGER.info("Starting interpolations");
+                int updatedInterpolations = 0;
+                int deletedInterpolations = 0;
+                int interpolationDocuments = 0;
+                for (Map<String, Object> sector : template.queryForList(
+                        "select geometry_sector,count(*) from location_property_osmline where indexed_status > 0 group by geometry_sector order by geometry_sector;")) {
+                    for (UpdateRow place : getIndexSectorInterpolations((Integer) sector.get("geometry_sector"))) {
+                        long placeId = place.getPlaceId();
+                        template.update("update location_property_osmline set indexed_status = 0 where place_id = ?;", placeId);
+
+                        Integer indexedStatus = place.getIndexdStatus();
+                        if (indexedStatus != CREATE) {
+                            updater.delete(placeId);
+                            if (indexedStatus == DELETE) {
+                                deletedInterpolations++;
+                                continue;
+                            }
+                        }
+                        updatedInterpolations++;
+
+                        final List<PhotonDoc> updatedDocs = exporter.getInterpolationsByPlaceId(place.getPlaceId());
+                        for (PhotonDoc updatedDoc : updatedDocs) {
+                            updater.create(updatedDoc);
+                            interpolationDocuments++;
+                        }
                     }
                 }
+                LOGGER.info(String.format("%d interpolations created or updated, %d deleted, %d documents added or updated", updatedInterpolations,
+                        deletedInterpolations, interpolationDocuments));
+                updater.finish();
+                template.update("update import_status set indexed=true;"); // indicate that we are finished
+
+                LOGGER.info("Finished updating");
+            } finally {
+                updateLock.unlock();
             }
+        } else {
+            LOGGER.info("Update already in progress");
         }
-
-        LOGGER.info(String.format("%d places created or updated, %d deleted", updatedPlaces, deletedPlaces));
-
-        // update documents generated from address interpolations
-        // .isUsefulForIndex() should always return true for documents
-        // created from interpolations so no need to check them
-        LOGGER.info("Starting interpolations");
-        int updatedInterpolations = 0;
-        int deletedInterpolations = 0;
-        int interpolationDocuments = 0;
-        for (Map<String, Object> sector : template.queryForList(
-                "select geometry_sector,count(*) from location_property_osmline where indexed_status > 0 group by geometry_sector order by geometry_sector;")) {
-            for (UpdateRow place : getIndexSectorInterpolations((Integer) sector.get("geometry_sector"))) {
-                long placeId = place.getPlaceId();
-                template.update("update location_property_osmline set indexed_status = 0 where place_id = ?;", placeId);
-
-                Integer indexedStatus = place.getIndexdStatus();
-                if (indexedStatus != CREATE) {
-                    updater.delete(placeId);
-                    if (indexedStatus == DELETE) {
-                        deletedInterpolations++;
-                        continue;
-                    }
-                } 
-                updatedInterpolations++;
-
-                final List<PhotonDoc> updatedDocs = exporter.getInterpolationsByPlaceId(place.getPlaceId());
-                for (PhotonDoc updatedDoc : updatedDocs) {
-                    updater.create(updatedDoc);
-                    interpolationDocuments++;
-                }
-            }
-        }
-        LOGGER.info(String.format("%d interpolations created or updated, %d deleted, %d documents added or updated", 
-                updatedInterpolations, deletedInterpolations, interpolationDocuments));
-        updater.finish();
-        template.update("update import_status set indexed=true;"); // indicate that we are finished
- 
-        LOGGER.info("Finished updating");
     }
 
     private List<Map<String, Object>> getIndexSectors(Integer rank) {
-        return template.queryForList("select geometry_sector,count(*) from placex where rank_search = ? " +
-                "and indexed_status > 0 group by geometry_sector order by geometry_sector;", rank);
+        return template.queryForList("select geometry_sector,count(*) from placex where rank_search = ? "
+                + "and indexed_status > 0 group by geometry_sector order by geometry_sector;", rank);
     }
 
     private List<UpdateRow> getIndexSectorPlaces(Integer rank, Integer geometrySector) {
-        return template.query("select place_id, indexed_status from placex where rank_search = ?" +
-                " and geometry_sector = ? and indexed_status > 0;", new Object[]{rank, geometrySector}, new RowMapper<UpdateRow>() {
-            @Override
-            public UpdateRow mapRow(ResultSet rs, int rowNum) throws SQLException {
-                UpdateRow updateRow = new UpdateRow();
-                updateRow.setPlaceId(rs.getLong("place_id"));
-                updateRow.setIndexdStatus(rs.getInt("indexed_status"));
-                return updateRow;
-            }
-        });
+        return template.query("select place_id, indexed_status from placex where rank_search = ?" + " and geometry_sector = ? and indexed_status > 0;",
+                new Object[] { rank, geometrySector }, new RowMapper<UpdateRow>() {
+                    @Override
+                    public UpdateRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+                        UpdateRow updateRow = new UpdateRow();
+                        updateRow.setPlaceId(rs.getLong("place_id"));
+                        updateRow.setIndexdStatus(rs.getInt("indexed_status"));
+                        return updateRow;
+                    }
+                });
     }
 
     private List<UpdateRow> getIndexSectorInterpolations(Integer geometrySector) {
         return template.query("select place_id, indexed_status from location_property_osmline where geometry_sector = ? and indexed_status > 0;",
                 new Object[] { geometrySector }, new RowMapper<UpdateRow>() {
-            @Override
-            public UpdateRow mapRow(ResultSet rs, int rowNum) throws SQLException {
-                UpdateRow updateRow = new UpdateRow();
-                updateRow.setPlaceId(rs.getLong("place_id"));
-                updateRow.setIndexdStatus(rs.getInt("indexed_status"));
-                return updateRow;
-            }
-        });
+                    @Override
+                    public UpdateRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+                        UpdateRow updateRow = new UpdateRow();
+                        updateRow.setPlaceId(rs.getLong("place_id"));
+                        updateRow.setIndexdStatus(rs.getInt("indexed_status"));
+                        return updateRow;
+                    }
+                });
     }
 
     /**
@@ -177,7 +191,7 @@ public class NominatimUpdater {
         dataSource.setPassword(password);
         dataSource.setDriverClassName(JtsWrapper.class.getCanonicalName());
         dataSource.setDefaultAutoCommit(true);
-        
+
         exporter = new NominatimConnector(host, port, database, username, password);
         template = new JdbcTemplate(dataSource);
     }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -54,13 +54,10 @@ public class NominatimUpdater {
                         if (indexedStatus == DELETE) {
                             deletedPlaces++;
                             continue;
-                        } else {
-                            updatedPlaces++;
-                            indexedStatus = CREATE; // always create
-                        }
-                    } else {
-                        updatedPlaces++;
-                    }
+                        } 
+                        indexedStatus = CREATE; // always create
+                    } 
+                    updatedPlaces++;
 
                     final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
                     boolean wasUseful = false;
@@ -98,7 +95,6 @@ public class NominatimUpdater {
         // .isUsefulForIndex() should always return true for documents
         // created from interpolations so no need to check them
         LOGGER.info("Starting interpolations");
-        int createdInterpolations = 0;
         int updatedInterpolations = 0;
         int deletedInterpolations = 0;
         int interpolationDocuments = 0;
@@ -115,10 +111,8 @@ public class NominatimUpdater {
                         deletedInterpolations++;
                         continue;
                     }
-                    updatedInterpolations++;
-                } else {
-                    createdInterpolations++;
-                }
+                } 
+                updatedInterpolations++;
 
                 final List<PhotonDoc> updatedDocs = exporter.getInterpolationsByPlaceId(place.getPlaceId());
                 for (PhotonDoc updatedDoc : updatedDocs) {
@@ -127,7 +121,7 @@ public class NominatimUpdater {
                 }
             }
         }
-        LOGGER.info(String.format("%d interpolations created, %d updated, %d deleted, %d documents added or updated", createdInterpolations,
+        LOGGER.info(String.format("%d interpolations created or updated, %d deleted, %d documents added or updated", 
                 updatedInterpolations, deletedInterpolations, interpolationDocuments));
         updater.finish();
         template.update("update import_status set indexed=true;"); // indicate that we are finished


### PR DESCRIPTION
- expand documents for multiple house numbers on objects and address
interpolations, based on code from @hendrikmoree
- retrieve and process updates to interpolations
- avoid inconsistencies in housenumber updates by deleting existing
documents
- remove code that tried to set indexed_status to 0 in the source
Nominatim database (running update.php --index will do that)
- generate some minimal stats
- minimal code cleanup