### PR TITLE
Add respecting Accept-Language header

### DIFF
--- a/src/main/java/de/komoot/photon/query/LanguageChecker.java
+++ b/src/main/java/de/komoot/photon/query/LanguageChecker.java
@@ -19,9 +19,13 @@ public class LanguageChecker implements Function<String, Boolean, BadRequestExce
     @Override
     public Boolean apply(String lang) throws BadRequestException {
         if (lang == null) lang = "en";
-        if (!supportedLanguages.contains(lang)) {
+        if (!isLanguageSupported(lang)) {
             throw new BadRequestException(400, "language " + lang + " is not supported, supported languages are: " + Joiner.on(", ").join(supportedLanguages));
         }
         return true;
+    }
+
+    public boolean isLanguageSupported(String lang) {
+        return this.supportedLanguages.contains(lang);
     }
 }

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -13,14 +13,14 @@ import java.util.Set;
  * Created by Sachin Dole on 2/12/2015.
  */
 public class PhotonRequestFactory {
-    private final LanguageChecker languageChecker;
+    private final RequestLanguageResolver languageResolver;
     private final static LocationParamConverter optionalLocationParamConverter = new LocationParamConverter(false);
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
             "limit", "osm_tag", "location_bias_scale"));
 
     public PhotonRequestFactory(Set<String> supportedLanguages) {
-        this.languageChecker = new LanguageChecker(supportedLanguages);
+        this.languageResolver = new RequestLanguageResolver(new LanguageChecker(supportedLanguages));
     }
 
     public <R extends PhotonRequest> R create(Request webRequest) throws BadRequestException {
@@ -30,10 +30,8 @@ public class PhotonRequestFactory {
             if (!m_hsRequestQueryParams.contains(queryParam))
                 throw new BadRequestException(400, "unknown query parameter '" + queryParam + "'.  Allowed parameters are: " + m_hsRequestQueryParams);
 
+        String language = languageResolver.resolverRequestedLanguage(webRequest);
 
-        String language = webRequest.queryParams("lang");
-        language = language == null ? "en" : language;
-        languageChecker.apply(language);
         String query = webRequest.queryParams("q");
         if (query == null) throw new BadRequestException(400, "missing search term 'q': /?q=berlin");
         Integer limit;
@@ -65,6 +63,7 @@ public class PhotonRequestFactory {
 
         return (R) photonRequest;
     }
+
 
     private void setUpTagFilters(FilteredPhotonRequest request, String[] tagFilters) {
         for (String tagFilter : tagFilters) {

--- a/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
+++ b/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
@@ -1,0 +1,41 @@
+package de.komoot.photon.query;
+
+import lombok.AllArgsConstructor;
+import spark.Request;
+import spark.utils.StringUtils;
+
+import java.util.List;
+import java.util.Locale;
+
+@AllArgsConstructor
+class RequestLanguageResolver {
+    static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    static final String DEFAULT_LANGUAGE = "en";
+
+    private final LanguageChecker languageChecker;
+
+    String resolverRequestedLanguage(Request webRequest) throws BadRequestException {
+        String language = webRequest.queryParams("lang");
+        if (StringUtils.isBlank(language))
+            language = fallbackLanguageFromHeaders(webRequest);
+        if (StringUtils.isBlank(language))
+            language = DEFAULT_LANGUAGE;
+        languageChecker.apply(language);
+        return language;
+    }
+
+    private String fallbackLanguageFromHeaders(Request webRequest) {
+        String acceptLanguageHeader = webRequest.headers(ACCEPT_LANGUAGE_HEADER);
+        if (StringUtils.isBlank(acceptLanguageHeader))
+            return null;
+        try {
+            List<Locale.LanguageRange> languages = Locale.LanguageRange.parse(acceptLanguageHeader);
+            for (Locale.LanguageRange lang : languages)
+                if (languageChecker.isLanguageSupported(lang.getRange()))
+                    return lang.getRange();
+        } catch (Throwable e) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
+++ b/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
@@ -34,7 +34,8 @@ public class SearchRequestHandlerTest {
         String path = ReflectionTestUtil.getFieldValue(searchRequestHandler, RouteImpl.class, "path");
         Assert.assertEquals("any", path);
         PhotonRequestFactory photonRequestFactory = ReflectionTestUtil.getFieldValue(searchRequestHandler, searchRequestHandler.getClass(), "photonRequestFactory");
-        LanguageChecker languageChecker = ReflectionTestUtil.getFieldValue(photonRequestFactory, photonRequestFactory.getClass(), "languageChecker");
+        Object languageResolver = ReflectionTestUtil.getFieldValue(photonRequestFactory, photonRequestFactory.getClass(), "languageResolver");
+        LanguageChecker languageChecker = ReflectionTestUtil.getFieldValue(languageResolver, languageResolver.getClass(), "languageChecker");
         Set<String> supportedLanguages = ReflectionTestUtil.getFieldValue(languageChecker, languageChecker.getClass(), "supportedLanguages");
         Set<String> supportedLanguagesExpected = ImmutableSet.of("en", "fr");
         Assert.assertThat(supportedLanguages, IsEqual.equalTo(supportedLanguagesExpected));

--- a/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
@@ -1,0 +1,95 @@
+package de.komoot.photon.query;
+
+import org.junit.Before;
+import org.junit.Test;
+import spark.Request;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.komoot.photon.query.RequestLanguageResolver.ACCEPT_LANGUAGE_HEADER;
+import static de.komoot.photon.query.RequestLanguageResolver.DEFAULT_LANGUAGE;
+import static java.util.Arrays.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class RequestLanguageTest {
+    // maybe could access directly from RequestLanguageResolver, but in case of change... whatever.
+    private final List<String> supportedLangs = asList("en", "fr", "de");
+    private RequestLanguageResolver languageResolver;
+
+    @Before
+    public void setup() {
+        Set<String> supportedLanguages = new HashSet<>(supportedLangs);
+        languageResolver = new RequestLanguageResolver(new LanguageChecker(supportedLanguages));
+    }
+
+    @Test
+    public void testDefaultLanguageFallback() {
+        validateReturnedLanguage(null, null, DEFAULT_LANGUAGE);
+    }
+
+    @Test
+    public void testValidQueryLangs() {
+        supportedLangs.forEach(l -> validateReturnedLanguage(l, null, l));
+    }
+
+    @Test
+    public void testLanguageNotSupported() {
+        asList("ru", "pl", "xyaasdas").forEach(l -> validateNotSupported(l, null));
+    }
+
+    @Test
+    public void testPriorityOfQueryParam() {
+        validateReturnedLanguage("de", "en", "de");
+        validateNotSupported("ko", "en");
+    }
+
+    @Test
+    public void testFallbackOnQueryNotSetBasicHeader() {
+        supportedLangs.forEach(l -> validateReturnedLanguage(null, l, l));
+    }
+
+    @Test
+    public void testFallbackMatchingHeaderLang() {
+        validateReturnedLanguage(null, "ru,pl;q=0.9,sp,fr;q=0.1", "fr");
+        validateReturnedLanguage(null, "ru,pl;q=0.7,sp,de", "de");
+        validateReturnedLanguage(null, "ru,pl;q=0.9,sp", DEFAULT_LANGUAGE);
+    }
+
+    @Test
+    public void validateIgnoreInvalidAcceptLangHeader() {
+        validateReturnedLanguage(null, "we loves cats", DEFAULT_LANGUAGE);
+        validateReturnedLanguage(null, "cookies?", DEFAULT_LANGUAGE);
+        validateReturnedLanguage(null, "Illegal/Header_", DEFAULT_LANGUAGE);
+    }
+
+
+    private Request buildRequest(String queryLang, String acceptLangHeader) {
+        Request request = mock(Request.class);
+        when(request.queryParams("lang")).thenReturn(queryLang);
+        when(request.headers(ACCEPT_LANGUAGE_HEADER)).thenReturn(acceptLangHeader);
+        return request;
+    }
+
+    private void validateReturnedLanguage(String queryLang, String acceptHeader, String expected) {
+        Request req = buildRequest(queryLang, acceptHeader);
+        try {
+            String actual = languageResolver.resolverRequestedLanguage(req);
+            assertEquals(expected, actual);
+        } catch (BadRequestException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void validateNotSupported(String queryLang, String acceptHeader) {
+        Request req = buildRequest(queryLang, acceptHeader);
+        try {
+            languageResolver.resolverRequestedLanguage(req);
+            fail("Language " + queryLang + " is not supported");
+        } catch (BadRequestException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
Will be applied as a fallback in case of missing `lang` query param, only if supported languages intersects languages in the header with header priority spec maintained.