### PR TITLE
Make default language configurable

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -173,10 +173,10 @@ public class App {
         }
 
         // setup search API
-        get("api", new SearchRequestHandler("api", esNodeClient, args.getLanguages()));
-        get("api/", new SearchRequestHandler("api/", esNodeClient, args.getLanguages()));
-        get("reverse", new ReverseSearchRequestHandler("reverse", esNodeClient, args.getLanguages()));
-        get("reverse/", new ReverseSearchRequestHandler("reverse/", esNodeClient, args.getLanguages()));
+        get("api", new SearchRequestHandler("api", esNodeClient, args.getLanguages(), args.getDefaultLanguage()));
+        get("api/", new SearchRequestHandler("api/", esNodeClient, args.getLanguages(), args.getDefaultLanguage()));
+        get("reverse", new ReverseSearchRequestHandler("reverse", esNodeClient, args.getLanguages(), args.getDefaultLanguage()));
+        get("reverse/", new ReverseSearchRequestHandler("reverse/", esNodeClient, args.getLanguages(), args.getDefaultLanguage()));
 
         // setup update API
         final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, esNodeClient);

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -26,6 +26,9 @@ public class CommandLineArgs {
     @Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default is 'en,fr,de,it')")
     private String languages = "en,fr,de,it";
 
+    @Parameter(names = "-default-language", description = "language to return results in when no explicit language is choosen by the user")
+    private String defaultLanguage = "default";
+
     @Parameter(names = "-country-codes", description = "country codes filter that nominatim importer should import, comma separated. If empty full planet is done")
     private String countryCodes = "";
 

--- a/src/main/java/de/komoot/photon/ReverseSearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/ReverseSearchRequestHandler.java
@@ -26,10 +26,10 @@ public class ReverseSearchRequestHandler<R extends ReverseRequest> extends Route
     private final ReverseRequestHandlerFactory requestHandlerFactory;
     private final ConvertToGeoJson geoJsonConverter;
 
