### PR TITLE
Update to ElasticSearch 5.6

### DIFF
--- a/es/modules/lang-painless/plugin-descriptor.properties
+++ b/es/modules/lang-painless/plugin-descriptor.properties
@@ -22,7 +22,7 @@
 description=An easy, safe and fast scripting language for Elasticsearch
 #
 # 'version': plugin's version
-version=5.5.0
+version=5.6.16
 #
 # 'name': the plugin name
 name=lang-painless
@@ -37,7 +37,7 @@ classname=org.elasticsearch.painless.PainlessPlugin
 java.version=1.8
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=5.5.0
+elasticsearch.version=5.6.16
 ### optional elements for plugins:
 #
 # 'has.native.controller': whether or not the plugin has a native controller

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,10 @@
                     <groupId>org.elasticsearch</groupId>
                     <artifactId>jna</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency><!-- required by elasticsearch -->
@@ -29,7 +33,11 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
-
+        </dependency>
+        <dependency><!-- required by elasticsearch -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
@@ -151,7 +159,6 @@
                 </exclusion>
            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -182,7 +189,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <filters>
@@ -233,7 +240,7 @@
                         <artifactItem>
                             <groupId>org.codelibs.elasticsearch.module</groupId>
                             <artifactId>lang-painless</artifactId>
-                            <version>5.5.0</version>
+                            <version>${elasticsearch.version}</version>
                             <type>jar</type>
                             <overWrite>false</overWrite>
                             <outputDirectory>${project.build.directory}/es/modules/lang-painless</outputDirectory>
@@ -318,7 +325,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 
-        <elasticsearch.version>5.5.0</elasticsearch.version>
+        <elasticsearch.version>5.6.16</elasticsearch.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.8.2</log4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,7 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
-            <exclusions><!-- gives a bad error -->
-                <exclusion>
-                    <groupId>org.elasticsearch</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
+            <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
@@ -49,12 +45,6 @@
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency><!-- required by elasticsearch to avoid warning on startup,
-            see https://github.com/elastic/elasticsearch/issues/13245 -->
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>jna</artifactId>
-            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -97,7 +97,7 @@
 							},
 							"script_score": {
 								"script": {
-									"inline": "double score = 1 + doc['importance'].value * 100; score",
+									"source": "double score = 1 + doc['importance'].value * 100; score",
 									"lang": "painless"
 								}
 							}

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -97,7 +97,7 @@
 							},
 							"script_score": {
 								"script": {
-									"inline": "double score = 1 + doc['importance'].value * 100; score",
+									"source": "double score = 1 + doc['importance'].value * 100; score",
 									"lang": "painless"
 								}
 							}


### PR DESCRIPTION
This is a prerequisite for switching to HTTP transport client. The resulting jar should still be compatible with the data dumps.