### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>2.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>postgis</groupId>
             <artifactId>postgis-jdbc-jts</artifactId>
             <version>1.1.5</version>
@@ -143,11 +138,6 @@
             <version>29.0-jre</version>
         </dependency>
         <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
@@ -157,13 +147,6 @@
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.2</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.32</version>
+            <version>1.78</version>
         </dependency>
         <dependency>
             <groupId>org.openstreetmap.osmosis</groupId>
@@ -68,17 +68,18 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>3.10</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>
-            <version>1.4.0</version>
+            <version>1.9.13</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.neovisionaries</groupId>
             <artifactId>nv-i18n</artifactId>
-            <version>1.4</version>
+            <version>1.27</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -119,14 +120,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.24.0</version>
+            <version>2.25.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -149,12 +150,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20140107</version>
+            <version>20190722</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -315,7 +316,7 @@
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 
         <elasticsearch.version>5.5.0</elasticsearch.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.8.2</log4j.version>
 
         <additionalparam>-Xdoclint:none</additionalparam>

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -184,14 +185,15 @@ public class Server {
                 .getResourceAsStream("mappings.json");
         final InputStream index_settings = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("index_settings.json");
+        final Charset utf8_charset = Charset.forName("utf-8");
 
-        String mappingsString = IOUtils.toString(mappings);
+        String mappingsString = IOUtils.toString(mappings, utf8_charset);
         JSONObject mappingsJSON = new JSONObject(mappingsString);
 
         // add all langs to the mapping
         mappingsJSON = addLangsToMapping(mappingsJSON);
 
-        JSONObject settings = new JSONObject(IOUtils.toString(index_settings));
+        JSONObject settings = new JSONObject(IOUtils.toString(index_settings, utf8_charset));
         if (shards != null) {
             settings.put("index", new JSONObject("{ \"number_of_shards\":" + shards + " }"));
         }

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim.model;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import lombok.Data;
 
 import java.util.Arrays;
@@ -92,7 +92,7 @@ public class AddressRow {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("placeId", placeId)
                 .add("name", name)
                 .add("osmKey", osmKey)

--- a/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderTest.java
+++ b/src/test/java/de/komoot/photon/query/TagFilterQueryBuilderTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 public class TagFilterQueryBuilderTest {
 
@@ -21,7 +22,7 @@ public class TagFilterQueryBuilderTest {
         TagFilterQueryBuilder photonQueryBuilder = PhotonQueryBuilder.builder("berlin", "en");
         InputStream resourceAsStream = this.getClass().getClassLoader()
                 .getResourceAsStream("json_queries/test_base_query.json");
-        String expectedJsonString = IOUtils.toString(resourceAsStream);
+        String expectedJsonString = IOUtils.toString(resourceAsStream, Charset.forName("utf-8"));
 
         String actualJsonString = new QueryToJson().convert(photonQueryBuilder.buildQuery());
         JsonNode actualJson = this.readJson(actualJsonString);
@@ -34,7 +35,7 @@ public class TagFilterQueryBuilderTest {
         TagFilterQueryBuilder photonQueryBuilder = PhotonQueryBuilder.builder("berlin", "fr");
         InputStream resourceAsStream = this.getClass().getClassLoader()
                 .getResourceAsStream("json_queries/test_base_query_fr.json");
-        String expectedJsonString = IOUtils.toString(resourceAsStream);
+        String expectedJsonString = IOUtils.toString(resourceAsStream, Charset.forName("utf-8"));
 
         String actualJsonString = new QueryToJson().convert(photonQueryBuilder.buildQuery());
         JsonNode actualJson = this.readJson(actualJsonString);


### PR DESCRIPTION
This moves the unproblematic dependencies to their latest version. Required a couple of minor code changes but nothing important. I have removed beanutils, zip4j and findbugs as they seem to be unused as far as I can see. Please yell if that was wrong.

I haven't touched elasticsearch and log4j or any of the JDBC stuff. They deserve a separate PR. 