### PR TITLE
Do not drop unnamed housenumber objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Continuous Integration"
+name: CI
 
 on:
   push:
@@ -35,6 +35,7 @@ jobs:
 
 
   import:
+    name: Import OSM data from Nominatim into Photon
     runs-on: ubuntu-20.04
 
     steps:
@@ -107,7 +108,7 @@ jobs:
 
       - name: Prepare import environment
         run: |
-            if [ ! -f monaco-latest.osm.pbf ]; then
+            if [ ! -f monaco.osm.pbf ]; then
                 wget --no-verbose https://download.geofabrik.de/europe/monaco-latest.osm.pbf
             fi
             mkdir data-env
@@ -124,3 +125,16 @@ jobs:
       - name: Import Photon
         run: |
             java -jar target/photon-*.jar -nominatim-import -database nominatim -user runner -password foobar
+
+      - name: Update Nominatim
+        run: |
+          nominatim replication --init
+          nominatim replication --no-index --once
+        shell: bash
+        working-directory: data-env
+        env:
+          NOMINATIM_REPLICATION_MAX_DIFF: 10
+
+      - name: Update Photon
+        run: |
+          java -jar target/photon-*.jar -nominatim-update -database nominatim -user runner -password foobar

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -176,13 +176,9 @@ public class PhotonDoc {
     public boolean isUsefulForIndex() {
         if ("place".equals(tagKey) && "houses".equals(tagValue)) return false;
 
-        if (houseNumber != null) return true;
-
-        if (name.isEmpty()) return false;
-
         if (linkedPlaceId > 0) return false;
 
-        return true;
+        return houseNumber != null || !name.isEmpty();
     }
     
     /**

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -77,10 +77,6 @@ public class NominatimConnector {
                     .rankAddress(rs.getInt("rank_address"))
                     .postcode(rs.getString("postcode"));
 
-            if (!doc.isUsefulForIndex()) {
-                return null;
-            }
-
             double importance = rs.getDouble("importance");
             doc.importance(rs.wasNull() ? (0.75 - rs.getInt("rank_search") / 40d) : importance);
 
@@ -230,8 +226,9 @@ public class NominatimConnector {
                 " ORDER BY geometry_sector; ", rs -> {
                     // turns a placex row into a photon document that gathers all de-normalised information
                     NominatimResult docs = placeRowMapper.mapRow(rs, 0);
+                    assert(docs != null);
 
-                    if (docs != null) {
+                    if (docs.isUsefulForIndex()) {
                         importThread.addDocument(docs);
                     }
                 });
@@ -240,8 +237,9 @@ public class NominatimConnector {
                 whereCountryCodeStr +
                 " ORDER BY geometry_sector; ", rs -> {
                     NominatimResult docs = osmlineRowMapper.mapRow(rs, 0);
+                    assert(docs != null);
 
-                    if (docs != null) {
+                    if (docs.isUsefulForIndex()) {
                         importThread.addDocument(docs);
                     }
                 });

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -181,4 +181,49 @@ public class NominatimConnectorDBTest {
         AssertUtil.assertNoAddress(doc, AddressType.CITY);
         Assert.assertTrue(doc.getContext().contains(munip.getNames()));
     }
+
+    /**
+     * Unnamed objects are imported when they have a housenumber.
+     */
+    @Test
+    public void testUnnamedObjectWithHousenumber() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes").housenumber(123).parent(parent).add(jdbc);
+
+        connector.readEntireDatabase();
+
+        Assert.assertEquals(2, importer.size());
+
+        importer.get(place);
+    }
+
+    /**
+     * Unnamed objects are ignored when they do not have a housenumber.
+     */
+    @Test
+    public void testUnnamedObjectWithOutHousenumber() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes").parent(parent).add(jdbc);
+
+        connector.readEntireDatabase();
+
+        Assert.assertEquals(1, importer.size());
+
+        importer.get(parent);
+    }
+
+    /**
+     * Interpolation lines in placex are ignored.
+     */
+    @Test
+    public void testInterpolationLines() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("place", "houses").name("something").parent(parent).add(jdbc);
+
+        connector.readEntireDatabase();
+
+        Assert.assertEquals(1, importer.size());
+
+        importer.get(parent);
+    }
 }


### PR DESCRIPTION
By moving the usefulness check from the NominatimDoc to the PhotonDoc, objects with only a housenumber but no name got suddenly filtered. This reinstates the previous code, which tested for usefulness before adding the document.

Also fixes #556.