### PR TITLE
Code cleanup NominatimConnector

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -1,0 +1,93 @@
+package de.komoot.photon.nominatim;
+
+import de.komoot.photon.Importer;
+import de.komoot.photon.PhotonDoc;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+class ImportThread {
+    private static final int PROGRESS_INTERVAL = 50000;
+    private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null, null, null, null, null, null, 0, 0, null, null, 0, 0);
+    private final BlockingQueue<PhotonDoc> documents = new LinkedBlockingDeque<>(20);
+    private final AtomicLong counter = new AtomicLong();
+    private final Importer importer;
+    private final Thread thread;
+    private final long startMillis;
+
+    public ImportThread(Importer importer) {
+        this.importer = importer;
+        this.thread = new Thread(new ImportRunnable());
+        this.thread.start();
+        this.startMillis = System.currentTimeMillis();
+    }
+
+    /**
+     * Adds the given document from Nominatim to the import queue.
+     *
+     * @param docs Fully filled nominatim document.
+     */
+    public void addDocument(NominatimResult docs) {
+        for (PhotonDoc doc : docs.getDocsWithHousenumber()) {
+            while (true) {
+                try {
+                    documents.put(doc);
+                    break;
+                } catch (InterruptedException e) {
+                    log.warn("Thread interrupted while placing document in queue.");
+                    // Restore interrupted state.
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (counter.incrementAndGet() % PROGRESS_INTERVAL == 0) {
+                final double documentsPerSecond = 1000d * counter.longValue() / (System.currentTimeMillis() - startMillis);
+                log.info(String.format("imported %d documents [%.1f/second]", counter.longValue(), documentsPerSecond));
+            }
+        }
+    }
+
+    /**
+     * Finalize the import.
+     *
+     * Sends an end marker to the import thread and waiting for it to join.
+     */
+    public void finish() {
+        while (true) {
+            try {
+                documents.put(FINAL_DOCUMENT);
+                thread.join();
+                break;
+            } catch (InterruptedException e) {
+                log.warn("Thread interrupted while placing document in queue.");
+                // Restore interrupted state.
+                Thread.currentThread().interrupt();
+            }
+        }
+        log.info(String.format("finished import of %d photon documents.", counter.longValue()));
+    }
+
+    private class ImportRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            while (true) {
+                PhotonDoc doc;
+                try {
+                    doc = documents.take();
+                    if (doc == FINAL_DOCUMENT)
+                        break;
+                    importer.add(doc);
+                } catch (InterruptedException e) {
+                    log.info("interrupted exception ", e);
+                    // Restore interrupted state.
+                    Thread.currentThread().interrupt();
+                }
+            }
+            importer.finish();
+        }
+    }
+
+}

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class NominatimConnector {
     private static final String SELECT_COLS_PLACEX = "SELECT place_id, osm_type, osm_id, class, type, name, housenumber, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_address, rank_search, importance, country_code, centroid";
     private static final String SELECT_COLS_OSMLINE = "SELECT place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
-    private static final String SELECT_COLS_ADDRESS = "SELECT p.place_id, p.name, p.class, p.type, p.rank_address";
+    private static final String SELECT_COLS_ADDRESS = "SELECT p.name, p.class, p.type, p.rank_address";
 
     private final DBDataAdapter dbutils;
     private final JdbcTemplate template;
@@ -183,7 +183,6 @@ public class NominatimConnector {
 
     List<AddressRow> getAddresses(PhotonDoc doc) {
         RowMapper<AddressRow> rowMapper = (rs, rowNum) -> new AddressRow(
-                rs.getLong("place_id"),
                 dbutils.getMap(rs, "name"),
                 rs.getString("class"),
                 rs.getString("type"),

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -1,11 +1,8 @@
 package de.komoot.photon.nominatim;
 
-import com.google.common.collect.ImmutableList;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.linearref.LengthIndexedLine;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressRow;
@@ -24,99 +21,6 @@ import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
-
-/**
- * A Nominatim result consisting of the basic PhotonDoc for the object
- * and a map of attached house numbers together with their respective positions.
- */
-class NominatimResult {
-    private PhotonDoc doc;
-    private Map<String, Point> housenumbers;
-
-    public NominatimResult(PhotonDoc baseobj) {
-        doc = baseobj;
-        housenumbers = null;
-    }
-
-    PhotonDoc getBaseDoc() {
-        return doc;
-    }
-
-    boolean isUsefulForIndex() {
-        return (housenumbers != null && !housenumbers.isEmpty()) || doc.isUsefulForIndex();
-    }
-
-    List<PhotonDoc> getDocsWithHousenumber() {
-        if (housenumbers == null || housenumbers.isEmpty()) {
-            return ImmutableList.of(doc);
-        }
-
-        List<PhotonDoc> results = new ArrayList<PhotonDoc>(housenumbers.size());
-        for (Map.Entry<String, Point> e : housenumbers.entrySet()) {
-            PhotonDoc copy = new PhotonDoc(doc);
-            copy.setHouseNumber(e.getKey());
-            copy.setCentroid(e.getValue());
-            results.add(copy);
-        }
-
-        return results;
-    }
-
-    /**
-     * Adds house numbers from a house number string.
-     * <p>
-     * This may either be a single house number or multiple
-     * house numbers delimited by a semicolon. All locations
-     * will be set to the centroid of the doc geometry.
-     *
-     * @param str House number string. May be null, in which case nothing is added.
-     */
-    public void addHousenumbersFromString(String str) {
-        if (str == null || str.isEmpty())
-            return;
-
-        if (housenumbers == null)
-            housenumbers = new HashMap<String, Point>();
-
-        String[] parts = str.split(";");
-        for (String part : parts) {
-            String h = part.trim();
-            if (!h.isEmpty())
-                housenumbers.put(h, doc.getCentroid());
-        }
-    }
-
-    public void addHouseNumbersFromInterpolation(long first, long last, String interpoltype, Geometry geom) {
-        if (last <= first || (last - first) > 1000)
-            return;
-
-        if (housenumbers == null)
-            housenumbers = new HashMap<String, Point>();
-
-        LengthIndexedLine line = new LengthIndexedLine(geom);
-        double si = line.getStartIndex();
-        double ei = line.getEndIndex();
-        double lstep = (ei - si) / (double) (last - first);
-
-        // leave out first and last, they have a distinct OSM node that is already indexed
-        long step = 2;
-        long num = 1;
-        if (interpoltype.equals("odd")) {
-            if (first % 2 == 1)
-                ++num;
-        } else if (interpoltype.equals("even")) {
-            if (first % 2 == 0)
-                ++num;
-        } else {
-            step = 1;
-        }
-
-        GeometryFactory fac = geom.getFactory();
-        for (; first + num < last; num += step) {
-            housenumbers.put(String.valueOf(num + first), fac.createPoint(line.extractPoint(si + lstep * num)));
-        }
-    }
-}
 
 /**
  * Export nominatim data

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -1,0 +1,106 @@
+package de.komoot.photon.nominatim;
+
+import com.google.common.collect.ImmutableList;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.linearref.LengthIndexedLine;
+import de.komoot.photon.PhotonDoc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Nominatim result consisting of the basic PhotonDoc for the object
+ * and a map of attached house numbers together with their respective positions.
+ */
+class NominatimResult {
+    private PhotonDoc doc;
+    private Map<String, Point> housenumbers;
+
+    public NominatimResult(PhotonDoc baseobj) {
+        doc = baseobj;
+        housenumbers = null;
+    }
+
+    PhotonDoc getBaseDoc() {
+        return doc;
+    }
+
+    boolean isUsefulForIndex() {
+        return (housenumbers != null && !housenumbers.isEmpty()) || doc.isUsefulForIndex();
+    }
+
+    List<PhotonDoc> getDocsWithHousenumber() {
+        if (housenumbers == null || housenumbers.isEmpty()) {
+            return ImmutableList.of(doc);
+        }
+
+        List<PhotonDoc> results = new ArrayList<PhotonDoc>(housenumbers.size());
+        for (Map.Entry<String, Point> e : housenumbers.entrySet()) {
+            PhotonDoc copy = new PhotonDoc(doc);
+            copy.setHouseNumber(e.getKey());
+            copy.setCentroid(e.getValue());
+            results.add(copy);
+        }
+
+        return results;
+    }
+
+    /**
+     * Adds house numbers from a house number string.
+     * <p>
+     * This may either be a single house number or multiple
+     * house numbers delimited by a semicolon. All locations
+     * will be set to the centroid of the doc geometry.
+     *
+     * @param str House number string. May be null, in which case nothing is added.
+     */
+    public void addHousenumbersFromString(String str) {
+        if (str == null || str.isEmpty())
+            return;
+
+        if (housenumbers == null)
+            housenumbers = new HashMap<String, Point>();
+
+        String[] parts = str.split(";");
+        for (String part : parts) {
+            String h = part.trim();
+            if (!h.isEmpty())
+                housenumbers.put(h, doc.getCentroid());
+        }
+    }
+
+    public void addHouseNumbersFromInterpolation(long first, long last, String interpoltype, Geometry geom) {
+        if (last <= first || (last - first) > 1000)
+            return;
+
+        if (housenumbers == null)
+            housenumbers = new HashMap<String, Point>();
+
+        LengthIndexedLine line = new LengthIndexedLine(geom);
+        double si = line.getStartIndex();
+        double ei = line.getEndIndex();
+        double lstep = (ei - si) / (double) (last - first);
+
+        // leave out first and last, they have a distinct OSM node that is already indexed
+        long step = 2;
+        long num = 1;
+        if (interpoltype.equals("odd")) {
+            if (first % 2 == 1)
+                ++num;
+        } else if (interpoltype.equals("even")) {
+            if (first % 2 == 0)
+                ++num;
+        } else {
+            step = 1;
+        }
+
+        GeometryFactory fac = geom.getFactory();
+        for (; first + num < last; num += step) {
+            housenumbers.put(String.valueOf(num + first), fac.createPoint(line.extractPoint(si + lstep * num)));
+        }
+    }
+}

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -38,7 +38,7 @@ class NominatimResult {
             return ImmutableList.of(doc);
         }
 
-        List<PhotonDoc> results = new ArrayList<PhotonDoc>(housenumbers.size());
+        List<PhotonDoc> results = new ArrayList<>(housenumbers.size());
         for (Map.Entry<String, Point> e : housenumbers.entrySet()) {
             PhotonDoc copy = new PhotonDoc(doc);
             copy.setHouseNumber(e.getKey());
@@ -63,7 +63,7 @@ class NominatimResult {
             return;
 
         if (housenumbers == null)
-            housenumbers = new HashMap<String, Point>();
+            housenumbers = new HashMap<>();
 
         String[] parts = str.split(";");
         for (String part : parts) {
@@ -78,7 +78,7 @@ class NominatimResult {
             return;
 
         if (housenumbers == null)
-            housenumbers = new HashMap<String, Point>();
+            housenumbers = new HashMap<>();
 
         LengthIndexedLine line = new LengthIndexedLine(geom);
         double si = line.getStartIndex();

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -1,9 +1,7 @@
 package de.komoot.photon.nominatim.model;
 
-import com.google.common.base.MoreObjects;
 import lombok.Data;
 
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -13,8 +11,6 @@ import java.util.Map;
  */
 @Data
 public class AddressRow {
-    private static final String[] USEFUL_CONTEXT_KEYS = new String[]{"boundary", "landuse", "place"}; // must be in alphabetic order to speed up lookup
-    private final long placeId;
     private final Map<String, String> name;
     private final String osmKey;
     private final String osmValue;
@@ -33,16 +29,6 @@ public class AddressRow {
     }
 
     public boolean isUsefulForContext() {
-        return !name.isEmpty() && !isPostcode() && Arrays.binarySearch(USEFUL_CONTEXT_KEYS, osmKey) >= 0;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("placeId", placeId)
-                .add("name", name)
-                .add("osmKey", osmKey)
-                .add("osmValue", osmValue)
-                .toString();
+        return !name.isEmpty() && !isPostcode();
     }
 }

--- a/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
@@ -1,0 +1,146 @@
+package de.komoot.photon.nominatim;
+
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import de.komoot.photon.PhotonDoc;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class NominatimResultTest {
+    private final PhotonDoc simpleDoc = new PhotonDoc(10000, "N", 123, "place", "house",
+                                                       new HashMap<>(), null, null, null, null, 0,
+                                            0.0, "de", null, 0, 30);
+
+    private void assertDocWithHousenumbers(List<String> housenumbers, List<PhotonDoc> docs) {
+        assertEquals(housenumbers.size(), docs.size());
+
+        List<String> outnumbers = new ArrayList<>();
+
+        for (PhotonDoc doc: docs) {
+            assertNotSame(simpleDoc, doc);
+            assertEquals("place", doc.getTagKey());
+            assertEquals("house", doc.getTagValue());
+            assertEquals(10000, doc.getPlaceId());
+            assertEquals("N", doc.getOsmType());
+            assertEquals(123, doc.getOsmId());
+
+            outnumbers.add(doc.getHouseNumber());
+        }
+
+        Collections.sort(outnumbers);
+        Collections.sort(housenumbers);
+
+        assertEquals(housenumbers, outnumbers);
+    }
+
+    private void assertSimpleOnly(List<PhotonDoc> docs) {
+        assertEquals(1, docs.size());
+        assertSame(simpleDoc, docs.get(0));
+    }
+
+    @Test
+    public void testIsUsefulForIndex() {
+        assertFalse(simpleDoc.isUsefulForIndex());
+        assertFalse(new NominatimResult(simpleDoc).isUsefulForIndex());
+    }
+
+    @Test
+    public void testGetDocsWithHousenumber() {
+        List<PhotonDoc> docs = new NominatimResult(simpleDoc).getDocsWithHousenumber();
+        assertSimpleOnly(docs);
+    }
+
+    @Test
+    public void testAddHousenumbersFromStringSimple() {
+        NominatimResult res = new NominatimResult(simpleDoc);
+        res.addHousenumbersFromString("34");
+
+        assertDocWithHousenumbers(Arrays.asList("34"), res.getDocsWithHousenumber());
+    }
+
+    @Test
+    public void testAddHousenumbersFromStringList() {
+        NominatimResult res = new NominatimResult(simpleDoc);
+        res.addHousenumbersFromString("34; 50b");
+
+        assertDocWithHousenumbers(Arrays.asList("34", "50b"), res.getDocsWithHousenumber());
+
+        res.addHousenumbersFromString("4;");
+        assertDocWithHousenumbers(Arrays.asList("34", "50b", "4"), res.getDocsWithHousenumber());
+    }
+
+    @Test
+    public void testAddHouseNumbersFromInterpolationBad() throws ParseException {
+        NominatimResult res = new NominatimResult(simpleDoc);
+
+        WKTReader reader = new WKTReader();
+        res.addHouseNumbersFromInterpolation(34, 33, "odd",
+                                              reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertSimpleOnly(res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(1, 10000, "odd",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertSimpleOnly(res.getDocsWithHousenumber());
+    }
+
+    @Test
+    public void testAddHouseNumbersFromInterpolationOdd() throws ParseException {
+        NominatimResult res = new NominatimResult(simpleDoc);
+
+        WKTReader reader = new WKTReader();
+
+        res.addHouseNumbersFromInterpolation(1, 5, "odd",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("3"), res.getDocsWithHousenumber());
+        res.addHouseNumbersFromInterpolation(10, 13, "odd",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("3", "11"), res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(101, 106, "odd",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("3", "11", "103", "105"), res.getDocsWithHousenumber());
+
+    }
+
+    @Test
+    public void testAddHouseNumbersFromInterpolationEven() throws ParseException {
+        NominatimResult res = new NominatimResult(simpleDoc);
+
+        WKTReader reader = new WKTReader();
+
+        res.addHouseNumbersFromInterpolation(1, 5, "even",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2", "4"), res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(10, 16, "even",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2", "4", "12", "14"), res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(51, 52, "even",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2", "4", "12", "14"), res.getDocsWithHousenumber());
+    }
+
+    @Test
+    public void testAddHouseNumbersFromInterpolationAll() throws ParseException {
+        NominatimResult res = new NominatimResult(simpleDoc);
+
+        WKTReader reader = new WKTReader();
+
+        res.addHouseNumbersFromInterpolation(1, 3, "",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2"), res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(22, 22, null,
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2"), res.getDocsWithHousenumber());
+
+        res.addHouseNumbersFromInterpolation(100, 106, "all",
+                reader.read("LINESTRING(0.0 0.0 ,0.0 0.1)"));
+        assertDocWithHousenumbers(Arrays.asList("2", "101", "102", "103", "104", "105"), res.getDocsWithHousenumber());
+    }
+
+}


### PR DESCRIPTION
* moves NominatimResult and ImportThread code into separate files
* trims AddressRow further to required parts
* use lambda notation where possible
* clean up of minor formatting issues and code smells

Also adds tests for interpolation computation.