### PR TITLE
Use housenumbers from address when importing from Nominatim

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -73,6 +73,16 @@ class NominatimResult {
         }
     }
 
+    public void addHousenumbersFromAddress(Map<String, String> address) {
+        if (address == null) {
+            return;
+        }
+
+        addHousenumbersFromString(address.get("housenumber"));
+        addHousenumbersFromString(address.get("streetnumber"));
+        addHousenumbersFromString(address.get("conscriptionnumber"));
+    }
+
     public void addHouseNumbersFromInterpolation(long first, long last, String interpoltype, Geometry geom) {
         if (last <= first || (last - first) > 1000)
             return;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -135,7 +135,7 @@ public class NominatimConnectorDBTest {
         PlacexTestRow expect = new PlacexTestRow("place", "house_number").id(osmline.getPlaceId()).parent(street).osm("W", 23);
 
         for (int i = 2; i < 11; ++i) {
-            importer.assertContains(expect.housenumber(i).centroid(0, (i - 1) * 0.1));
+            importer.assertContains(expect.centroid(0, (i - 1) * 0.1), i);
         }
     }
 
@@ -188,15 +188,51 @@ public class NominatimConnectorDBTest {
     @Test
     public void testUnnamedObjectWithHousenumber() {
         PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
-        PlacexTestRow place = new PlacexTestRow("building", "yes").housenumber(123).parent(parent).add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes").addr("housenumber", "123").parent(parent).add(jdbc);
 
         connector.readEntireDatabase();
 
         Assert.assertEquals(2, importer.size());
 
-        importer.get(place);
+        PhotonDoc doc = importer.get(place);
+        Assert.assertEquals(doc.getHouseNumber(), "123");
     }
 
+    /**
+     * Semicolon-separated housenumber lists result in multiple iport objects.
+     */
+    @Test
+    public void testObjectWithHousenumberList() throws ParseException {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes").addr("housenumber", "1;2;3").parent(parent).add(jdbc);
+
+        connector.readEntireDatabase();
+
+        Assert.assertEquals(4, importer.size());
+
+        importer.assertContains(place, 1);
+        importer.assertContains(place, 2);
+        importer.assertContains(place, 3);
+    }
+
+    /**
+     * streetnumbers and conscription numbers are recognised.
+     */
+    @Test
+    public void testObjectWithconscriptionNumber() throws ParseException {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes")
+                .addr("streetnumber", "34")
+                .addr("conscriptionnumber", "99521")
+                .parent(parent).add(jdbc);
+
+        connector.readEntireDatabase();
+
+        Assert.assertEquals(3, importer.size());
+
+        importer.assertContains(place, 34);
+        importer.assertContains(place, 99521);
+    }
     /**
      * Unnamed objects are ignored when they do not have a housenumber.
      */

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -51,8 +51,7 @@ public class CollectingImporter implements Importer {
     public void assertContains(PlacexTestRow row) throws ParseException {
         PhotonDoc doc = null;
         for (PhotonDoc outdoc : docs) {
-            if (outdoc.getPlaceId() == row.getPlaceId()
-                    && (row.getHousenumber() == null || row.getHousenumber().equals(outdoc.getHouseNumber()))) {
+            if (outdoc.getPlaceId() == row.getPlaceId()) {
                 Assert.assertNull("Row is contained multiple times", doc);
                 doc = outdoc;
             }
@@ -62,4 +61,18 @@ public class CollectingImporter implements Importer {
 
         row.assertEquals(doc);
     }
-}
+
+    public void assertContains(PlacexTestRow row, int housenumber) throws ParseException {
+        String hnrstr = Integer.toString(housenumber);
+        PhotonDoc doc = null;
+        for (PhotonDoc outdoc : docs) {
+            if (outdoc.getPlaceId() == row.getPlaceId() && hnrstr.equals(outdoc.getHouseNumber())) {
+                Assert.assertNull("Row is contained multiple times", doc);
+                doc = outdoc;
+            }
+        }
+
+        Assert.assertNotNull("Row not found", doc);
+
+        row.assertEquals(doc);
+    }}

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -22,11 +22,11 @@ public class PlacexTestRow {
     private String key;
     private String value;
     private Map<String, String> names = new HashMap<>();
+    private Map<String, String> address = new HashMap<>();
     private Integer rankAddress = 30;
     private Integer rankSearch = 30;
     private String centroid;
     private String countryCode = "us";
-    private String housenumber = null;
     private Double importance = null;
 
     public PlacexTestRow(String key, String value) {
@@ -77,8 +77,13 @@ public class PlacexTestRow {
         return this;
     }
 
-    public PlacexTestRow housenumber(int nr) {
-        housenumber = Integer.toString(nr);
+    public PlacexTestRow housenumber(int value) {
+        addr("housenumber", Integer.toString(value));
+        return this;
+    }
+
+    public PlacexTestRow addr(String type, String value) {
+        address.put(type, value);
         return this;
     }
 
@@ -109,10 +114,10 @@ public class PlacexTestRow {
 
     public PlacexTestRow add(JdbcTemplate jdbc) {
         jdbc.update("INSERT INTO placex (place_id, parent_place_id, osm_type, osm_id, class, type, rank_search, rank_address,"
-                        + " centroid, name, country_code, importance, housenumber)"
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ?, ?, ?)",
+                        + " centroid, name, country_code, importance, address)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ?, ?, ? FORMAT JSON)",
                 placeId, parentPlaceId, osmType, osmId, key, value, rankSearch, rankAddress, centroid,
-                asJson(names), countryCode, importance, housenumber);
+                asJson(names), countryCode, importance, asJson(address));
 
         return this;
     }


### PR DESCRIPTION
The housenumber field in placex will carry a transliterated version
in the future, so switch to using the terms from the address directly.
Also adds support for conscription numbers.