### PR TITLE
Experimental: simple synonym list

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -65,7 +65,7 @@ public class App {
 
             // Working on an existing installation.
             // Update the index settings in case there are any changes.
-            esServer.updateIndexSettings();
+            esServer.updateIndexSettings(args.getSynonymFile());
             esClient.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
 
             if (args.isNominatimUpdate()) {

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -35,6 +35,9 @@ public class CommandLineArgs {
     @Parameter(names = "-extra-tags", description = "additional tags to save for each place")
     private String extraTags = "";
 
+    @Parameter(names = "-synonym-file", description = "list of synonyms to apply at query time")
+    private  String synonymFile = null;
+
     @Parameter(names = "-json", description = "import nominatim database and dump it to a json like files in (useful for developing)")
     private String jsonDump = null;
 

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
@@ -72,7 +72,7 @@ public class IndexSettings {
             if (line.indexOf(' ') >= 0) {
                 throw new RuntimeException("Synonym list must not contain any spaces or multi word terms.");
             }
-            synonyms.put(line);
+            synonyms.put(line.toLowerCase());
         }
 
         JSONObject filters = (JSONObject) settings.optQuery("/analysis/filter");

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
@@ -2,9 +2,13 @@ package de.komoot.photon.elasticsearch;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -42,6 +46,45 @@ public class IndexSettings {
     }
 
     /**
+     * Add query-time synonyms to the search analyzer.
+     *
+     * Synonyms need to be supplied in a simple text file with one synonym entry per line.
+     * Synonyms need to be comma-separated. Only single-term synonyms are supported at this
+     * time. Spaces in the synonym list are considered a syntax error.
+     *
+     * @param synonymFile File containing the synonyms.
+     *
+     * @return This object for chaining.
+     */
+    public IndexSettings setSynonyms(String synonymFile) throws IOException {
+        if (synonymFile == null) {
+            return this;
+        }
+
+        insertJsonArrayAfter(settings, "/analysis/analyzer/search_ngram/filter", "lowercase", "extra_synonyms");
+        insertJsonArrayAfter(settings, "/analysis/analyzer/search_raw/filter", "lowercase", "extra_synonyms");
+
+        BufferedReader br = new BufferedReader(new FileReader(synonymFile));
+
+        JSONArray synonyms = new JSONArray();
+        String line;
+        while ((line = br.readLine()) != null) {
+            if (line.indexOf(' ') >= 0) {
+                throw new RuntimeException("Synonym list must not contain any spaces or multi word terms.");
+            }
+            synonyms.put(line);
+        }
+
+        JSONObject filters = (JSONObject) settings.optQuery("/analysis/filter");
+        if (filters == null) {
+            throw new RuntimeException("Analyser update: cannot find filter definition");
+        }
+        filters.put("extra_synonyms", new JSONObject().put("type", "synonym").put("synonyms", synonyms));
+
+        return this;
+    }
+
+    /**
      * Create a new index using the current index settings.
      *
      * @param client Client connection to use for creating the index.
@@ -64,5 +107,30 @@ public class IndexSettings {
         client.admin().indices().prepareClose(PhotonIndex.NAME).execute().actionGet();
         client.admin().indices().prepareUpdateSettings(PhotonIndex.NAME).setSettings(settings.toString(), XContentType.JSON).execute().actionGet();
         client.admin().indices().prepareOpen(PhotonIndex.NAME).execute().actionGet();
+    }
+
+    /**
+     * Insert the given value into the array after the string given by positionString.
+     * If the position string is not found, throws a runtime error.
+     *
+     * @param obj            JSON object to insert into.
+     * @param jsonPointer    Path description of the array to insert into.
+     * @param positionString Marker string after which to insert.
+     * @param value          Value to insert.
+     */
+    private void insertJsonArrayAfter(JSONObject obj, String jsonPointer, String positionString, String value) {
+        JSONArray array = (JSONArray) obj.optQuery(jsonPointer);
+        if (array == null) {
+            throw new RuntimeException("Analyser update: cannot find JSON array at" + jsonPointer);
+        }
+
+        for (int i = 0; i < array.length(); i++) {
+            if (positionString.equals(array.getString(i))) {
+                array.put(i + 1, value);
+                return;
+            }
+        }
+
+        throw new RuntimeException("Analyser update: cannot find position string " + positionString);
     }
 }

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -178,14 +178,14 @@ public class Server {
         return dbProperties;
     }
 
-    public void updateIndexSettings() {
+    public void updateIndexSettings(String synonymFile) throws IOException {
         // Load the settings from the database to make sure it is at the right
         // version. If the version is wrong, we should not be messing with the
         // index.
         DatabaseProperties dbProperties = new DatabaseProperties();
         dbProperties.loadFromDatabase(getClient());
 
-        loadIndexSettings().updateIndex(getClient(), PhotonIndex.NAME);
+        loadIndexSettings().setSynonyms(synonymFile).updateIndex(getClient(), PhotonIndex.NAME);
 
         // Sanity check: legacy databases don't save the languages, so there is no way to update
         //               the mappings consistently.


### PR DESCRIPTION
This adds a new command-line parameter `-synonym-file` which can be used to experiment with applying synonyms at query time. The synonym list is loaded when Photon is started. It is not necessary to reindex the existing database and will work against our precomputed database dumps.

The synonym file must be a simple text file. Each line contains a comma-separated list of mutual synonyms. Only single word
synonyms are allowed. To that end, the loader will reject any synonym file that contains spaces.

This PR is unlikely to make it into master as is. I just thought I put it out in public in case somebody else wants to experiment with using synonyms.

@hbruch 