### PR TITLE
Move from Travis to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: "Continuous Integration"
 on:
   push:
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: "Continuous Integration"
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    name: Compile project and run tests (Java ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - 8
+          - 11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Fetch cached Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: maven-deps
+
+      - name: Compile project, run tests
+        run: |
+          mvn --no-transfer-progress test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-
-jdk:
-  - openjdk8
-  - openjdk11
-


### PR DESCRIPTION
This PR adds a skeletal nominatim integration test that uses a docker image (https://github.com/stadtnavi/nominatim-docker/tree/master/latest) which import Monaco, connects to it and imports a single document.

There is _a lot_ of room for improvement, but I would like to submit this to review to figure out if it's going into the right direction.

Test output is here: https://github.com/mfdz/photon/runs/758004572

Note: I took the liberty to remove `travis.yml`. I hope this is ok.

Open question: is Java 8 still supported and should the test run with it as well as Java 11?