-    ReverseSearchRequestHandler(String path, Client esNodeClient, String languages) {
+    ReverseSearchRequestHandler(String path, Client esNodeClient, String languages, String defaultLanguage) {
         super(path);
         List<String> supportedLanguages = Arrays.asList(languages.split(","));
-        this.reverseRequestFactory = new ReverseRequestFactory(supportedLanguages);
+        this.reverseRequestFactory = new ReverseRequestFactory(supportedLanguages, defaultLanguage);
         this.geoJsonConverter = new ConvertToGeoJson();
         this.requestHandlerFactory = new ReverseRequestHandlerFactory(new ReverseElasticsearchSearcher(esNodeClient));
     }

--- a/src/main/java/de/komoot/photon/SearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/SearchRequestHandler.java
@@ -28,10 +28,10 @@ public class SearchRequestHandler<R extends PhotonRequest> extends RouteImpl {
     private final PhotonRequestHandlerFactory requestHandlerFactory;
     private final ConvertToGeoJson geoJsonConverter;
 
-    SearchRequestHandler(String path, Client esNodeClient, String languages) {
+    SearchRequestHandler(String path, Client esNodeClient, String languages, String defaultLanguage) {
         super(path);
         List<String> supportedLanguages = Arrays.asList(languages.split(","));
-        this.photonRequestFactory = new PhotonRequestFactory(supportedLanguages);
+        this.photonRequestFactory = new PhotonRequestFactory(supportedLanguages, defaultLanguage);
         this.geoJsonConverter = new ConvertToGeoJson();
         this.requestHandlerFactory = new PhotonRequestHandlerFactory(new BaseElasticsearchSearcher(esNodeClient));
     }

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -21,8 +21,9 @@ public class PhotonRequestFactory {
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
             "limit", "osm_tag", "location_bias_scale", "bbox", "debug"));
-    public PhotonRequestFactory(List<String> supportedLanguages) {
-        this.languageResolver = new RequestLanguageResolver(supportedLanguages);
+
+    public PhotonRequestFactory(List<String> supportedLanguages, String defaultLanguage) {
+        this.languageResolver = new RequestLanguageResolver(supportedLanguages, defaultLanguage);
         this.bboxParamConverter = new BoundingBoxParamConverter();
     }
 

--- a/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
+++ b/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
@@ -14,9 +14,9 @@ import java.util.Locale;
 @AllArgsConstructor
 public class RequestLanguageResolver {
     static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
-    static final String DEFAULT_LANGUAGE = "en";
 
     private final List<String> supportedLanguages;
+    private final String defaultLanguage;
 
     /**
      * Get the language to use for the response to the given request.
@@ -34,7 +34,7 @@ public class RequestLanguageResolver {
         if (StringUtils.isBlank(language)) {
             language = fallbackLanguageFromHeaders(webRequest);
             if (StringUtils.isBlank(language))
-                language = DEFAULT_LANGUAGE;
+                language = defaultLanguage;
         } else {
             checkLanguageSupported(language);
         }
@@ -69,8 +69,8 @@ public class RequestLanguageResolver {
      * @throws BadRequestException The language is not in the list of supported languages.
      */
     private void checkLanguageSupported(String lang) throws BadRequestException {
-        if (!supportedLanguages.contains((lang))) {
-            throw new BadRequestException(400, "language " + lang + " is not supported, supported languages are: " + Joiner.on(", ").join(supportedLanguages));
+        if (!("default".equals(lang) || supportedLanguages.contains((lang)))) {
+            throw new BadRequestException(400, "language " + lang + " is not supported, supported languages are: default, " + Joiner.on(", ").join(supportedLanguages));
         }
     }
 }

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -16,8 +16,8 @@ public class ReverseRequestFactory {
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "lon", "lat", "radius", "query_string_filter", "distance_sort", "limit"));
 
-    public ReverseRequestFactory(List<String> supportedLanguages) {
-        this.languageResolver = new RequestLanguageResolver(supportedLanguages);
+    public ReverseRequestFactory(List<String> supportedLanguages, String defaultLanguage) {
+        this.languageResolver = new RequestLanguageResolver(supportedLanguages, defaultLanguage);
     }
 
     public <R extends ReverseRequest> R create(Request webRequest) throws BadRequestException {

--- a/src/test/java/de/komoot/photon/ReverseSearchRequestHandlerTest.java
+++ b/src/test/java/de/komoot/photon/ReverseSearchRequestHandlerTest.java
@@ -36,7 +36,7 @@ public class ReverseSearchRequestHandlerTest {
     @Test
     public void testConstructor() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         Client client = Mockito.mock(Client.class);
-        ReverseSearchRequestHandler reverseSearchRequestHandler = new ReverseSearchRequestHandler("any", client, "en,fr");
+        ReverseSearchRequestHandler reverseSearchRequestHandler = new ReverseSearchRequestHandler("any", client, "en,fr", "en");
         String path = ReflectionTestUtil.getFieldValue(reverseSearchRequestHandler, RouteImpl.class, "path");
         Assert.assertEquals("any", path);
         ReverseRequestFactory reverseRequestFactory = ReflectionTestUtil.getFieldValue(reverseSearchRequestHandler, reverseSearchRequestHandler.getClass(), "reverseRequestFactory");
@@ -49,7 +49,7 @@ public class ReverseSearchRequestHandlerTest {
     @Test
     public void testHandle() throws BadRequestException {
         Client client = Mockito.mock(Client.class);
-        ReverseSearchRequestHandler reverseSearchRequestHandlerUnderTest = new ReverseSearchRequestHandler("any", client, "en,fr");
+        ReverseSearchRequestHandler reverseSearchRequestHandlerUnderTest = new ReverseSearchRequestHandler("any", client, "en,fr", "en");
         ReverseRequestFactory mockReverseRequestFactory = Mockito.mock(ReverseRequestFactory.class);
         Request mockWebRequest = Mockito.mock(Request.class);
         ReflectionTestUtil.setFieldValue(reverseSearchRequestHandlerUnderTest, ReverseSearchRequestHandler.class, "reverseRequestFactory", mockReverseRequestFactory);

--- a/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
+++ b/src/test/java/de/komoot/photon/SearchRequestHandlerTest.java
@@ -24,7 +24,7 @@ public class SearchRequestHandlerTest {
     @Test
     public void testConstructor() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         Client client = Mockito.mock(Client.class);
-        SearchRequestHandler searchRequestHandler = new SearchRequestHandler("any", client, "en,fr");
+        SearchRequestHandler searchRequestHandler = new SearchRequestHandler("any", client, "en,fr", "en");
         String path = ReflectionTestUtil.getFieldValue(searchRequestHandler, RouteImpl.class, "path");
         Assert.assertEquals("any", path);
         PhotonRequestFactory photonRequestFactory = ReflectionTestUtil.getFieldValue(searchRequestHandler, searchRequestHandler.getClass(), "photonRequestFactory");
@@ -37,7 +37,7 @@ public class SearchRequestHandlerTest {
     @Test
     public void testHandle() throws BadRequestException {
         Client client = Mockito.mock(Client.class);
-        SearchRequestHandler searchRequestHandlerUnderTest = new SearchRequestHandler("any", client, "en,fr");
+        SearchRequestHandler searchRequestHandlerUnderTest = new SearchRequestHandler("any", client, "en,fr", "en");
         PhotonRequestFactory mockPhotonRequestFactory = Mockito.mock(PhotonRequestFactory.class);
         Request mockWebRequest = Mockito.mock(Request.class);
         ReflectionTestUtil.setFieldValue(searchRequestHandlerUnderTest, SearchRequestHandler.class, "photonRequestFactory", mockPhotonRequestFactory);

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -27,7 +27,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("limit")).thenReturn("5");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         photonRequest = photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", photonRequest.getQuery());
         Assert.assertEquals(-87, photonRequest.getLocationForBias().getX(), 0);
@@ -44,7 +44,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
         Mockito.when(mockRequest.queryParams("lon")).thenReturn(null);
         Mockito.when(mockRequest.queryParams("lat")).thenReturn(null);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
@@ -65,7 +65,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
             Assert.fail();
         } catch (BadRequestException e) {
@@ -82,7 +82,7 @@ public class PhotonRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
         Mockito.when(mockRequest.queryParams("limit")).thenReturn(null);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
@@ -97,7 +97,7 @@ public class PhotonRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         Mockito.when(mockRequest.queryParams("q")).thenReturn(null);
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
             Assert.fail();
         } catch (BadRequestException e) {
@@ -113,7 +113,7 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"aTag"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         FilteredPhotonRequest filteredPhotonRequest = (FilteredPhotonRequest) photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
@@ -130,7 +130,7 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"aTag:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         FilteredPhotonRequest filteredPhotonRequest = (FilteredPhotonRequest) photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
@@ -147,7 +147,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{":aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         FilteredPhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
@@ -163,7 +163,7 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!aTag"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         FilteredPhotonRequest filteredPhotonRequest = (FilteredPhotonRequest) photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
@@ -180,7 +180,7 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!aTag:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         FilteredPhotonRequest filteredPhotonRequest = (FilteredPhotonRequest) photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
@@ -196,7 +196,7 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         FilteredPhotonRequest filteredPhotonRequest = (FilteredPhotonRequest) photonRequestFactory.create(mockRequest);
         Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
@@ -214,7 +214,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn("9.6,52.3,9.8,52.4");
         
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         PhotonRequest photonRequest = photonRequestFactory.create(mockRequest); 
         
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("bbox");
@@ -230,7 +230,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn("9.6,52.3,9.8");
 
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequestFactory.create(mockRequest);
             Assert.fail();
         } catch (BadRequestException e) {
@@ -268,7 +268,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn(minLon + "," + minLat + "," + maxLon + "," + maxLat);
 
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"));
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequestFactory.create(mockRequest);
             Assert.fail();
         } catch (BadRequestException e) {

--- a/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
@@ -30,8 +30,10 @@ public class RequestLanguageTest {
     }
 
     @Test
-    public void testValidQueryLangs() {
+    public void testValidQueryLangs()
+    {
         supportedLangs.forEach(l -> validateReturnedLanguage(l, null, l));
+        validateReturnedLanguage("default", null, "default");
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
@@ -7,7 +7,6 @@ import spark.Request;
 import java.util.List;
 
 import static de.komoot.photon.query.RequestLanguageResolver.ACCEPT_LANGUAGE_HEADER;
-import static de.komoot.photon.query.RequestLanguageResolver.DEFAULT_LANGUAGE;
 import static java.util.Arrays.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -18,9 +17,11 @@ public class RequestLanguageTest {
     private final List<String> supportedLangs = asList("en", "fr", "de");
     private RequestLanguageResolver languageResolver;
 
+    private static final String DEFAULT_LANGUAGE = "en";
+
     @Before
     public void setup() {
-        languageResolver = new RequestLanguageResolver(supportedLangs);
+        languageResolver = new RequestLanguageResolver(supportedLangs, DEFAULT_LANGUAGE);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -28,7 +28,7 @@ public class ReverseRequestFactoryTest {
     public void testWithLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"));
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(-87, reverseRequest.getLocation().getX(), 0);
         Assert.assertEquals(41, reverseRequest.getLocation().getY(), 0);
@@ -38,7 +38,7 @@ public class ReverseRequestFactoryTest {
 
     public void assertBadRequest(Request mockRequest, String expectedMessage) {
         try {
-            ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"));
+            ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
             reverseRequest = reverseRequestFactory.create(mockRequest);
             Assert.fail();
         } catch (BadRequestException e) {
@@ -131,7 +131,7 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
         Mockito.when(mockRequest.queryParams("radius")).thenReturn("5.1");
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"));
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(reverseRequest.getRadius(), 5.1d, 0);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("radius");
@@ -157,7 +157,7 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
         Mockito.when(mockRequest.queryParams("limit")).thenReturn("51");
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"));
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Assert.assertEquals(reverseRequest.getLimit().longValue(), 50);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("limit");
@@ -167,7 +167,7 @@ public class ReverseRequestFactoryTest {
     public void testDistanceSortDefault() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"));
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("distance_sort", "true");
         Assert.assertEquals(true, reverseRequest.getLocationDistanceSort());


### PR DESCRIPTION
Adds a new command line parameter for choosing the default language returned for queries. If not set the results will returned in the locale form (aka the contents of the 'name' tag without language).

As a result of these changes it is now also possible to explicitly ask for locale results with 'lang=default'. I'm not particularly attached to using 'default' here. It just happens to be what we call it in the mapping configuration already.

**Warning:** This PR changes the behaviour of existing installations in that the default is to return the default name tag. You can easily switch back to the old behaviour by setting `-default-language en` on the command line.

Fixes #441.