### PR TITLE
Always use Index API for updates

### DIFF
--- a/src/main/java/de/komoot/photon/Updater.java
+++ b/src/main/java/de/komoot/photon/Updater.java
@@ -6,11 +6,7 @@ package de.komoot.photon;
 public interface Updater {
     public void create(PhotonDoc doc);
 
-    public void update(PhotonDoc doc);
-
     public void delete(Long id);
 
     public void finish();
-
-    public void updateOrCreate(PhotonDoc updatedDoc);
 }

--- a/src/main/java/de/komoot/photon/elasticsearch/Updater.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Updater.java
@@ -31,28 +31,11 @@ public class Updater implements de.komoot.photon.Updater {
     }
 
     @Override
-    public void updateOrCreate(PhotonDoc updatedDoc) {
-        final boolean exists = this.esClient.get(this.esClient.prepareGet(PhotonIndex.NAME, PhotonIndex.TYPE, String.valueOf(updatedDoc.getPlaceId())).request()).actionGet().isExists();
-        if (exists) {
-            this.update(updatedDoc);
-        } else {
-            this.create(updatedDoc);
-        }
-    }
-
     public void create(PhotonDoc doc) {
         try {
             this.bulkRequest.add(this.esClient.prepareIndex(PhotonIndex.NAME, PhotonIndex.TYPE).setSource(Utils.convert(doc, this.languages)).setId(String.valueOf(doc.getPlaceId())));
         } catch (IOException e) {
             log.error(String.format("creation of new doc [%s] failed", doc), e);
-        }
-    }
-
-    public void update(PhotonDoc doc) {
-        try {
-            this.bulkRequest.add(this.esClient.prepareUpdate(PhotonIndex.NAME, PhotonIndex.TYPE, String.valueOf(doc.getPlaceId())).setDoc(Utils.convert(doc, this.languages)));
-        } catch (IOException e) {
-            log.error(String.format("update of new doc [%s] failed", doc), e);
         }
     }
 

