### PR TITLE
Use SearchType.DFS_QUERY_THEN_FETCH for consistent scoring

### DIFF
--- a/src/main/java/de/komoot/photon/searcher/BaseElasticsearchSearcher.java
+++ b/src/main/java/de/komoot/photon/searcher/BaseElasticsearchSearcher.java
@@ -21,7 +21,7 @@ public class BaseElasticsearchSearcher implements ElasticsearchSearcher {
     public SearchResponse search(QueryBuilder queryBuilder, Integer limit) {
         TimeValue timeout = TimeValue.timeValueSeconds(7);
         return client.prepareSearch("photon").
-                setSearchType(SearchType.QUERY_AND_FETCH).
+                setSearchType(SearchType.DFS_QUERY_THEN_FETCH).
                 setQuery(queryBuilder).
                 setSize(limit).
                 setTimeout(timeout).


### PR DESCRIPTION
While working on adding a test with location bias in https://github.com/komoot/photon/pull/400 I was getting back a best scored result that was further away from the queried location than other (not really different) documents. 

I investigated and this behaviour (widely varying scores) remained even when I used -identical- documents with the exception of the ids and wasn't using location bias. The difference in scores was roughly a factor two. This isn't good because lots of scoring in Photon multiplies these values with other scores making the erroneous results worse (for example when using location bias). 

As far as I could determine (aka half a day later) this is simply an artefact of the default scoring mechanism, and it goes away when using SearchType.DFS_QUERY_THEN_FETCH , however I wouldn't rule out that the behaviour is caused by the small number of documents in the index during the test (18). It would be really good if somebody with more ES knowledge could weigh in.