### PR TITLE
Add 'type' field to geocodejson output

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -412,6 +412,10 @@
 				"type": "keyword",
 				"index": true
 			},
+			"object_type": {
+				"type": "text",
+				"index": false
+			},
 			"postcode": {
 				"type": "text",
 				"index": false,

--- a/src/main/java/de/komoot/photon/Constants.java
+++ b/src/main/java/de/komoot/photon/Constants.java
@@ -29,4 +29,5 @@ public class Constants {
     public static final String OSM_TYPE = "osm_type";
     public static final String OSM_KEY = "osm_key";
     public static final String OSM_VALUE = "osm_value";
+    public static final String OBJECT_TYPE = "object_type";
 }

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -33,7 +33,7 @@ public class PhotonDoc {
     final private double importance;
     final private CountryCode countryCode;
     final private long linkedPlaceId; // 0 if unset
-    final private int rankSearch;
+    final private int rankAddress;
 
     private Map<String, String> street;
     private Map<String, String> locality;
@@ -46,7 +46,7 @@ public class PhotonDoc {
     private String houseNumber;
     private Point centroid;
 
-    public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> address, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankSearch) {
+    public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> address, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankAddress) {
         String place = extratags != null ? extratags.get("place") : null;
         if (place != null) {
             // take more specific extra tag information
@@ -69,7 +69,7 @@ public class PhotonDoc {
         this.countryCode = countryCode;
         this.centroid = centroid;
         this.linkedPlaceId = linkedPlaceId;
-        this.rankSearch = rankSearch;
+        this.rankAddress = rankAddress;
     }
 
     public PhotonDoc(PhotonDoc other) {
@@ -89,7 +89,7 @@ public class PhotonDoc {
         this.countryCode = other.countryCode;
         this.centroid = other.centroid;
         this.linkedPlaceId = other.linkedPlaceId;
-        this.rankSearch = other.rankSearch;
+        this.rankAddress = other.rankAddress;
         this.street = other.street;
         this.locality = other.locality;
         this.district = other.district;
@@ -113,6 +113,21 @@ public class PhotonDoc {
     public static PhotonDoc create(long placeId, String osmType, long osmId, Map<String, String> nameMap) {
         return new PhotonDoc(placeId, osmType, osmId, "", "", nameMap,
                 "", null, null, null, 0, 0, null, null, 0, 0);
+    }
+
+    /**
+     * Return the GeocodeJSON place type.
+     *
+     * @return A string representation of the type
+     */
+    public final String getObjectType() {
+        if (rankAddress >= 28) return "house";
+        if (rankAddress >= 26) return "street";
+        if (rankAddress >= 13 && rankAddress <= 16) return "city";
+        if (rankAddress >= 5 && rankAddress <= 12) return "region";
+        if (rankAddress == 4) return "country";
+
+        return "locality";
     }
 
     public boolean isUsefulForIndex() {

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -28,6 +28,7 @@ public class Utils {
                 .field(Constants.OSM_TYPE, doc.getOsmType())
                 .field(Constants.OSM_KEY, doc.getTagKey())
                 .field(Constants.OSM_VALUE, doc.getTagValue())
+                .field(Constants.OBJECT_TYPE, doc.getObjectType())
                 .field(Constants.IMPORTANCE, doc.getImportance());
 
         if (doc.getCentroid() != null) {

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -195,7 +195,7 @@ public class NominatimConnector {
                     CountryCode.getByCode(rs.getString("country_code")),
                     (Point) DBUtils.extractGeometry(rs, "centroid"),
                     rs.getLong("linked_place_id"),
-                    rs.getInt("rank_search")
+                    rs.getInt("rank_address")
             );
 
             doc.setPostcode(rs.getString("postcode"));
@@ -207,7 +207,7 @@ public class NominatimConnector {
             return result;
         }
     };
-    private final String selectColsPlaceX = "place_id, osm_type, osm_id, class, type, name, housenumber, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_search, importance, country_code, centroid";
+    private final String selectColsPlaceX = "place_id, osm_type, osm_id, class, type, name, housenumber, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_address, rank_search, importance, country_code, centroid";
     private final String selectColsOsmline = "place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
     private final String selectColsAddress = "p.place_id, p.name, p.class, p.type, p.rank_address";
     private Importer importer;
@@ -282,7 +282,7 @@ public class NominatimConnector {
             }
         };
 
-        boolean isPoi = doc.getRankSearch() > 28;
+        boolean isPoi = doc.getRankAddress() > 28;
         long placeId = (isPoi) ? doc.getParentPlaceId() : doc.getPlaceId();
 
         List<AddressRow> terms = template.query("SELECT " + selectColsAddress + " FROM placex p, place_addressline pa WHERE p.place_id = pa.address_place_id and pa.place_id = ? and pa.cached_rank_address > 4 and pa.address_place_id != ? and pa.isaddress order by rank_address desc,fromarea desc,distance asc,rank_search desc", new Object[]{placeId, placeId}, rowMapper);

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -52,6 +52,9 @@ public class ConvertToJson {
                     properties.put(key, getLocalised(source, key, lang));
             }
 
+            // place type
+            properties.put("type", source.get(Constants.OBJECT_TYPE));
+
             // add extent of geometry
             final Map<String, Object> extent = (Map<String, Object>) source.get("extent");
             if (extent != null) {


### PR DESCRIPTION
The type field is computed from the address rank similar to what is done for the address objects. The 'location' type munges everything together that does not fit into the other values: house, street, city, region, country.

The type field is present in the database but not indexed.

Fixes #470.