### PR TITLE
Dump JSON version of api query to result if debug param is present

### DIFF
--- a/src/main/java/de/komoot/photon/SearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/SearchRequestHandler.java
@@ -24,6 +24,8 @@ import static spark.Spark.halt;
  * Created by Sachin Dole on 2/12/2015.
  */
 public class SearchRequestHandler<R extends PhotonRequest> extends RouteImpl {
+    private static final String DEBUG_PARAMETER = "debug";
+    
     private final PhotonRequestFactory photonRequestFactory;
     private final PhotonRequestHandlerFactory requestHandlerFactory;
     private final ConvertToGeoJson geoJsonConverter;
@@ -49,8 +51,12 @@ public class SearchRequestHandler<R extends PhotonRequest> extends RouteImpl {
         PhotonRequestHandler<R> handler = requestHandlerFactory.createHandler(photonRequest);
         List<JSONObject> results = handler.handle(photonRequest);
         JSONObject geoJsonResults = geoJsonConverter.convert(results);
-        if (request.queryParams("debug") != null)
+        if (request.queryParams(DEBUG_PARAMETER) != null) {
+            JSONObject debug = new JSONObject();
+            debug.put("query", new JSONObject(handler.dumpQuery(photonRequest)));
+            geoJsonResults.put(DEBUG_PARAMETER, debug);
             return geoJsonResults.toString(4);
+        }
 
         return geoJsonResults.toString();
     }

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -17,7 +17,7 @@ public class PhotonRequestFactory {
     private final static LocationParamConverter optionalLocationParamConverter = new LocationParamConverter(false);
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
-            "limit", "osm_tag", "location_bias_scale"));
+            "limit", "osm_tag", "location_bias_scale", "debug"));
 
     public PhotonRequestFactory(Set<String> supportedLanguages) {
         this.languageChecker = new LanguageChecker(supportedLanguages);

--- a/src/main/java/de/komoot/photon/searcher/AbstractPhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/AbstractPhotonRequestHandler.java
@@ -38,9 +38,17 @@ public abstract class AbstractPhotonRequestHandler<R extends PhotonRequest> impl
         return resultJsonObjects;
     }
 
+    @Override
+    public String dumpQuery(R photonRequest) {
+        return buildQuery(photonRequest).buildQuery().toString();
+    }
+    
     /**
      * Given a {@link PhotonRequest photon request}, build a {@link TagFilterQueryBuilder photon specific query builder} that can be used in the {@link
      * AbstractPhotonRequestHandler#handle handle} method to execute the search.
+     * 
+     * @param photonRequest a PhotonRequest instance holding the parsed query
+     * @return an instance of a TagFilterQueryBuilder
      */
     abstract TagFilterQueryBuilder buildQuery(R photonRequest);
 }

--- a/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
@@ -12,5 +12,19 @@ import java.util.List;
  * Created by Sachin Dole on 2/12/2015.
  */
 public interface PhotonRequestHandler<R extends PhotonRequest> {
+    /**
+     * Use the request to query ES
+     * 
+     * @param photonRequest the request
+     * @return a List of returned results
+     */
     List<JSONObject> handle(R photonRequest);
+    
+    /**
+     * Get a JSON representation of the query that would be built from the request
+     * 
+     * @param photonRequest the request
+     * @return a String containing JSON
+     */
+    String dumpQuery(R photonRequest);
 }


### PR DESCRIPTION
This PR tries to make life a bit simpler for everybody working on photon by adding a debug flag that includes the generated query in JSON format in the result JSON object. Currently this is only supported for api queries and not fore reverse geo-coding.