### PR TITLE
Bug/Reproduction case: NullPointerException during Photon update after updating Nominatim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
         with:
             path: |
                Nominatim/data/country_grid.sql.gz
-               monaco-latest.osm.pbf
             key: nominatim-test-data-${{ steps.get-date.outputs.date }}
 
       - name: Setup database
@@ -107,8 +106,11 @@ jobs:
 
       - name: Prepare import environment
         run: |
-            if [ ! -f monaco-latest.osm.pbf ]; then
-                wget --no-verbose https://download.geofabrik.de/europe/monaco-latest.osm.pbf
+            # get the first day of the previous month to make sure that there really are updates to apply
+            # Geofabrik stores snapshot from the first of the month for up to 3 month
+            two_months_ago=`date --date="1 months ago" +%y%m01`
+            if [ ! -f monaco.osm.pbf ]; then
+                wget --no-verbose https://download.geofabrik.de/europe/monaco-${two_months_ago}.osm.pbf -O monaco.osm.pbf
             fi
             mkdir data-env
             cd data-env
@@ -116,7 +118,7 @@ jobs:
 
       - name: Import Nominatim
         run: |
-          nominatim import --osm-file ../monaco-latest.osm.pbf --reverse-only
+          nominatim import --osm-file ../monaco.osm.pbf --reverse-only
           nominatim admin --check-database
         shell: bash
         working-directory: data-env
@@ -124,3 +126,14 @@ jobs:
       - name: Import Photon
         run: |
             java -jar target/photon-*.jar -nominatim-import -database nominatim -user runner -password foobar
+
+      - name: Update Nominatim
+        run: |
+          nominatim replication --init
+          nominatim replication --no-index --once
+        shell: bash
+        working-directory: data-env
+
+      - name: Update Photon
+        run: |
+          java -jar target/photon-*.jar -nominatim-update -database nominatim -user runner -password foobar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Continuous Integration"
+name: CI
 
 on:
   push:
@@ -35,6 +35,7 @@ jobs:
 
 
   import:
+    name: Import OSM data from Nominatim into Photon
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,10 @@ jobs:
       - name: Prepare import environment
         run: |
             # get the first day of the previous month to make sure that there really are updates to apply
-            # Geofabrik stores snapshot from the first of the month for up to 3 month
-            two_months_ago=`date --date="1 months ago" +%y%m01`
+            # (Geofabrik stores a snapshot from the first of the month for up to 3 months)
+            first_of_previous_month=`date --date="1 months ago" +%y%m01`
             if [ ! -f monaco.osm.pbf ]; then
-                wget --no-verbose https://download.geofabrik.de/europe/monaco-${two_months_ago}.osm.pbf -O monaco.osm.pbf
+                wget --no-verbose https://download.geofabrik.de/europe/monaco-${first_of_previous_month}.osm.pbf -O monaco.osm.pbf
             fi
             mkdir data-env
             cd data-env


### PR DESCRIPTION
This isn't a PR pre se but rather a reproduction case for my problem: I've noticed that when I tried to continuously update my Photon instance with updates from Nominatim it would fail because an NPE is thrown in `NominatimConnector`.

```
2021-03-31 11:01:26,292 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 1
2021-03-31 11:01:26,730 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 2
2021-03-31 11:01:26,738 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 3
2021-03-31 11:01:26,745 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 4
2021-03-31 11:01:26,751 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 5
2021-03-31 11:01:26,759 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 6
2021-03-31 11:01:26,766 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 7
2021-03-31 11:01:26,774 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 8
2021-03-31 11:01:26,780 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 9
2021-03-31 11:01:26,785 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 10
2021-03-31 11:01:26,794 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 11
2021-03-31 11:01:26,801 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 12
2021-03-31 11:01:26,809 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 13
2021-03-31 11:01:26,815 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 14
2021-03-31 11:01:26,824 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 15
2021-03-31 11:01:26,830 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 16
2021-03-31 11:01:27,602 [main] INFO  de.komoot.photon.nominatim.NominatimUpdater - Starting rank 17
Exception in thread "main" java.lang.NullPointerException
	at de.komoot.photon.nominatim.NominatimConnector.getByPlaceId(NominatimConnector.java:152)
	at de.komoot.photon.nominatim.NominatimUpdater.update(NominatimUpdater.java:69)
	at de.komoot.photon.App.main(App.java:74)
```	

You can see the complete log output here: https://github.com/komoot/photon/pull/556/checks?check_run_id=2236208723

After debugging I can confirm that the document returned by the database template is indeed `null`. I can find the place in the Nominatim database so my speculation is that it has to do with the usefulness check here https://github.com/komoot/photon/commit/3739bcfc5186969c7ddcb83186c35c231ae3a235#diff-c91219b055943ffb8a4b3a5b017c91fc9207ad8fae6a21139e4d4ae5b1151364R80

Rather than just describing the problem, I thought it would be better to also contribute a reproduction case for the CI, so that this can be fixed and _stays_ fixed.

On the other hand, there might also be a problem with the way I'm updating the nominatim database. If this is the case please let me know that the correct way of doing this is.

Many thanks for a great project!