### PR TITLE
config.js.example: allow high definition map tiles

### DIFF
--- a/website/config.js.example
+++ b/website/config.js.example
@@ -1,4 +1,4 @@
 API_URL = 'http://localhost:5001/api/?';
-TILELAYER = 'https://{s}.tile.hosted.thunderforest.com/komoot-2/{z}/{x}/{y}.png';
+TILELAYER = 'https://{s}.tile.hosted.thunderforest.com/komoot-2/{z}/{x}/{y}{r}.png';
 CENTER = [52.3879, 13.0582];
 MAXZOOM = 18;


### PR DESCRIPTION
As mentioned in https://github.com/komoot/photon/pull/500#discussion_r499408890

https://leafletjs.com/reference-1.7.1.html#tilelayer "{r} can be used to add "@2x" to the URL to load retina tiles."