### PR TITLE
Only wait for yellow health status on startup

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -53,7 +53,7 @@ public class App {
             Client esClient = esServer.getClient();
 
             log.info("Make sure that the ES cluster is ready, this might take some time.");
-            esClient.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+            esClient.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
             log.info("ES cluster is now ready.");
 
             if (args.isRecreateIndex()) {


### PR DESCRIPTION
The documentation says that the yellow health status is reached, when the primary shard is available and green status only when the replica shards are online. Tests are run with a single shard only, thus they can never reach green state because there is no replica shard configured. Waiting for the green status in fact resulted in a silent timeout of the operation after 30s. This made the API tests annoyingly slow.

Having the primary shard available should be sufficient for most operations. So this commit changes the status operation to only wait for yellow state.

Side note: the status check shouldn't just time out silently but at least omit a warning but that is something for another commit.