### PR TITLE
Revert "Jts postgis dependencies update"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,95 @@ jobs:
       - name: Compile project, run tests
         run: |
           mvn --no-transfer-progress test
+
+
+  import:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Fetch cached Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: maven-deps
+
+      - name: Compile project
+        run: |
+          mvn --no-transfer-progress package -Dmaven.test.skip=true
+
+      - uses: actions/checkout@v2
+        with:
+          repository: osm-search/Nominatim
+          submodules: true
+          path: Nominatim
+
+      - name: Get Date
+        id: get-date
+        run: |
+            echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+        shell: bash
+
+      - uses: actions/cache@v2
+        with:
+            path: |
+               Nominatim/data/country_grid.sql.gz
+               monaco-latest.osm.pbf
+            key: nominatim-test-data-${{ steps.get-date.outputs.date }}
+
+      - name: Setup database
+        run: |
+            echo 'fsync = off' | sudo tee /etc/postgresql/13/main/conf.d/local.conf
+            echo 'synchronous_commit = off' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
+            echo 'full_page_writes = off' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
+            echo 'shared_buffers = 512MB' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
+            sudo systemctl start postgresql
+            sudo -u postgres createuser -S www-data
+            sudo -u postgres createuser -s runner
+            psql -d postgres -c "ALTER USER runner PASSWORD 'foobar'"
+            psql --version
+            psql -d postgres -c "SELECT version()"
+        shell: bash
+
+      - name: Install prerequisits
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libpq-dev libproj-dev python3-psycopg2 python3-pyosmium python3-dotenv postgresql-server-dev-13 postgresql-13-postgis-3
+        shell: bash
+
+      - name: Download dependencies
+        run: |
+            if [ ! -f Nominatim/data/country_osm_grid.sql.gz ]; then
+                wget --no-verbose -O Nominatim/data/country_osm_grid.sql.gz https://www.nominatim.org/data/country_grid.sql.gz
+            fi
+        shell: bash
+
+      - name: Build Nominatim
+        run: mkdir build && cd build && cmake ../Nominatim && make -j2 && sudo make install
+        shell: bash
+
+      - name: Prepare import environment
+        run: |
+            if [ ! -f monaco-latest.osm.pbf ]; then
+                wget --no-verbose https://download.geofabrik.de/europe/monaco-latest.osm.pbf
+            fi
+            mkdir data-env
+            cd data-env
+        shell: bash
+
+      - name: Import Nominatim
+        run: |
+          nominatim import --osm-file ../monaco-latest.osm.pbf --reverse-only
+          nominatim admin --check-database
+        shell: bash
+        working-directory: data-env
+
+      - name: Import Photon
+        run: |
+            java -jar target/photon-*.jar -nominatim-import -database nominatim -user runner -password foobar

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
             <version>${elasticsearch.version}</version>
+
         </dependency>
         <dependency><!-- required by elasticsearch -->
             <groupId>org.apache.logging.log4j</groupId>
@@ -103,17 +104,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.locationtech.jts/jts -->
         <dependency>
-            <groupId>org.locationtech.jts</groupId>
+            <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
-            <version>1.16.1</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.locationtech.jts</groupId>
-            <artifactId>jts-core</artifactId>
-            <version>1.16.1</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>
@@ -128,7 +122,7 @@
         <dependency>
             <groupId>net.postgis</groupId>
             <artifactId>postgis-jdbc-jtsparser</artifactId>
-            <version>2.5.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -320,7 +314,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-        <compilerArgument>-Xlint:unchecked</compilerArgument>
+
         <elasticsearch.version>5.6.16</elasticsearch.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.8.2</log4j.version>

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -2,9 +2,9 @@ package de.komoot.photon;
 
 import com.google.common.collect.ImmutableMap;
 import com.neovisionaries.i18n.CountryCode;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
 import de.komoot.photon.nominatim.model.AddressType;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -4,7 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.neovisionaries.i18n.CountryCode;
-import org.locationtech.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Envelope;
 import de.komoot.photon.nominatim.model.AddressType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;

--- a/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim;
 
-import org.locationtech.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Geometry;
 
 import javax.annotation.Nullable;
 import java.sql.ResultSet;
