### PR TITLE
Update fix

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -388,8 +388,8 @@
 				"index": true
 			},
 			"osm_type": {
-				"type": "text",
-				"index": false
+				"type": "keyword",
+				"index": true
 			},
 			"osm_value": {
 				"type": "keyword",

--- a/src/main/java/de/komoot/photon/Updater.java
+++ b/src/main/java/de/komoot/photon/Updater.java
@@ -1,5 +1,8 @@
 package de.komoot.photon;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * @author felix
  */
@@ -8,7 +11,18 @@ public interface Updater {
 
     public void update(PhotonDoc doc);
 
-    public void delete(Long id);
+    public void delete(String id);
+    
+    /**
+     * Delete matching documents that were generated from a specific OSM object 
+     * 
+     * @param osmType the type of OSM element
+     * @param osmId the OSM id of the element
+     * @param osmKey optional tag key
+     * @param osmValue optional tag value
+     */
+    public void delete(@Nonnull String osmType, long osmId, @Nullable String osmKey, @Nullable String osmValue);
+
 
     public void finish();
 

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,8 +37,13 @@ public class Utils {
                     .endObject();
         }
 
-        if (doc.getHouseNumber() != null) {
-            builder.field("housenumber", doc.getHouseNumber());
+        List<String>houseNumbers = doc.getHouseNumbers();
+        if (doc.getHouseNumbers() != null ) {
+            builder.startArray("housenumber");
+            for (String houseNumber:houseNumbers) {
+                builder.value(houseNumber);
+            }
+            builder.endArray();
         }
 
         if (doc.getPostcode() != null) {

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.node.InternalSettingsPreparer;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
@@ -107,6 +108,7 @@ public class Server {
                 Settings settings = sBuilder.build();
                 Collection<Class<? extends Plugin>> lList = new LinkedList<>();
                 lList.add(Netty4Plugin.class);
+                lList.add(ReindexPlugin.class);
                 esNode = new MyNode(settings, lList);
                 esNode.start();
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Updater.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Updater.java
@@ -6,6 +6,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 
 import java.io.IOException;
 
@@ -26,13 +31,14 @@ public class Updater implements de.komoot.photon.Updater {
         this.languages = languages.split(",");
     }
 
+    @Override
     public void finish() {
         this.updateDocuments();
     }
 
     @Override
     public void updateOrCreate(PhotonDoc updatedDoc) {
-        final boolean exists = this.esClient.get(this.esClient.prepareGet("photon", "place", String.valueOf(updatedDoc.getPlaceId())).request()).actionGet().isExists();
+        final boolean exists = this.esClient.get(this.esClient.prepareGet("photon", "place", updatedDoc.getUid()).request()).actionGet().isExists();
         if (exists) {
             this.update(updatedDoc);
         } else {
@@ -40,24 +46,42 @@ public class Updater implements de.komoot.photon.Updater {
         }
     }
 
+    @Override
     public void create(PhotonDoc doc) {
         try {
-            this.bulkRequest.add(this.esClient.prepareIndex("photon", "place").setSource(Utils.convert(doc, this.languages)).setId(String.valueOf(doc.getPlaceId())));
+            this.bulkRequest.add(this.esClient.prepareIndex("photon", "place").setSource(Utils.convert(doc, this.languages)).setId(doc.getUid()));
         } catch (IOException e) {
             log.error(String.format("creation of new doc [%s] failed", doc), e);
         }
     }
 
+    @Override
     public void update(PhotonDoc doc) {
         try {
-            this.bulkRequest.add(this.esClient.prepareUpdate("photon", "place", String.valueOf(doc.getPlaceId())).setDoc(Utils.convert(doc, this.languages)));
+            this.bulkRequest.add(this.esClient.prepareUpdate("photon", "place", doc.getUid()).setDoc(Utils.convert(doc, this.languages)));
         } catch (IOException e) {
             log.error(String.format("update of new doc [%s] failed", doc), e);
         }
     }
 
-    public void delete(Long id) {
+    @Override
+    public void delete(String id) {
         this.bulkRequest.add(this.esClient.prepareDelete("photon", "place", String.valueOf(id)));
+    }
+    
+    @Override
+    public void delete(String osmType, long osmId, String osmKey, String osmValue) {
+        BoolQueryBuilder query = QueryBuilders.boolQuery().must(QueryBuilders.matchQuery("osm_id", osmId));
+        if (osmKey != null) {
+            query.must(QueryBuilders.matchQuery("osm__key", osmKey));
+            if (osmValue != null) {
+                query.must(QueryBuilders.matchQuery("osm__value", osmValue));
+            }
+        }
+        query.must(QueryBuilders.matchQuery("_source['osm_type']", osmType));
+        BulkByScrollResponse response = new DeleteByQueryRequestBuilder(this.esClient, DeleteByQueryAction.INSTANCE)
+                .filter(query).source("photon").get();
+        log.info(String.format("deleted %d documents based on osm object", response.getDeleted()));
     }
 
     private void updateDocuments() {

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -54,8 +54,9 @@ class NominatimResult {
         List<PhotonDoc> results = new ArrayList<PhotonDoc>(housenumbers.size());
         for (Map.Entry<String, Point> e : housenumbers.entrySet()) {
             PhotonDoc copy = new PhotonDoc(doc);
-            copy.setHouseNumber(e.getKey());
+            copy.setHouseNumbers(Arrays.asList(new String[] {e.getKey()}));
             copy.setCentroid(e.getValue());
+            copy.setExpanded(true);
             results.add(copy);
         }
 
@@ -72,18 +73,20 @@ class NominatimResult {
      * @param str House number string. May be null, in which case nothing is added.
      */
     public void addHousenumbersFromString(String str) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return;
+        }
 
-        if (housenumbers == null)
-            housenumbers = new HashMap<String, Point>();
+        List<String> houseNumbers = new ArrayList<>();
 
-        String[] parts = str.split(";");
+        String[] parts = str.split("[;]");
         for (String part : parts) {
             String h = part.trim();
-            if (!h.isEmpty())
-                housenumbers.put(h, doc.getCentroid());
+            if (!h.isEmpty()) {
+                houseNumbers.add(h);
+            }
         }
+        doc.setHouseNumbers(houseNumbers);
     }
 
     public void addHouseNumbersFromInterpolation(long first, long last, String interpoltype, Geometry geom) {
@@ -142,7 +145,7 @@ public class NominatimConnector {
                     "place",
                     "house_number",
                     Collections.<String, String>emptyMap(), // no name
-                    (String) null,
+                    null,
                     Collections.<String, String>emptyMap(), // no extratags
                     (Envelope) null,
                     rs.getLong("parent_place_id"),
@@ -185,7 +188,7 @@ public class NominatimConnector {
                     rs.getString("class"),
                     rs.getString("type"),
                     DBUtils.getMap(rs, "name"),
-                    (String) null,
+                    null,
                     DBUtils.getMap(rs, "extratags"),
                     envelope,
                     rs.getLong("parent_place_id"),

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -57,13 +57,10 @@ public class NominatimUpdater {
                             template.update("update placex set indexed_status = 0 where place_id = ?;", placeId);
 
                             Integer indexedStatus = place.getIndexdStatus();
-                            if (indexedStatus == DELETE || (indexedStatus == UPDATE && rank == MAX_RANK)) {
-                                updater.delete(placeId);
-                                if (indexedStatus == DELETE) {
-                                    deletedPlaces++;
-                                    continue;
-                                }
-                                indexedStatus = CREATE; // always create
+                            if (indexedStatus == DELETE) {
+                                updater.delete(PhotonDoc.getBaseId(place.getOsmType(), place.getOsmId(), place.getOsmKey()));
+                                deletedPlaces++;
+                                continue;
                             }
                             updatedPlaces++;
 
@@ -88,9 +85,8 @@ public class NominatimUpdater {
                                 }
                             }
                             if (indexedStatus == UPDATE && !wasUseful) {
-                                // only true when rank != 30
                                 // if no documents for the place id exist this will likely cause moaning
-                                updater.delete(placeId);
+                                updater.delete(PhotonDoc.getBaseId(place.getOsmType(), place.getOsmId(), place.getOsmKey()));
                                 updatedPlaces--;
                             }
                         }
@@ -114,7 +110,7 @@ public class NominatimUpdater {
 
                         Integer indexedStatus = place.getIndexdStatus();
                         if (indexedStatus != CREATE) {
-                            updater.delete(placeId);
+                            updater.delete("W", place.getOsmId(), "place", "house_number");
                             if (indexedStatus == DELETE) {
                                 deletedInterpolations++;
                                 continue;
@@ -156,6 +152,10 @@ public class NominatimUpdater {
                         UpdateRow updateRow = new UpdateRow();
                         updateRow.setPlaceId(rs.getLong("place_id"));
                         updateRow.setIndexdStatus(rs.getInt("indexed_status"));
+                        updateRow.setOsmType(rs.getString("osm_type"));
+                        updateRow.setOsmId(rs.getLong("osm_id"));
+                        updateRow.setOsmKey(rs.getString("osm_key"));
+                        updateRow.setOsmValue(rs.getString("osm_value"));
                         return updateRow;
                     }
                 });
@@ -169,6 +169,7 @@ public class NominatimUpdater {
                         UpdateRow updateRow = new UpdateRow();
                         updateRow.setPlaceId(rs.getLong("place_id"));
                         updateRow.setIndexdStatus(rs.getInt("indexed_status"));
+                        updateRow.setOsmId(rs.getLong("osm_id"));
                         return updateRow;
                     }
                 });

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -109,12 +109,11 @@ public class NominatimUpdater {
                         template.update("update location_property_osmline set indexed_status = 0 where place_id = ?;", placeId);
 
                         Integer indexedStatus = place.getIndexdStatus();
-                        if (indexedStatus != CREATE) {
-                            updater.delete("W", place.getOsmId(), "place", "house_number");
-                            if (indexedStatus == DELETE) {
-                                deletedInterpolations++;
-                                continue;
-                            }
+                        // nominatim is rather flaky about setting the update flag so lets always delete
+                        updater.delete("W", place.getOsmId(), "place", "house_number");
+                        if (indexedStatus == DELETE) {
+                            deletedInterpolations++;
+                            continue;
                         }
                         updatedInterpolations++;
 

--- a/src/main/java/de/komoot/photon/nominatim/model/UpdateRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/UpdateRow.java
@@ -10,4 +10,8 @@ public class UpdateRow {
 
     public Long placeId;
     public Integer indexdStatus; // 1 - index, 2 - update, 100 - delete
+    private String osmType;
+    private long osmId;
+    private String osmKey;
+    private String osmValue;
 }


### PR DESCRIPTION
-don't expand multiple housenumbers on the same object
-use a nominatim instance independent document id
-delete documents expanded from interpolations by the osm data

This fixes the remaining update problems outside of https://github.com/openstreetmap/Nominatim/issues/1360 It currently continues to expand address interpolations and in general is rather ugly. As the mapping has changed this requires a re-import.

The alternative is to not expand interpolations, use a distance based scoring to the actual interpolation way and generate individual results from that on the fly. This will require changes to the queries and will have an unknown performance impact.