### PR TITLE
Introduce enum for Photon's address type

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -24,33 +24,7 @@ public class AddressRow {
         return AddressType.fromRank(rankAddress);
     }
 
-    /**
-     * @return whether nominatim thinks this place is a street
-     */
-    public boolean isStreet() {
-        return AddressType.STREET.coversRank(rankAddress);
-    }
-
-    /**
-     * @return whether nominatim thinks this place is a town or city
-     */
-    public boolean isCity() {
-        return AddressType.CITY.coversRank(rankAddress);
-    }
-
-    /**
-     * @return whether nominatim thinks this place is a state
-     */
-    public boolean isState() {
-        return AddressType.STATE.coversRank(rankAddress);
-    }
-
-    public boolean isCountry() {
-        return AddressType.COUNTRY.coversRank(rankAddress);
-    }
-
-
-    public boolean isPostcode() {
+    private boolean isPostcode() {
         if ("place".equals(osmKey) && "postcode".equals(osmValue)) {
             return true;
         }

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
@@ -1,0 +1,58 @@
+package de.komoot.photon.nominatim.model;
+
+/**
+ * List of address ranks available to Photon.
+ * <p>
+ * The different types correspond to the address parts available in GeocodeJSON. This type also defines
+ * the mapping toward Nominatim's address ranks.
+ */
+public enum AddressType {
+    HOUSE("house", 29, 30),
+    STREET("street", 26, 28),
+    LOCALITY("locality", 22, 26),
+    DISTRICT("district", 17, 22),
+    CITY("city", 13, 17),
+    COUNTY("county", 10, 13),
+    STATE("state", 5, 10),
+    COUNTRY("country", 4, 4);
+
+    private final String name;
+    private final int minRank;
+    private final int maxRank;
+
+    AddressType(String name, int minRank, int maxRank) {
+        this.name = name;
+        this.minRank = minRank;
+        this.maxRank = maxRank;
+    }
+
+    /**
+     * Convert a Nominatim address rank into a Photon address type.
+     *
+     * @param addressRank Nominatim address rank.
+     * @return The corresponding address type or null if not covered.
+     */
+    public static AddressType fromRank(int addressRank) {
+        for (AddressType a : AddressType.values()) {
+            if (a.coversRank(addressRank)) {
+                return a;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if the given address rank is mapped to the given address type.
+     *
+     * @param addressRank Nominatim address rank.
+     * @return True, if the type covers the rank.
+     */
+    public boolean coversRank(int addressRank) {
+        return addressRank >= minRank && addressRank <= maxRank;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/java/de/komoot/photon/AssertUtil.java
+++ b/src/test/java/de/komoot/photon/AssertUtil.java
@@ -1,0 +1,17 @@
+package de.komoot.photon;
+
+import de.komoot.photon.nominatim.model.AddressType;
+import org.junit.Assert;
+
+public class AssertUtil {
+    private AssertUtil() {}
+
+    public static void assertAddressName(String name, PhotonDoc doc, AddressType addressType) {
+        Assert.assertNotNull(doc.getAddressParts().get(addressType));
+        Assert.assertEquals(name, doc.getAddressParts().get(addressType).get("name"));
+    }
+
+    public static void assertNoAddress(PhotonDoc doc, AddressType addressType) {
+        Assert.assertNull(doc.getAddressParts().get(addressType));
+    }
+}

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -2,6 +2,7 @@ package de.komoot.photon;
 
 import java.util.HashMap;
 
+import de.komoot.photon.nominatim.model.AddressType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,10 +16,10 @@ public class PhotonDocTest {
         
         HashMap<String, String> streetNames = new HashMap<>();
         streetNames.put("name", "parent place street");
-        doc.setStreet(streetNames);
+        doc.setAddressPartIfNew(AddressType.STREET, streetNames);
         
         doc.completeFromAddress();
-        Assert.assertEquals("test street", doc.getStreet().get("name"));
+        AssertUtil.assertAddressName("test street", doc, AddressType.STREET);
     }
 
     @Test
@@ -28,7 +29,7 @@ public class PhotonDocTest {
         PhotonDoc doc = createPhotonDocWithAddress(address);
         
         doc.completeFromAddress();
-        Assert.assertEquals("test street", doc.getStreet().get("name"));
+        AssertUtil.assertAddressName("test street", doc, AddressType.STREET);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -17,9 +17,6 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
-import java.sql.SQLException;
-import java.util.HashMap;
-
 
 public class NominatimConnectorDBTest {
     private EmbeddedDatabase db;

--- a/src/test/java/de/komoot/photon/nominatim/model/AddressTypeTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/model/AddressTypeTest.java
@@ -1,0 +1,18 @@
+package de.komoot.photon.nominatim.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AddressTypeTest {
+
+    /**
+     * All ranks coverd by Nominatim must return a corresponding Photon rank.
+     */
+    @Test
+    public void testAllRanksAreCovered() {
+        for (int i = 4; i <= 30; ++i) {
+            assertNotNull(AddressType.fromRank(i));
+        }
+    }
+}

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -37,6 +37,10 @@ public class PlacexTestRow {
         centroid = "POINT (1.0 34.0)";
     }
 
+    public static PlacexTestRow make_street(String name) {
+        return new PlacexTestRow("highway", "residential").name(name).rankAddress(26).rankSearch(26);
+    }
+
     private static String asJson(Map<String, String> map) {
         if (map == null) {
             return null;


### PR DESCRIPTION
The enum lists the possible address fields that Photon may index and output. It is also responsible for mapping Nominatim's address rank values to the address type. This should now be the only place where raw Nominatim address rank numbers are used.

PhotonDoc uses the type to define its address in a map instead of having lots of separate fields. That simplifies code in a number
of places.

The commit also disallows adding an address part with the same level as the place object itself. CC @hendrikmoree 

Fixes #499. 