--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @Slf4j
 class ImportThread {
     private static final int PROGRESS_INTERVAL = 50000;
-    private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null, null, null, null, null, null, 0, 0, null, null, 0, 0);
+    private static final PhotonDoc FINAL_DOCUMENT = new PhotonDoc(0, null, 0, null, null);
     private final BlockingQueue<PhotonDoc> documents = new LinkedBlockingDeque<>(20);
     private final AtomicLong counter = new AtomicLong();
     private final Importer importer;

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -41,8 +41,8 @@ class NominatimResult {
         List<PhotonDoc> results = new ArrayList<>(housenumbers.size());
         for (Map.Entry<String, Point> e : housenumbers.entrySet()) {
             PhotonDoc copy = new PhotonDoc(doc);
-            copy.setHouseNumber(e.getKey());
-            copy.setCentroid(e.getValue());
+            copy.houseNumber(e.getKey());
+            copy.centroid(e.getValue());
             results.add(copy);
         }
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -69,21 +69,9 @@ public class NominatimUpdater {
                             final List<PhotonDoc> updatedDocs = exporter.getByPlaceId(place.getPlaceId());
                             boolean wasUseful = false;
                             for (PhotonDoc updatedDoc : updatedDocs) {
-                                switch (indexedStatus) {
-                                case CREATE:
-                                    if (updatedDoc.isUsefulForIndex()) {
-                                        updater.create(updatedDoc);
-                                    }
-                                    break;
-                                case UPDATE:
-                                    if (updatedDoc.isUsefulForIndex()) {
-                                        updater.updateOrCreate(updatedDoc);
-                                        wasUseful = true;
-                                    }
-                                    break;
-                                default:
-                                    LOGGER.error(String.format("Unknown index status %d", indexedStatus));
-                                    break;
+                                if (updatedDoc.isUsefulForIndex()) {
+                                    updater.create(updatedDoc);
+                                    wasUseful = true;
                                 }
                             }
                             if (indexedStatus == UPDATE && !wasUseful) {

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static spark.Spark.*;
 
-import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.elasticsearch.Importer;
 
 /**
@@ -89,7 +88,7 @@ public class ApiIntegrationTest extends ESBaseTester {
         assertEquals(1, features.length());
         JSONObject feature = features.getJSONObject(0);
         JSONObject properties = feature.getJSONObject("properties");
-        assertEquals("way", properties.getString("osm_type"));
+        assertEquals("W", properties.getString("osm_type"));
         assertEquals("place", properties.getString("osm_key"));
         assertEquals("city", properties.getString("osm_value"));
         assertEquals("berlin", properties.getString("name"));
@@ -110,7 +109,7 @@ public class ApiIntegrationTest extends ESBaseTester {
         assertEquals(1, features.length());
         JSONObject feature = features.getJSONObject(0);
         JSONObject properties = feature.getJSONObject("properties");
-        assertEquals("way", properties.getString("osm_type"));
+        assertEquals("W", properties.getString("osm_type"));
         assertEquals("place", properties.getString("osm_key"));
         assertEquals("town", properties.getString("osm_value"));
         assertEquals("berlin", properties.getString("name"));
@@ -130,7 +129,7 @@ public class ApiIntegrationTest extends ESBaseTester {
         assertEquals(1, features.length());
         JSONObject feature = features.getJSONObject(0);
         JSONObject properties = feature.getJSONObject("properties");
-        assertEquals("way", properties.getString("osm_type"));
+        assertEquals("W", properties.getString("osm_type"));
         assertEquals("place", properties.getString("osm_key"));
         assertEquals("city", properties.getString("osm_value"));
         assertEquals("berlin", properties.getString("name"));

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon;
 
-import com.google.common.collect.ImmutableMap;
+import de.komoot.photon.elasticsearch.Importer;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
@@ -16,8 +16,6 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static spark.Spark.*;
-
-import de.komoot.photon.elasticsearch.Importer;
 
 /**
  * These test connect photon to an already running ES node (setup in ESBaseTester) so that we can directly test the API

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,19 +1,16 @@
 package de.komoot.photon;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.PrecisionModel;
-import de.komoot.photon.elasticsearch.Importer;
 import de.komoot.photon.elasticsearch.PhotonIndex;
 import de.komoot.photon.elasticsearch.Server;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.client.Client;
 import org.junit.After;
-import org.junit.Before;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,45 +22,17 @@ import java.io.IOException;
  */
 @Slf4j
 public class ESBaseTester {
-
-    public final String clusterName = "photon-test";
+    public static final String TEST_CLUSTER_NAME = "photon-test";
+    private static GeometryFactory FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     private Server server;
 
-    GeometryFactory FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
-
-    protected Client client;
-
-    private PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
+    protected PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
         ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
         Point location = FACTORY.createPoint(new Coordinate(lon, lat));
         return new PhotonDoc(id, "way", osmId, key, value, nameMap, null, null, null, null, 0, 0.5, null, location, 0, 0);
     }
 
-    @Before
-    public void setUp() throws Exception {
-        setUpES();
-        ImmutableList<String> tags = ImmutableList.of("tourism", "attraction", "tourism", "hotel", "tourism", "museum", "tourism", "information", "amenity",
-                "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station");
-        client = getClient();
-        Importer instance = new Importer(client, "en");
-        double lon = 13.38886;
-        double lat = 52.51704;
-        for (int i = 0; i < tags.size(); i++) {
-            String key = tags.get(i);
-            String value = tags.get(++i);
-            PhotonDoc doc = this.createDoc(lon, lat, i, i, key, value);
-            instance.add(doc);
-            lon += 0.00004;
-            lat += 0.00086;
-            doc = this.createDoc(lon, lat, i + 1, i + 1, key, value);
-            instance.add(doc);
-            lon += 0.00004;
-            lat += 0.00086;
-        }
-        instance.finish();
-        refresh();
-    }
 
     @After
     public void tearDown() {
@@ -76,7 +45,7 @@ public class ESBaseTester {
      * @throws IOException
      */
     public void setUpES() throws IOException {
-        server = new Server(clusterName, new File("./target/es_photon_test").getAbsolutePath(), "en", "").setMaxShards(1).start();
+        server = new Server(TEST_CLUSTER_NAME, new File("./target/es_photon_test").getAbsolutePath(), "en", "").setMaxShards(1).start();
         server.recreateIndex();
         refresh();
     }

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -9,6 +9,7 @@ import de.komoot.photon.elasticsearch.PhotonIndex;
 import de.komoot.photon.elasticsearch.Server;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.junit.After;
 
@@ -31,6 +32,10 @@ public class ESBaseTester {
         ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
         Point location = FACTORY.createPoint(new Coordinate(lon, lat));
         return new PhotonDoc(id, "W", osmId, key, value).names(nameMap).centroid(location);
+    }
+
+    protected GetResponse getById(int id) {
+        return getClient().prepareGet(PhotonIndex.NAME,PhotonIndex.TYPE, String.valueOf(id)).execute().actionGet();
     }
 
 

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -46,6 +46,7 @@ public class ESBaseTester {
      */
     public void setUpES() throws IOException {
         server = new Server(TEST_CLUSTER_NAME, new File("./target/es_photon_test").getAbsolutePath(), "en", "").setMaxShards(1).start();
+        deleteIndex(); // just in case of an abnormal abort previously
         server.recreateIndex();
         refresh();
     }

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -30,7 +30,7 @@ public class ESBaseTester {
     protected PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
         ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
         Point location = FACTORY.createPoint(new Coordinate(lon, lat));
-        return new PhotonDoc(id, "way", osmId, key, value, nameMap, null, null, null, null, 0, 0.5, null, location, 0, 0);
+        return new PhotonDoc(id, "W", osmId, key, value).names(nameMap).centroid(location);
     }
 
 

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -10,38 +10,38 @@ public class PhotonDocTest {
 
     @Test
     public void testCompleteAddressOverwritesStreet() {
-        HashMap<String, String> address = new HashMap<>();
-        address.put("street", "test street");
-        PhotonDoc doc = createPhotonDocWithAddress(address);
+        PhotonDoc doc = simplePhotonDoc();
         
         HashMap<String, String> streetNames = new HashMap<>();
         streetNames.put("name", "parent place street");
         doc.setAddressPartIfNew(AddressType.STREET, streetNames);
-        
-        doc.completeFromAddress();
+
+        HashMap<String, String> address = new HashMap<>();
+        address.put("street", "test street");
+        doc.address(address);
         AssertUtil.assertAddressName("test street", doc, AddressType.STREET);
     }
 
     @Test
     public void testCompleteAddressCreatesStreetIfNonExistantBefore() {
+        PhotonDoc doc = simplePhotonDoc();
+
         HashMap<String, String> address = new HashMap<>();
         address.put("street", "test street");
-        PhotonDoc doc = createPhotonDocWithAddress(address);
-        
-        doc.completeFromAddress();
+        doc.address(address);
         AssertUtil.assertAddressName("test street", doc, AddressType.STREET);
     }
 
     @Test
     public void testAddCountryCode() {
-        PhotonDoc doc = new PhotonDoc(1, "W", 2, "highway", "residential", null, "4", null, null, null, 0, 30, "de", null, 0, 30);
+        PhotonDoc doc = new PhotonDoc(1, "W", 2, "highway", "residential").countryCode("de");
 
         Assert.assertNotNull(doc.getCountryCode());
         Assert.assertEquals("DE", doc.getCountryCode().getAlpha2());
     }
 
-    private PhotonDoc createPhotonDocWithAddress(HashMap<String, String> address) {
-        return new PhotonDoc(1, "W", 2, "highway", "residential", null, "4", address, null, null, 0, 30, null, null, 0, 30);
+    private PhotonDoc simplePhotonDoc() {
+        return new PhotonDoc(1, "W", 2, "highway", "residential").houseNumber("4");
     }
 
 }

--- a/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
@@ -1,0 +1,39 @@
+package de.komoot.photon.elasticsearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import org.elasticsearch.action.get.GetResponse;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class ImporterTest extends ESBaseTester {
+
+    GetResponse getById(int id) {
+        return getClient().prepareGet(PhotonIndex.NAME,PhotonIndex.TYPE, String.valueOf(id))
+                .execute()
+                .actionGet();
+    }
+
+    @After
+    public void tearDown() {
+        deleteIndex();
+        shutdownES();
+    }
+
+    @Test
+    public void addSimpleDoc() throws IOException {
+        setUpES();
+        Importer instance = new Importer(getClient(), "en");
+        instance.add(new PhotonDoc(1234, "N", 1000, "place", "city"));
+        instance.finish();
+        refresh();
+
+        GetResponse response = getById(1234);
+
+        assertTrue(response.isExists());
+    }
+}

--- a/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
@@ -12,12 +12,6 @@ import static org.junit.Assert.*;
 
 public class ImporterTest extends ESBaseTester {
 
-    GetResponse getById(int id) {
-        return getClient().prepareGet(PhotonIndex.NAME,PhotonIndex.TYPE, String.valueOf(id))
-                .execute()
-                .actionGet();
-    }
-
     @After
     public void tearDown() {
         deleteIndex();

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -14,12 +14,6 @@ import static org.junit.Assert.*;
 
 public class UpdaterTest extends ESBaseTester {
 
-    private GetResponse getById(int id) {
-        return getClient().prepareGet(PhotonIndex.NAME,PhotonIndex.TYPE, String.valueOf(id))
-                .execute()
-                .actionGet();
-    }
-
     @After
     public void tearDown() {
         deleteIndex();

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -41,7 +41,7 @@ public class UpdaterTest extends ESBaseTester {
 
         names.put("name:en", "Enfoo");
         Updater updater = new Updater(getClient(), "en,de");
-        updater.updateOrCreate(doc);
+        updater.create(doc);
         updater.finish();
         refresh();
 
@@ -68,7 +68,7 @@ public class UpdaterTest extends ESBaseTester {
 
         names.remove("name");
         Updater updater = new Updater(getClient(), "en,de");
-        updater.updateOrCreate(doc);
+        updater.create(doc);
         updater.finish();
         refresh();
 
@@ -76,7 +76,7 @@ public class UpdaterTest extends ESBaseTester {
 
         assertTrue(response.isExists());
         Map<String, String> out_names = (Map<String, String>) response.getSourceAsMap().get("name");
-        //assertFalse(out_names.containsKey("default"));
+        assertFalse(out_names.containsKey("default"));
         assertEquals("Enfoo", out_names.get("en"));
     }
 }

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -1,0 +1,82 @@
+package de.komoot.photon.elasticsearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import org.elasticsearch.action.get.GetResponse;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class UpdaterTest extends ESBaseTester {
+
+    private GetResponse getById(int id) {
+        return getClient().prepareGet(PhotonIndex.NAME,PhotonIndex.TYPE, String.valueOf(id))
+                .execute()
+                .actionGet();
+    }
+
+    @After
+    public void tearDown() {
+        deleteIndex();
+        shutdownES();
+    }
+
+
+    @Test
+    public void addNameToDoc() throws IOException {
+        Map<String, String> names = new HashMap<>();
+        names.put("name", "Foo");
+        PhotonDoc doc = new PhotonDoc(1234, "N", 1000, "place", "city").names(names);
+
+        setUpES();
+        Importer instance = new Importer(getClient(), "en");
+        instance.add(doc);
+        instance.finish();
+        refresh();
+
+        names.put("name:en", "Enfoo");
+        Updater updater = new Updater(getClient(), "en,de");
+        updater.updateOrCreate(doc);
+        updater.finish();
+        refresh();
+
+        GetResponse response = getById(1234);
+
+        assertTrue(response.isExists());
+        Map<String, String> out_names = (Map<String, String>) response.getSourceAsMap().get("name");
+        assertEquals("Foo", out_names.get("default"));
+        assertEquals("Enfoo", out_names.get("en"));
+    }
+
+    @Test
+    public void removeNameFromDoc() throws IOException {
+        Map<String, String> names = new HashMap<>();
+        names.put("name", "Foo");
+        names.put("name:en", "Enfoo");
+        PhotonDoc doc = new PhotonDoc(1234, "N", 1000, "place", "city").names(names);
+
+        setUpES();
+        Importer instance = new Importer(getClient(), "en");
+        instance.add(doc);
+        instance.finish();
+        refresh();
+
+        names.remove("name");
+        Updater updater = new Updater(getClient(), "en,de");
+        updater.updateOrCreate(doc);
+        updater.finish();
+        refresh();
+
+        GetResponse response = getById(1234);
+
+        assertTrue(response.isExists());
+        Map<String, String> out_names = (Map<String, String>) response.getSourceAsMap().get("name");
+        //assertFalse(out_names.containsKey("default"));
+        assertEquals("Enfoo", out_names.get("en"));
+    }
+}

--- a/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
@@ -10,9 +10,8 @@ import java.util.*;
 import static org.junit.Assert.*;
 
 public class NominatimResultTest {
-    private final PhotonDoc simpleDoc = new PhotonDoc(10000, "N", 123, "place", "house",
-                                                       new HashMap<>(), null, null, null, null, 0,
-                                            0.0, "de", null, 0, 30);
+    private final PhotonDoc simpleDoc = new PhotonDoc(10000, "N", 123, "place", "house")
+                                                .countryCode("de");
 
     private void assertDocWithHousenumbers(List<String> housenumbers, List<PhotonDoc> docs) {
         assertEquals(housenumbers.size(), docs.size());

--- a/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
@@ -1,15 +1,9 @@
 package de.komoot.photon.query;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.util.Set;
-
 import com.google.common.collect.ImmutableList;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.elasticsearch.Importer;
 import org.elasticsearch.action.search.SearchResponse;
@@ -19,10 +13,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Set;
 
-import de.komoot.photon.ESBaseTester;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Sachin Dole on 2/20/2015.

--- a/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
@@ -5,10 +5,18 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.PrecisionModel;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.elasticsearch.Importer;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -20,6 +28,31 @@ import de.komoot.photon.ESBaseTester;
  * Created by Sachin Dole on 2/20/2015.
  */
 public class PhotonQueryBuilderSearchTest extends ESBaseTester {
+
+    @Before
+    public void setUp() throws Exception {
+        setUpES();
+        ImmutableList<String> tags = ImmutableList.of("tourism", "attraction", "tourism", "hotel", "tourism", "museum", "tourism", "information", "amenity",
+                "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station");
+        Importer instance = new Importer(getClient(), "en");
+        double lon = 13.38886;
+        double lat = 52.51704;
+        for (int i = 0; i < tags.size(); i++) {
+            String key = tags.get(i);
+            String value = tags.get(++i);
+            PhotonDoc doc = this.createDoc(lon, lat, i, i, key, value);
+            instance.add(doc);
+            lon += 0.00004;
+            lat += 0.00086;
+            doc = this.createDoc(lon, lat, i + 1, i + 1, key, value);
+            instance.add(doc);
+            lon += 0.00004;
+            lat += 0.00086;
+        }
+        instance.finish();
+        refresh();
+    }
+
 
     /**
      * Find me all places named "berlin" that are tagged "tourism=attraction"

--- a/src/test/java/de/komoot/photon/searcher/StreetDupesRemoverTest.java
+++ b/src/test/java/de/komoot/photon/searcher/StreetDupesRemoverTest.java
@@ -1,15 +1,12 @@
 package de.komoot.photon.searcher;
 
-import static org.junit.Assert.*;
-
-import java.util.ArrayList;
-import java.util.List;
-
+import de.komoot.photon.Constants;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
-import de.komoot.photon.Constants;
+import java.util.ArrayList;
+import java.util.List;
 
 public class StreetDupesRemoverTest {
 


### PR DESCRIPTION
The Update API merges the given document with an existing one. We need to completely replace the document, which is done via the Index API.

Also adds tests for the case where a name is removed which confirms the issue. To make it easier to write these tests I've changed PhotonDoc to a builder pattern to get rid of the rather uncomfortably long constructor. See separate commits for details.

Fixes #525.