### PR TITLE
Added addr:housename to index

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -381,6 +381,19 @@
 						"copy_to": [
 							"collector.default"
 						]
+					},
+					"housename": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw"
+							}
+						},
+						"copy_to": [
+							"collector.default"
+						]
 					}
 				}
 			},

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -155,9 +155,6 @@ public class Utils {
         if (names.get("name") != null) {
             filteredNames.put("default", names.get("name"));
         }
-        else if (names.get("addr:housename") != null) {
-            filteredNames.put("default", names.get("addr:housename"));
-        }
 
         for (String language : languages) {
             if (names.get("name:" + language) != null) {

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -97,6 +97,9 @@ public class Utils {
         if (name.get("reg_name") != null)
             fNames.put("reg", name.get("reg_name"));
 
+        if (name.get("addr:housename") != null)
+            fNames.put("housename", name.get("addr:housename"));
+
         write(builder, fNames, "name");
     }
 
@@ -151,6 +154,9 @@ public class Utils {
 
         if (names.get("name") != null) {
             filteredNames.put("default", names.get("name"));
+        }
+        else if (names.get("addr:housename") != null) {
+            filteredNames.put("default", names.get("addr:housename"));
         }
 
         for (String language : languages) {

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -20,6 +20,7 @@ import java.util.Map;
 public class ConvertToJson {
     private final static String[] KEYS_LANG_UNSPEC = {Constants.OSM_ID, Constants.OSM_VALUE, Constants.OSM_KEY, Constants.POSTCODE, Constants.HOUSENUMBER, Constants.COUNTRYCODE, Constants.OSM_TYPE};
     private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.STREET, Constants.STATE};
+    private final static String[] NAME_PRECEDENCE = {"housename", "int", "loc", "reg", "alt", "old"};
     private final String lang;
 
     public ConvertToJson(String lang) {
@@ -76,9 +77,13 @@ public class ConvertToJson {
             return map.get(lang);
         }
 
-        if (!map.containsKey("default")) {
-            return map.get(map.keySet().toArray()[0]); // Returning first value in the map
+        if (fieldName.equals("name")) {
+            for (String key : NAME_PRECEDENCE) {
+                if (map.containsKey(key))
+                    return map.get(key);
+            }
         }
+
         return map.get("default");
     }
 

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class ConvertToJson {
     private final static String[] KEYS_LANG_UNSPEC = {Constants.OSM_ID, Constants.OSM_VALUE, Constants.OSM_KEY, Constants.POSTCODE, Constants.HOUSENUMBER, Constants.COUNTRYCODE, Constants.OSM_TYPE};
     private final static String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.STREET, Constants.STATE};
-    private final static String[] NAME_PRECEDENCE = {"housename", "int", "loc", "reg", "alt", "old"};
+    private final static String[] NAME_PRECEDENCE = {"default", "housename", "int", "loc", "reg", "alt", "old"};
     private final String lang;
 
     public ConvertToJson(String lang) {

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -76,6 +76,9 @@ public class ConvertToJson {
             return map.get(lang);
         }
 
+        if (!map.containsKey("default")) {
+            return map.get(map.keySet().toArray()[0]); // Returning first value in the map
+        }
         return map.get("default");
     }
 


### PR DESCRIPTION
For issue #448:

1. Added housename mapping to mappings.json.
2. Modified `writeName` function to include housename in `fNames`.
3. Modified `filterNames` function to set `names.get("housename")` as default if `names` is not null and `names.get("name")` is null.

**Reason for including point 3 above:**
Current implementation: In filterNames function, if the `names` map is not `null`, then names.get("name") is set as the default name. This fails if the map does not contain the `name` key.

Examples:
```
Name: [{name:es=La Adelita}]
fNames: [{}]
```
```
Name: [{operator=Gasopas}]
fNames: [{}]
```
```
Name: [{addr:housename=Caradon}]
fNames: [{housename=Caradon}]
```
I noticed that many of the places with `addr:housename` do not have `name` key. There should either be a hierarchy to select the `"default"` or the point 3 above could be opted.


