### PR TITLE
added if statement to avoid overwriting existing mapping.json

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -266,7 +266,9 @@ public class Server {
         JSONObject keyObject = properties.optJSONObject(key);
         JSONObject keyProperties = keyObject == null ? null : keyObject.optJSONObject("properties");
         if (keyProperties != null) {
-            keyProperties.put(lang, collectorObject);
+            if (!keyProperties.has(lang)) {
+                keyProperties.put(lang, collectorObject);
+            }
             keyObject.put("properties", keyProperties);
             return properties.put(key, keyObject);
         }


### PR DESCRIPTION
Hi, we were trying to add supporting for Japanese language into Photon in this [feature/adopt-japanese-lang](https://github.com/MIERUNE/photon/tree/feature/adopt-japanese-lang) branch. We have successfully added Japanese support for Photon. During our development, we found a bug in existing code which alway overwrite our mapping.json by default tokenizer.

We added `ja` and `ja_kana` languages into our [mapping.json](https://github.com/MIERUNE/photon/blob/feature/adopt-japanese-lang/es/mappings.json). However, our additional mapping for collector will be always overwritten by the [default mapping](https://github.com/MIERUNE/photon/blob/691331b800096c83cf2b7862fbcab8d5515a60f2/src/main/java/de/komoot/photon/elasticsearch/Server.java#L234-L236) when we use `-languages ja,ja_kana`.

Current source code might not affect the languages from western countries, but it become very difficult to adopt multibyte languages' countries like Japan and China because of this bug.

This is an example when we used `-languages en`.

Current source code overwrote mapping for collector.en like this
```
          "en": {
            "copy_to": [
              "collector.en"
            ],
            "index": false,
            "type": "text",
            "fields": {
              "raw": {
                "analyzer": "index_raw",
                "type": "text"
              },
              "ngrams": {
                "analyzer": "index_ngram",
                "type": "text"
              }
            }
``` 

After fixing this bug, the mapping will be like this, which is the same with `es/mapping.json`
```
          "en": {
            "copy_to": [
              "collector.en"
            ],
            "index": false,
            "type": "text",
            "fields": {
              "raw": {
                "analyzer": "index_raw",
                "type": "text"
              },
              "ngrams": {
                "search_analyzer": "search_ngram",
                "analyzer": "index_ngram",
                "type": "text"
              }
            }
```

You can see current source code overwrote mapping.json for collcter.en

Could you merge this PR into the source code?