@@ -15,6 +15,7 @@ public interface DBDataAdapter {
      * Create a hash map from the given column data.
      */
     Map<String, String> getMap(ResultSet rs, String columnName) throws SQLException;
+
     /**
      * Create a JTS geometry from the given column data.
      */

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim;
 
-import org.locationtech.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Geometry;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressRow;

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -1,10 +1,10 @@
 package de.komoot.photon.nominatim;
 
 import com.google.common.collect.ImmutableList;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.linearref.LengthIndexedLine;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.linearref.LengthIndexedLine;
 import de.komoot.photon.PhotonDoc;
 
 import java.util.ArrayList;

--- a/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim;
 
 import com.google.common.collect.Maps;
-import org.locationtech.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Geometry;
 import org.postgis.jts.JtsGeometry;
 
 import javax.annotation.Nullable;

--- a/src/main/java/de/komoot/photon/query/BoundingBoxParamConverter.java
+++ b/src/main/java/de/komoot/photon/query/BoundingBoxParamConverter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Envelope;
 
 import spark.Request;
 

--- a/src/main/java/de/komoot/photon/query/LocationParamConverter.java
+++ b/src/main/java/de/komoot/photon/query/LocationParamConverter.java
@@ -1,9 +1,9 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.PrecisionModel;
 
 import spark.Request;
 

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -2,8 +2,8 @@ package de.komoot.photon.query;
 
 
 import com.google.common.collect.ImmutableSet;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Point;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery.ScoreMode;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -184,7 +184,9 @@ public class PhotonQueryBuilder {
             Set<String> valuesToInclude = tags.get(tagKey);
             TermQueryBuilder keyQuery = QueryBuilders.termQuery("osm_key", tagKey);
             TermsQueryBuilder valueQuery = QueryBuilders.termsQuery("osm_value", valuesToInclude.toArray(new String[valuesToInclude.size()]));
+
             BoolQueryBuilder includeAndQuery = QueryBuilders.boolQuery().must(keyQuery).mustNot(valueQuery);
+
             termQueries.add(includeAndQuery);
         }
         this.appendIncludeTermQueries(termQueries);
@@ -279,7 +281,7 @@ public class PhotonQueryBuilder {
 
 
     /**
-     * When this method is called, all filters are placed inside their {@link QueryBuilder OR} or {@link QueryBuilder AND} containers and the top level filter
+     * When this method is called, all filters are placed inside their {@link OrQueryBuilder OR} or {@link AndQueryBuilder AND} containers and the top level filter
      * builder is built. Subsequent invocations of this method have no additional effect. Note that after this method is called, calling other methods on this class also
      * have no effect.
      */

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Point;
 
 import java.io.Serializable;
 import java.util.HashMap;

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Point;
 import spark.QueryParamsMap;
 import spark.Request;
 

--- a/src/main/java/de/komoot/photon/query/ReverseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/ReverseQueryBuilder.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Point;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;

--- a/src/main/java/de/komoot/photon/query/ReverseRequest.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Point;
 
 import java.io.Serializable;
 

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Point;
 import spark.Request;
 
 import java.util.Arrays;

--- a/src/main/java/de/komoot/photon/searcher/BaseElasticsearchSearcher.java
+++ b/src/main/java/de/komoot/photon/searcher/BaseElasticsearchSearcher.java
@@ -21,7 +21,7 @@ public class BaseElasticsearchSearcher {
     public SearchResponse search(QueryBuilder queryBuilder, Integer limit) {
         TimeValue timeout = TimeValue.timeValueSeconds(7);
         return client.prepareSearch(PhotonIndex.NAME).
-                setSearchType(SearchType.QUERY_THEN_FETCH).
+                setSearchType(SearchType.QUERY_AND_FETCH).
                 setQuery(queryBuilder).
                 setSize(limit).
                 setTimeout(timeout).

--- a/src/main/java/de/komoot/photon/searcher/ReverseElasticsearchSearcher.java
+++ b/src/main/java/de/komoot/photon/searcher/ReverseElasticsearchSearcher.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.searcher;
 
-import org.locationtech.jts.geom.Point;
+import com.vividsolutions.jts.geom.Point;
 import de.komoot.photon.elasticsearch.PhotonIndex;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -26,7 +26,7 @@ public class ReverseElasticsearchSearcher {
                                  Boolean locationDistanceSort) {
         TimeValue timeout = TimeValue.timeValueSeconds(7);
 
-        SearchRequestBuilder builder = client.prepareSearch(PhotonIndex.NAME).setSearchType(SearchType.QUERY_THEN_FETCH)
+        SearchRequestBuilder builder = client.prepareSearch(PhotonIndex.NAME).setSearchType(SearchType.QUERY_AND_FETCH)
                 .setQuery(queryBuilder).setSize(limit).setTimeout(timeout);
 
         if (locationDistanceSort)

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,10 +1,10 @@
 package de.komoot.photon;
 
 import com.google.common.collect.ImmutableMap;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.PrecisionModel;
 import de.komoot.photon.elasticsearch.PhotonIndex;
 import de.komoot.photon.elasticsearch.Server;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim;
 
-import org.locationtech.jts.io.ParseException;
+import com.vividsolutions.jts.io.ParseException;
 import de.komoot.photon.AssertUtil;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.ReflectionTestUtil;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim;
 
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
 import org.junit.Test;
 

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim.testdb;
 
-import org.locationtech.jts.io.ParseException;
+import com.vividsolutions.jts.io.ParseException;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -1,7 +1,8 @@
 package de.komoot.photon.nominatim.testdb;
 
-import org.locationtech.jts.geom.Geometry;
-
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.nominatim.DBDataAdapter;
 import org.json.JSONObject;
 
@@ -30,7 +31,15 @@ public class H2DataAdapter implements DBDataAdapter {
     @Nullable
     @Override
     public Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException {
-        Geometry geom = (Geometry) rs.getObject(columnName);
-        return geom;
+        String wkt = (String) rs.getObject(columnName);
+        if (wkt != null) {
+            try {
+                return new WKTReader().read(wkt);
+            } catch (ParseException e) {
+                // ignore
+            }
+        }
+
+        return null;
     }
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim.testdb;
 
-import org.locationtech.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Geometry;
 import org.springframework.lang.Nullable;
 
 import java.sql.ResultSet;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim.testdb;
 
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
 import lombok.Getter;
 import org.json.JSONObject;

--- a/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
@@ -231,6 +231,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
     }
 
     private SearchResponse search(Client client, QueryBuilder queryBuilder) {
-        return client.prepareSearch("photon").setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(queryBuilder).execute().actionGet();
+        return client.prepareSearch("photon").setSearchType(SearchType.QUERY_AND_FETCH).setQuery(queryBuilder).execute().actionGet();
     }
 }

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -3,7 +3,7 @@ package de.komoot.photon.query;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.locationtech.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Envelope;
 
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
ElasticSearch pulls the vividsolution version of jts which then conflicts with the one from locationtech. The update needs to wait until we got rid of the netty client.

The PR also adds a full import pipeline to the CI (import OSM data into Nominatim and export it to Photon from there) to catch these kinds of issues.

Fixes #541.