### PR TITLE
Update database dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
             <version>4.4.0</version>
         </dependency>
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.1-901-1.jdbc4</version>
+            <version>42.2.12</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -59,11 +59,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <version>1.78</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openstreetmap.osmosis</groupId>
-            <artifactId>osmosis-hstore-jdbc</artifactId>
-            <version>0.43.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,14 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
-            <groupId>postgis</groupId>
-            <artifactId>postgis-jdbc-jts</artifactId>
-            <version>1.1.5</version>
+            <groupId>net.postgis</groupId>
+            <artifactId>postgis-jdbc</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.postgis</groupId>
+            <artifactId>postgis-jdbc-jtsparser</artifactId>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,24 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
             <version>${elasticsearch.version}</version>
+
         </dependency>
         <dependency><!-- required by elasticsearch -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
+
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
             <version>${elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency><!-- required by elasticsearch to avoid warning on startup,
             see https://github.com/elastic/elasticsearch/issues/13245 -->
@@ -85,12 +93,18 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>4.0.0.RELEASE</version>
+            <version>5.2.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
             <version>2.7.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
             <version>4.0.0.RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>1.4</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>

--- a/src/main/java/de/komoot/photon/nominatim/DBUtils.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBUtils.java
@@ -2,7 +2,6 @@ package de.komoot.photon.nominatim;
 
 import com.google.common.collect.Maps;
 import com.vividsolutions.jts.geom.Geometry;
-import org.openstreetmap.osmosis.hstore.PGHStore;
 import org.postgis.jts.JtsGeometry;
 
 import javax.annotation.Nullable;
@@ -17,16 +16,12 @@ import java.util.Map;
  */
 public class DBUtils {
     public static Map<String, String> getMap(ResultSet rs, String columnName) throws SQLException {
-        Map<String, String> tags = Maps.newHashMap();
-
-        PGHStore dbTags = (PGHStore) rs.getObject(columnName);
-        if (dbTags != null) {
-            for (Map.Entry<String, String> tagEntry : dbTags.entrySet()) {
-                tags.put(tagEntry.getKey(), tagEntry.getValue());
-            }
+        Map<String, String> map = (Map<String, String>) rs.getObject(columnName);
+        if (map == null) {
+            return Maps.newHashMap();
         }
 
-        return tags;
+        return map;
     }
 
     @Nullable

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -11,7 +11,7 @@ import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressRow;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.postgis.jts.JtsWrapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowCallbackHandler;

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -3,7 +3,7 @@ package de.komoot.photon.nominatim;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.Updater;
 import de.komoot.photon.nominatim.model.UpdateRow;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.postgis.jts.JtsWrapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;


### PR DESCRIPTION
This updates the postgresql and postgis packages as well as commons-dbcp and spring-jdbc. Hstore is now natively supported, so we can drop the special osmosis hstore package.