### PR TITLE
evaluate extratags->linked_place from placex table

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -47,11 +47,16 @@ public class PhotonDoc {
     private Point centroid;
 
     public PhotonDoc(long placeId, String osmType, long osmId, String tagKey, String tagValue, Map<String, String> name, String houseNumber, Map<String, String> address, Map<String, String> extratags, Envelope bbox, long parentPlaceId, double importance, CountryCode countryCode, Point centroid, long linkedPlaceId, int rankAddress) {
-        String place = extratags != null ? extratags.get("place") : null;
-        if (place != null) {
-            // take more specific extra tag information
-            tagKey = "place";
-            tagValue = place;
+        if (extratags != null) {
+            String place = extratags.get("place");
+            if (place == null) {
+                place = extratags.get("linked_place");
+            }
+            if (place != null) {
+                // take more specific extra tag information
+                tagKey = "place";
+                tagValue = place;
+            }
         }
 
         this.placeId = placeId;


### PR DESCRIPTION
In recent versions of Nominatim the type of a linked place
has been moved from extratags->place to extratags->linked_place
so that it does not overwrite values set by mappers.

Change Photon to look at both fields. Keep a preference to the
'place' value as this would be whatever the mapper has chosen.

This change is backward compatible in the sense that Photon works
with older and newer versions of Nominatim.

Fixes #489.