### PR TITLE
Add some tests of the API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
+                <configuration>
+                    <excludes>
+                        <exclude>modules/lang-painless/*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,26 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -1,0 +1,159 @@
+package de.komoot.photon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static spark.Spark.awaitInitialization;
+import static spark.Spark.awaitStop;
+import static spark.Spark.port;
+import static spark.Spark.stop;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.stream.Collectors;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * These test connect photon to an already running ES node (setup in ESBaseTester) so that we can directly test the API
+ * 
+ */
+public class ApiIntegrationTest extends ESBaseTester {
+    private static final int LISTEN_PORT = 30234;
+
+    /**
+     * Test that the Access-Control-Allow-Origin header is not set
+     *
+     */
+    @Test
+    public void testNoCors() {
+        try {
+            App.main(new String[] { "-cluster", clusterName, "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1" });
+            awaitInitialization();
+            HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin").openConnection();
+            String result = new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n"));
+            assertNull(connection.getHeaderField("Access-Control-Allow-Origin"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        } finally {
+            stop();
+            awaitStop();
+            deleteIndex();
+        }
+    }
+
+    /**
+     * Test that the Access-Control-Allow-Origin header is set to *
+     *
+     */
+    @Test
+    public void testCorsAny() {
+        try {
+            App.main(new String[] { "-cluster", "photon-test", "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1",
+                    "-cors-any" });
+            awaitInitialization();
+            HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin").openConnection();
+            String result = new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n"));
+            assertEquals("*", connection.getHeaderField("Access-Control-Allow-Origin"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        } finally {
+            stop();
+            awaitStop();
+            deleteIndex();
+        }
+    }
+
+    /**
+     * Test that the Access-Control-Allow-Origin header is set to a specific domain
+     *
+     */
+    @Test
+    public void testCorsOrigin() {
+        try {
+            App.main(new String[] { "-cluster", "photon-test", "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1",
+                    "-cors-origin", "www.poole.ch" });
+            awaitInitialization();
+            HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin").openConnection();
+            String result = new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n"));
+            assertEquals("www.poole.ch", connection.getHeaderField("Access-Control-Allow-Origin"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        } finally {
+            stop();
+            awaitStop();
+            deleteIndex();
+        }
+    }
+
+    /**
+     * Search for Berlin
+     *
+     */
+    @Test
+    public void testApi()  {
+        try {
+            App.main(new String[] { "-cluster", "photon-test", "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1" });
+            awaitInitialization();
+            HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin&limit=1").openConnection();
+            try {
+                JSONObject json = new JSONObject(
+                        new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n")));
+                JSONArray features = json.getJSONArray("features");
+                assertEquals(1, features.length());
+                JSONObject feature = features.getJSONObject(0);
+                JSONObject properties = feature.getJSONObject("properties");
+                assertEquals("way", properties.getString("osm_type"));
+                assertEquals("amenity", properties.getString("osm_key"));
+                assertEquals("information", properties.getString("osm_value"));
+                assertEquals("berlin", properties.getString("name"));
+            } catch (JSONException jsex) {
+                fail(jsex.getMessage());
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        } finally {
+            stop();
+            awaitStop();
+            deleteIndex();
+        }
+    }
+
+    /**
+     * Reverse geocode test
+     *
+     */
+    @Test
+    public void testApiReverse() {
+        try {
+            App.main(new String[] { "-cluster", "photon-test", "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1" });
+            awaitInitialization();
+            HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/reverse/?lon=10&lat=47").openConnection();
+            try {
+                JSONObject json = new JSONObject(
+                        new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n")));
+                JSONArray features = json.getJSONArray("features");
+                assertEquals(1, features.length());
+                JSONObject feature = features.getJSONObject(0);
+                JSONObject properties = feature.getJSONObject("properties");
+                assertEquals("way", properties.getString("osm_type"));
+                assertEquals("amenity", properties.getString("osm_key"));
+                assertEquals("information", properties.getString("osm_value"));
+                assertEquals("berlin", properties.getString("name"));
+            } catch (JSONException jsex) {
+                fail(jsex.getMessage());
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        } finally {
+            stop();
+            awaitStop();
+            deleteIndex();
+        }
+    }
+}

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -109,8 +109,8 @@ public class ApiIntegrationTest extends ESBaseTester {
                 JSONObject feature = features.getJSONObject(0);
                 JSONObject properties = feature.getJSONObject("properties");
                 assertEquals("way", properties.getString("osm_type"));
-                assertEquals("amenity", properties.getString("osm_key"));
-                assertEquals("information", properties.getString("osm_value"));
+                assertEquals("tourism", properties.getString("osm_key"));
+                assertEquals("attraction", properties.getString("osm_value"));
                 assertEquals("berlin", properties.getString("name"));
             } catch (JSONException jsex) {
                 fail(jsex.getMessage());

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -35,10 +35,10 @@ public class ESBaseTester {
 
     protected Client client;
 
-    private PhotonDoc createDoc(int id, String key, String value) {
+    private PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
         ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
-        Point location = FACTORY.createPoint(new Coordinate(10., 47.));
-        return new PhotonDoc(id, "way", id, key, value, nameMap, null, null, null, 0, 0.5, null, location, 0, 0);
+        Point location = FACTORY.createPoint(new Coordinate(lon, lat));
+        return new PhotonDoc(id, "way", osmId, key, value, nameMap, null, null, null, 0, 0.5, null, location, 0, 0);
     }
 
     @Before
@@ -48,13 +48,19 @@ public class ESBaseTester {
                 "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station");
         client = getClient();
         Importer instance = new Importer(client, "en");
+        double lon = 13.38886;
+        double lat = 52.51704;
         for (int i = 0; i < tags.size(); i++) {
             String key = tags.get(i);
             String value = tags.get(++i);
-            PhotonDoc doc = this.createDoc(i, key, value);
+            PhotonDoc doc = this.createDoc(lon, lat, i, i, key, value);
             instance.add(doc);
-            doc = this.createDoc(i + 1, key, value);
+            lon += 0.00004;
+            lat += 0.00086;
+            doc = this.createDoc(lon, lat, i + 1, i + 1, key, value);
             instance.add(doc);
+            lon += 0.00004;
+            lat += 0.00086;
         }
         instance.finish();
         refresh();

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -71,8 +71,13 @@ public class ESBaseTester {
         shutdownES();
     }
 
+    /**
+     * Setup the ES server
+     * 
+     * @throws IOException
+     */
     public void setUpES() throws IOException {
-        server = new Server(clusterName, new File("./target/es_photon_test").getAbsolutePath(), "en", "").start();
+        server = new Server(clusterName, new File("./target/es_photon_test").getAbsolutePath(), "en", "").setMaxShards(1).start();
         server.recreateIndex();
         refresh();
     }

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,29 +1,72 @@
 package de.komoot.photon;
 
+import de.komoot.photon.elasticsearch.Importer;
 import de.komoot.photon.elasticsearch.Server;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.client.Client;
 import org.junit.After;
+import org.junit.Before;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.PrecisionModel;
 
 import java.io.File;
 import java.io.IOException;
 
 /**
+ * Start an ES server with some test data that then can be queried in tests that extend this class
+ * 
  * @author Peter Karich
  */
 @Slf4j
 public class ESBaseTester {
+
+    public final String  clusterName = "photon-test";
+    private final String indexName   = "photon";
+
     private Server server;
 
+    GeometryFactory FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    protected Client client;
+
+    private PhotonDoc createDoc(int id, String key, String value) {
+        ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
+        Point location = FACTORY.createPoint(new Coordinate(10., 47.));
+        return new PhotonDoc(id, "way", id, key, value, nameMap, null, null, null, 0, 0.5, null, location, 0, 0);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        setUpES();
+        ImmutableList<String> tags = ImmutableList.of("tourism", "attraction", "tourism", "hotel", "tourism", "museum", "tourism", "information", "amenity",
+                "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station");
+        client = getClient();
+        Importer instance = new Importer(client, "en");
+        for (int i = 0; i < tags.size(); i++) {
+            String key = tags.get(i);
+            String value = tags.get(++i);
+            PhotonDoc doc = this.createDoc(i, key, value);
+            instance.add(doc);
+            doc = this.createDoc(i + 1, key, value);
+            instance.add(doc);
+        }
+        instance.finish();
+        refresh();
+    }
+
     @After
-    public void tearDownClass() {
+    public void tearDown() {
         shutdownES();
     }
 
     public void setUpES() throws IOException {
-        server = new Server("photon-test", new File("./target/es_photon").getAbsolutePath(), "en", "").
-                start();
+        server = new Server(clusterName, new File("./target/es_photon_test").getAbsolutePath(), "en", "").start();
         server.recreateIndex();
         refresh();
     }
@@ -36,15 +79,17 @@ public class ESBaseTester {
         return server.getClient();
     }
 
-    private final String indexName = "photon";
-
     protected void refresh() {
         getClient().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
     }
 
+    /**
+     * Shutdown the ES node
+     */
     public void shutdownES() {
-        if (server != null)
+        if (server != null) {
             server.shutdown();
+        }
     }
 
     public void deleteIndex() {

--- a/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderSearchTest.java
@@ -1,63 +1,26 @@
 package de.komoot.photon.query;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
-import de.komoot.photon.ESBaseTester;
-import de.komoot.photon.PhotonDoc;
-import de.komoot.photon.elasticsearch.Importer;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Set;
+
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import de.komoot.photon.ESBaseTester;
 
 /**
  * Created by Sachin Dole on 2/20/2015.
  */
 public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
-    GeometryFactory FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
-
-    private Client client;
-    private List<PhotonDoc> testData;
-
-    @Before
-    public void setUp() throws Exception {
-        setUpES();
-        ImmutableList<String> tags = ImmutableList.of("tourism", "attraction",
-                "tourism", "hotel",
-                "tourism", "museum",
-                "tourism", "information",
-                "amenity", "parking",
-                "amenity", "restaurant",
-                "amenity", "information",
-                "food", "information",
-                "railway", "station");
-        Importer instance = new Importer(getClient(), "en");
-        for (int i = 0; i < tags.size(); i++) {
-            String key = tags.get(i);
-            String value = tags.get(++i);
-            PhotonDoc doc = this.createDoc(i, key, value);
-            instance.add(doc);
-            doc = this.createDoc(i + 1, key, value);
-            instance.add(doc);
-        }
-        instance.finish();
-        refresh();
-    }
 
     /**
      * Find me all places named "berlin" that are tagged "tourism=attraction"
@@ -150,7 +113,8 @@ public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
     /**
      * Find me all places named "berlin" that are tagged with the key "tourism" but not tagged with value "information".
      * <p/>
-     * Note: This is a different method of achieving the same result as {@link TagFilterQueryBuilderSearchTest#testKeyTourismButValueNotInformation()}
+     * Note: This is a different method of achieving the same result as
+     * {@link TagFilterQueryBuilderSearchTest#testKeyTourismButValueNotInformation()}
      */
     @Test
     public void testKeyTourismAndValueNotInformation() throws IOException {
@@ -166,7 +130,8 @@ public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
     /**
      * Find me all places named "berlin" that are tagged with the key "tourism" but not tagged with value "information".
      * <p/>
-     * Note: This is a different method of achieving the same result as {@link TagFilterQueryBuilderSearchTest#testKeyTourismAndValueNotInformation}.
+     * Note: This is a different method of achieving the same result as
+     * {@link TagFilterQueryBuilderSearchTest#testKeyTourismAndValueNotInformation}.
      */
     @Test
     public void testKeyTourismButValueNotInformation() throws IOException {
@@ -195,8 +160,9 @@ public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
     }
 
     /**
-     * Find me all places named "berlin" that are tagged with the key "tourism" but not "amenity". This test works, but, the use case does not make sense because by searching for
-     * key "tourism", this test already excludes places keyed on "amenity"
+     * Find me all places named "berlin" that are tagged with the key "tourism" but not "amenity". This test works, but,
+     * the use case does not make sense because by searching for key "tourism", this test already excludes places keyed
+     * on "amenity"
      */
     @Test
     public void testKeyTourismAndKeyNotAmenity() throws IOException {
@@ -236,18 +202,6 @@ public class TagFilterQueryBuilderSearchTest extends ESBaseTester {
         assertThat(searchResponse.getHits().getTotalHits(), is(16l));
 
         deleteIndex();
-    }
-
-    private PhotonDoc createDoc(int id, String key, String value) {
-        ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
-        Point location = FACTORY.createPoint(new Coordinate(10., 47.));
-        return new PhotonDoc(id, "way", id, key, value, nameMap, null, null, null, 0, 0.5, null, location, 0, 0);
-    }
-
-
-    @After
-    public void tearDownClass() {
-        shutdownES();
     }
 
     private SearchResponse search(Client client, QueryBuilder queryBuilder) {


### PR DESCRIPTION
This adds some integration tests for the API (in a wide sense of the word), further I've added the jacoco plugin so that we can at least get local coverage reports (integrating with travis is left as an exercise for the reader :-)).The test class is currently intermingled with the unit tests and run by the surefire plugin and not by failsafe, I don't think separation makes at lot of sense at this stage.

Note that this is based on https://github.com/komoot/photon/pull/399 and will need to be rebased before merging one way or the other.