### PR TITLE
Output importance and score in debug mode

### DIFF
--- a/src/main/java/de/komoot/photon/SearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/SearchRequestHandler.java
@@ -21,8 +21,6 @@ import static spark.Spark.halt;
  * Created by Sachin Dole on 2/12/2015.
  */
 public class SearchRequestHandler extends RouteImpl {
-    private static final String DEBUG_PARAMETER = "debug";
-    
     private final PhotonRequestFactory photonRequestFactory;
     private final PhotonRequestHandler requestHandler;
     private final ConvertToGeoJson geoJsonConverter;
@@ -47,10 +45,10 @@ public class SearchRequestHandler extends RouteImpl {
         }
         List<JSONObject> results = requestHandler.handle(photonRequest);
         JSONObject geoJsonResults = geoJsonConverter.convert(results);
-        if (request.queryParams(DEBUG_PARAMETER) != null) {
+        if (photonRequest.getDebug()) {
             JSONObject debug = new JSONObject();
             debug.put("query", new JSONObject(requestHandler.dumpQuery(photonRequest)));
-            geoJsonResults.put(DEBUG_PARAMETER, debug);
+            geoJsonResults.put("debug", debug);
             return geoJsonResults.toString(4);
         }
 

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -19,6 +19,7 @@ public class PhotonRequest implements Serializable {
     private String language;
     private final double scale;
     private Envelope bbox;
+    private boolean debug;
 
     private Set<String> excludeKeys;
     private Set<String> includeKeys;
@@ -29,13 +30,14 @@ public class PhotonRequest implements Serializable {
     private Map<String, Set<String>> excludeTagValues;
 
 
-    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, String language) {
+    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, String language, boolean debug) {
         this.query = query;
         this.limit = limit;
         this.locationForBias = locationForBias;
         this.scale = scale;
         this.language = language;
         this.bbox = bbox;
+        this.debug = debug;
     }
 
     public String getQuery() {
@@ -61,6 +63,8 @@ public class PhotonRequest implements Serializable {
     public String getLanguage() {
         return language;
     }
+
+    public boolean getDebug() { return debug; }
 
     public Set<String> keys() {
         return includeKeys;

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -57,7 +57,9 @@ public class PhotonRequestFactory {
                 throw new BadRequestException(400, "invalid parameter 'location_bias_scale' must be a number");
             }
 
-        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, language);
+        boolean debug = webRequest.queryParams("debug") != null;
+
+        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, language, debug);
 
         QueryParamsMap tagFiltersQueryMap = webRequest.queryMap("osm_tag");
         if (new CheckIfFilteredRequest().execute(tagFiltersQueryMap)) {

--- a/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
@@ -36,7 +36,7 @@ public class PhotonRequestHandler {
             lastLenient = true;
             results = elasticsearchSearcher.search(buildQuery(photonRequest, true).buildQuery(), extLimit);
         }
-        List<JSONObject> resultJsonObjects = new ConvertToJson(photonRequest.getLanguage()).convert(results);
+        List<JSONObject> resultJsonObjects = new ConvertToJson(photonRequest.getLanguage()).convert(results, photonRequest.getDebug());
         StreetDupesRemover streetDupesRemover = new StreetDupesRemover(photonRequest.getLanguage());
         resultJsonObjects = streetDupesRemover.execute(resultJsonObjects);
         if (resultJsonObjects.size() > limit) {

--- a/src/main/java/de/komoot/photon/searcher/ReverseRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/ReverseRequestHandler.java
@@ -19,7 +19,7 @@ public class ReverseRequestHandler {
         ReverseQueryBuilder queryBuilder = buildQuery(photonRequest);
         SearchResponse results = elasticsearchSearcher.search(queryBuilder.buildQuery(), photonRequest.getLimit(), photonRequest.getLocation(),
                 photonRequest.getLocationDistanceSort());
-        List<JSONObject> resultJsonObjects = new ConvertToJson(photonRequest.getLanguage()).convert(results);
+        List<JSONObject> resultJsonObjects = new ConvertToJson(photonRequest.getLanguage()).convert(results, false);
         if (resultJsonObjects.size() > photonRequest.getLimit()) {
             resultJsonObjects = resultJsonObjects.subList(0, photonRequest.getLimit());
         }

--- a/src/main/java/de/komoot/photon/utils/ConvertToJson.java
+++ b/src/main/java/de/komoot/photon/utils/ConvertToJson.java
@@ -27,13 +27,17 @@ public class ConvertToJson {
         this.lang = lang;
     }
 
-    public List<JSONObject> convert(SearchResponse searchResponse) {
+    public List<JSONObject> convert(SearchResponse searchResponse, boolean debugMode) {
         SearchHit[] hits = searchResponse.getHits().getHits();
         final List<JSONObject> list = Lists.newArrayListWithExpectedSize(hits.length);
         for (SearchHit hit : hits) {
             final Map<String, Object> source = hit.getSource();
 
             final JSONObject feature = new JSONObject();
+            if (debugMode) {
+                feature.put("score", hit.getScore());
+                feature.put("importance", source.get("importance"));
+            }
             feature.put(Constants.TYPE, Constants.FEATURE);
             feature.put(Constants.GEOMETRY, getPoint(source));
 

--- a/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class PhotonRequestTest {
 
     private PhotonRequest simpleRequest() {
-        return new PhotonRequest("foo", 1, null, null, 1.6, "de");
+        return new PhotonRequest("foo", 1, null, null, 1.6, "de", false);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -46,7 +46,7 @@ public class ConvertToJsonTest extends ESBaseTester {
 
         SearchResponse response = databaseFromDoc(new PhotonDoc(1234, "N", 1000, "place", "city").extraTags(extratags));
 
-        List<JSONObject> json = new ConvertToJson("de").convert(response);
+        List<JSONObject> json = new ConvertToJson("de").convert(response, false);
 
         JSONObject extra = json.get(0).getJSONObject("properties").getJSONObject("extra");
 
@@ -60,7 +60,7 @@ public class ConvertToJsonTest extends ESBaseTester {
     public void testConvertWithoutExtraTags() throws IOException {
         SearchResponse response = databaseFromDoc(new PhotonDoc(1234, "N", 1000, "place", "city"));
 
-        List<JSONObject> json = new ConvertToJson("de").convert(response);
+        List<JSONObject> json = new ConvertToJson("de").convert(response, false);
 
         assertNull(json.get(0).getJSONObject("properties").optJSONObject("extra"));
     }


### PR DESCRIPTION
When the parameter `debug` is given, add fields for importance and score. This is useful for debugging the query scoring mechanism.

Works for search only.