### PR TITLE
reenable autocommit in Updater

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -235,20 +235,20 @@ public class NominatimConnector {
      * @param password db username's password
      */
     public NominatimConnector(String host, int port, String database, String username, String password) {
-        BasicDataSource dataSource = buildDataSource(host, port, database, username, password);
+        BasicDataSource dataSource = buildDataSource(host, port, database, username, password, false);
 
         template = new JdbcTemplate(dataSource);
         template.setFetchSize(100000);
     }
 
-    static BasicDataSource buildDataSource(String host, int port, String database, String username, String password) {
+    static BasicDataSource buildDataSource(String host, int port, String database, String username, String password, boolean autocommit) {
         BasicDataSource dataSource = new BasicDataSource();
 
         dataSource.setUrl(String.format("jdbc:postgres_jts://%s:%d/%s", host, port, database));
         dataSource.setUsername(username);
         dataSource.setPassword(password);
         dataSource.setDriverClassName(JtsWrapper.class.getCanonicalName());
-        dataSource.setDefaultAutoCommit(false);
+        dataSource.setDefaultAutoCommit(autocommit);
         return dataSource;
     }
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -184,7 +184,7 @@ public class NominatimUpdater {
      * @param password Nominatim database password
      */
     public NominatimUpdater(String host, int port, String database, String username, String password) {
-        BasicDataSource dataSource = NominatimConnector.buildDataSource(host, port, database, username, password);
+        BasicDataSource dataSource = NominatimConnector.buildDataSource(host, port, database, username, password, true);
 
         exporter = new NominatimConnector(host, port, database, username, password);
         template = new JdbcTemplate(dataSource);


### PR DESCRIPTION
This fixes the missing index update in the Nominatim database. I'm not sure why we ever disable auto-commit at all. The remaining disabled autocommit still causes roolbacks.

Fixes #474.

