### PR TITLE
Add reusable method for constructing datasource

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -233,6 +233,13 @@ public class NominatimConnector {
      * @param password db username's password
      */
     public NominatimConnector(String host, int port, String database, String username, String password) {
+        BasicDataSource dataSource = buildDataSource(host, port, database, username, password);
+
+        template = new JdbcTemplate(dataSource);
+        template.setFetchSize(100000);
+    }
+
+    static BasicDataSource buildDataSource(String host, int port, String database, String username, String password) {
         BasicDataSource dataSource = new BasicDataSource();
 
         dataSource.setUrl(String.format("jdbc:postgres_jts://%s:%d/%s", host, port, database));
@@ -240,9 +247,7 @@ public class NominatimConnector {
         dataSource.setPassword(password);
         dataSource.setDriverClassName(JtsWrapper.class.getCanonicalName());
         dataSource.setDefaultAutoCommit(false);
-
-        template = new JdbcTemplate(dataSource);
-        template.setFetchSize(100000);
+        return dataSource;
     }
 
     public void setImporter(Importer importer) {

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -184,13 +184,7 @@ public class NominatimUpdater {
      * @param password Nominatim database password
      */
     public NominatimUpdater(String host, int port, String database, String username, String password) {
-        BasicDataSource dataSource = new BasicDataSource();
-
-        dataSource.setUrl(String.format("jdbc:postgresql://%s:%d/%s", host, port, database));
-        dataSource.setUsername(username);
-        dataSource.setPassword(password);
-        dataSource.setDriverClassName(JtsWrapper.class.getCanonicalName());
-        dataSource.setDefaultAutoCommit(true);
+        BasicDataSource dataSource = NominatimConnector.buildDataSource(host, port, database, username, password);
 
         exporter = new NominatimConnector(host, port, database, username, password);
         template = new JdbcTemplate(dataSource);


### PR DESCRIPTION
This fixes #465 and makes sure that the two classes use the same way to build a datasource.