### PR TITLE
Add command line option to fetch updates and exit afterwards

### DIFF
--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -20,6 +20,9 @@ public class CommandLineArgs {
     @Parameter(names = "-nominatim-import", description = "import nominatim database into photon (this will delete previous index)")
     private boolean nominatimImport = false;
 
+    @Parameter(names = "-nominatim-update", description = "fetch updates from nominatim database into photon and exit (this updates the index only without offering an API")
+    private boolean nominatimUpdate = false;
+
     @Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default is 'en,fr,de,it')")
     private String languages = "en,fr,de,it";
 


### PR DESCRIPTION
When doing Photon upgrades on a (master) host not serving requests but getting its database rsynced to remote hosts, it is pretty annoying that it is only visible in the logfile when an update is completed. Therefore, I propose to add a new option `-nominatim-update` which makes Photon start, apply updates from Nominatim and then exit.