### PR TITLE
Introduce global persistent database properties

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -56,12 +56,6 @@ public class App {
             esClient.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
             log.info("ES cluster is now ready.");
 
-            if (args.isRecreateIndex()) {
-                shutdownES = true;
-                startRecreatingIndex(esServer, args);
-                return;
-            }
-
             if (args.isNominatimImport()) {
                 shutdownES = true;
                 startNominatimImport(args, esServer, esClient);
@@ -80,22 +74,6 @@ public class App {
         } finally {
             if (shutdownES) esServer.shutdown();
         }
-    }
-
-
-    /**
-     * dump elastic search index and create a new and empty one
-     *
-     * @param esServer
-     */
-    private static void startRecreatingIndex(Server esServer, CommandLineArgs args) {
-        try {
-            esServer.recreateIndex(args.getLanguages().split(","));
-        } catch (IOException e) {
-            throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
-        }
-
-        log.info("deleted photon index and created an empty new one.");
     }
 
 

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -48,7 +48,7 @@ public class App {
         }
 
         boolean shutdownES = false;
-        final Server esServer = new Server(args).start();
+        final Server esServer = new Server(args.getDataDirectory()).start(args.getCluster(), args.getTransportAddresses());
         try {
             Client esClient = esServer.getClient();
 
@@ -58,7 +58,7 @@ public class App {
 
             if (args.isRecreateIndex()) {
                 shutdownES = true;
-                startRecreatingIndex(esServer);
+                startRecreatingIndex(esServer, args);
                 return;
             }
 
@@ -88,9 +88,9 @@ public class App {
      *
      * @param esServer
      */
-    private static void startRecreatingIndex(Server esServer) {
+    private static void startRecreatingIndex(Server esServer, CommandLineArgs args) {
         try {
-            esServer.recreateIndex();
+            esServer.recreateIndex(args.getLanguages().split(","));
         } catch (IOException e) {
             throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
         }
@@ -127,7 +127,7 @@ public class App {
      */
     private static void startNominatimImport(CommandLineArgs args, Server esServer, Client esNodeClient) {
         try {
-            esServer.recreateIndex(); // dump previous data
+            esServer.recreateIndex(args.getLanguages().split(",")); // dump previous data
         } catch (IOException e) {
             throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
         }

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -24,7 +24,7 @@ public class CommandLineArgs {
     private boolean nominatimUpdate = false;
 
     @Parameter(names = "-languages", description = "languages nominatim importer should import and use at run-time, comma separated (default is 'en,fr,de,it')")
-    private String languages = "en,fr,de,it";
+    private String languages = "";
 
     @Parameter(names = "-default-language", description = "language to return results in when no explicit language is choosen by the user")
     private String defaultLanguage = "default";

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -38,9 +38,6 @@ public class CommandLineArgs {
     @Parameter(names = "-json", description = "import nominatim database and dump it to a json like files in (useful for developing)")
     private String jsonDump = null;
 
-    @Parameter(names = "-recreate-index", description = "delete index and all documents, creates a new and empty photon index")
-    private boolean recreateIndex = false;
-
     @Parameter(names = "-host", description = "postgres host (default 127.0.0.1)")
     private String host = "127.0.0.1";
 

--- a/src/main/java/de/komoot/photon/ReverseSearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/ReverseSearchRequestHandler.java
@@ -25,9 +25,9 @@ public class ReverseSearchRequestHandler extends RouteImpl {
     private final ReverseRequestHandler requestHandler;
     private final ConvertToGeoJson geoJsonConverter;
 
-    ReverseSearchRequestHandler(String path, Client esNodeClient, String languages, String defaultLanguage) {
+    ReverseSearchRequestHandler(String path, Client esNodeClient, String[] languages, String defaultLanguage) {
         super(path);
-        List<String> supportedLanguages = Arrays.asList(languages.split(","));
+        List<String> supportedLanguages = Arrays.asList(languages);
         this.reverseRequestFactory = new ReverseRequestFactory(supportedLanguages, defaultLanguage);
         this.geoJsonConverter = new ConvertToGeoJson();
         this.requestHandler = new ReverseRequestHandler(new ReverseElasticsearchSearcher(esNodeClient));

--- a/src/main/java/de/komoot/photon/SearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/SearchRequestHandler.java
@@ -25,9 +25,9 @@ public class SearchRequestHandler extends RouteImpl {
     private final PhotonRequestHandler requestHandler;
     private final ConvertToGeoJson geoJsonConverter;
 
-    SearchRequestHandler(String path, Client esNodeClient, String languages, String defaultLanguage) {
+    SearchRequestHandler(String path, Client esNodeClient, String[] languages, String defaultLanguage) {
         super(path);
-        List<String> supportedLanguages = Arrays.asList(languages.split(","));
+        List<String> supportedLanguages = Arrays.asList(languages);
         this.photonRequestFactory = new PhotonRequestFactory(supportedLanguages, defaultLanguage);
         this.geoJsonConverter = new ConvertToGeoJson();
         this.requestHandler = new PhotonRequestHandler(new BaseElasticsearchSearcher(esNodeClient), supportedLanguages);

--- a/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
@@ -5,7 +5,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.*;
@@ -63,23 +62,23 @@ public class DatabaseProperties {
      *
      * @param languageList Comma-separated list of two-letter language codes.
      */
-    public void restrictLanguges(String languageList) {
+    public void restrictLanguages(String[] languageList) {
         if (languages == null) {
             // Special case for versions that did not yet have a language list set
             // in the database: Use the given list as is.
-            languages = languageList.split(",");
+            languages = languageList;
         } else {
             Set<String> currentLanguageSet = new HashSet<>(Arrays.asList(languages));
             List<String> newLanguageList = new ArrayList<>();
 
-            for (String lang : languageList.split(",")) {
+            for (String lang : languageList) {
                 if (currentLanguageSet.contains(lang)) {
                     newLanguageList.add(lang);
                 }
             }
 
             if (newLanguageList.isEmpty()) {
-                throw new RuntimeException("Language list '" + languageList +
+                throw new RuntimeException("Language list '" + languageList.toString() +
                         "not compatible with languages in database(" + languages.toString() + ")");
             }
 

--- a/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
@@ -1,0 +1,142 @@
+package de.komoot.photon.elasticsearch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Class responsible for loading and saving database global properties.
+ *
+ * The properties are saved in a separate document in the Photon index that does not contain
+ * any indexed data.
+ */
+@Slf4j
+public class DatabaseProperties {
+    /**
+     * Database version created by new imports with the current code.
+     *
+     * Format must be: major.minor.patch-dev
+     *
+     * Increase to next to be released version when the database layout
+     * changes in an incompatible way. If it is alredy at the next released
+     * version, increase the dev version.
+     */
+    private static final String DATABASE_VERSION = "0.3.4-0";
+    public static final String PROPERTY_DOCUMENT_ID = "DATABASE_PROPERTIES";
+
+    private static final String BASE_FIELD = "document_properties";
+    private static final String FIELD_VERSION = "database_version";
+    private static final String FIELD_LANGUAGES = "indexed_languages";
+
+    private String[] languages = null;
+
+    /**
+     * Return the list of languages for which the database is configured.
+     * @return
+     */
+    public String[] getLanguages() {
+        return languages;
+    }
+
+    /**
+     * Replace the language list with the given list.
+     *
+     * @param languages Array of two-letter language codes.
+     *
+     * @return This object for chaining.
+     */
+    public DatabaseProperties setLanguages(String[] languages) {
+        this.languages = languages;
+        return this;
+    }
+
+    /**
+     * Set language list to the intersection between the existing list and the given list.
+     *
+     * The final list will use the same order as the given list.
+     *
+     * @param languageList Comma-separated list of two-letter language codes.
+     */
+    public void restrictLanguges(String languageList) {
+        if (languages == null) {
+            // Special case for versions that did not yet have a language list set
+            // in the database: Use the given list as is.
+            languages = languageList.split(",");
+        } else {
+            Set<String> currentLanguageSet = new HashSet<>(Arrays.asList(languages));
+            List<String> newLanguageList = new ArrayList<>();
+
+            for (String lang : languageList.split(",")) {
+                if (currentLanguageSet.contains(lang)) {
+                    newLanguageList.add(lang);
+                }
+            }
+
+            if (newLanguageList.isEmpty()) {
+                throw new RuntimeException("Language list '" + languageList +
+                        "not compatible with languages in database(" + languages.toString() + ")");
+            }
+
+            languages = newLanguageList.toArray(new String[]{});
+        }
+    }
+
+    /**
+     * Save the global properties to the database.
+     *
+     * The function saved properties available as members and the database version
+     * as currently defined in DATABASE_VERSION.
+     */
+    public void saveToDatabase(Client client) throws IOException  {
+        final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(BASE_FIELD)
+                        .field(FIELD_VERSION, DATABASE_VERSION)
+                        .field(FIELD_LANGUAGES, String.join(",", languages))
+                        .endObject().endObject();
+
+        client.prepareIndex(PhotonIndex.NAME, PhotonIndex.TYPE).
+                    setSource(builder).setId(PROPERTY_DOCUMENT_ID).execute().actionGet();
+    }
+
+    /**
+     * Load the global properties from the database.
+     *
+     * The function first loads the database version and throws an exception if it does not correspond
+     * to the version as defined in DATABASE_VERSION.
+     *
+     * Currently does nothing when the property entry is missing. Later versions with a higher
+     * database version will then fail.
+     */
+    public void loadFromDatabase(Client client) {
+        GetResponse response = client.prepareGet(PhotonIndex.NAME, PhotonIndex.TYPE, PROPERTY_DOCUMENT_ID).execute().actionGet();
+
+        // We are currently at the database version where versioning was introduced.
+        if (!response.isExists()) {
+            return;
+        }
+
+        Map<String, String> properties = (Map<String, String>) response.getSource().get(BASE_FIELD);
+
+        if (properties == null) {
+            throw new RuntimeException("Found database properties but no '" + BASE_FIELD +"' field. Database corrupt?");
+        }
+
+        String version = properties.getOrDefault(FIELD_VERSION, "");
+        if (!DATABASE_VERSION.equals(version)) {
+            log.error("Database has incompatible version '" + version + "'. Expected: " + DATABASE_VERSION);
+            throw new RuntimeException("Incompatible database.");
+        }
+
+        String langString = properties.get(FIELD_LANGUAGES);
+        if (langString == null) {
+            languages = null;
+        } else {
+            languages = langString.split(",");
+        }
+    }
+}

--- a/src/main/java/de/komoot/photon/elasticsearch/Importer.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Importer.java
@@ -23,10 +23,10 @@ public class Importer implements de.komoot.photon.Importer {
     private final String[] languages;
     private final String[] extraTags;
 
-    public Importer(Client esClient, String languages, String extraTags) {
+    public Importer(Client esClient, String[] languages, String extraTags) {
         this.esClient = esClient;
         this.bulkRequest = esClient.prepareBulk();
-        this.languages = languages.split(",");
+        this.languages = languages;
         this.extraTags = extraTags.split(",");
     }
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -163,7 +163,7 @@ public class Server {
 
     }
 
-    public void recreateIndex(String[] languages) throws IOException {
+    public DatabaseProperties recreateIndex(String[] languages) throws IOException {
         deleteIndex();
 
         final Client client = this.getClient();
@@ -187,6 +187,11 @@ public class Server {
 
         client.admin().indices().preparePutMapping(PhotonIndex.NAME).setType(PhotonIndex.TYPE).setSource(mappingsJSON.toString(), XContentType.JSON).execute().actionGet();
         log.info("mapping created: " + mappingsJSON.toString());
+
+        DatabaseProperties dbProperties = new DatabaseProperties().setLanguages(languages);
+        dbProperties.saveToDatabase(client);
+
+        return dbProperties;
     }
 
     public void deleteIndex() {

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -49,7 +49,6 @@ public class Server {
     private File esDirectory;
 
     private final String[] languages;
-    private String[] extraTags = new String[0];
 
     private String transportAddresses;
 
@@ -63,9 +62,6 @@ public class Server {
 
     public Server(CommandLineArgs args) {
         this(args.getCluster(), args.getDataDirectory(), args.getLanguages(), args.getTransportAddresses());
-        if (args.getExtraTags().length() > 0) {
-            this.extraTags = args.getExtraTags().split(",");
-        }
     }
 
     public Server(String clusterName, String mainDirectory, String languages, String transportAddresses) {

--- a/src/main/java/de/komoot/photon/elasticsearch/Updater.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Updater.java
@@ -21,10 +21,10 @@ public class Updater implements de.komoot.photon.Updater {
     private final String[] languages;
     private final String[] extraTags;
 
-    public Updater(Client esClient, String languages, String extraTags) {
+    public Updater(Client esClient, String[] languages, String extraTags) {
         this.esClient = esClient;
         this.bulkRequest = esClient.prepareBulk();
-        this.languages = languages.split(",");
+        this.languages = languages;
         this.extraTags = extraTags.split(",");
     }
 

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -37,7 +37,6 @@ public class ApiIntegrationTest extends ESBaseTester {
     public void shutdown() {
         stop();
         awaitStop();
-        deleteIndex();
     }
 
     /**

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -26,7 +26,7 @@ public class ApiIntegrationTest extends ESBaseTester {
     @Before
     public void setUp() throws Exception {
         setUpES();
-        Importer instance = new Importer(getClient(), "en", "");
+        Importer instance = makeImporter();
         instance.add(createDoc(13.38886, 52.51704, 1000, 1000, "place", "city"));
         instance.add(createDoc(13.39026, 52.54714, 1001, 1001, "place", "town"));
         instance.finish();

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -50,9 +50,9 @@ public class ESBaseTester {
      * @throws IOException
      */
     public void setUpES() throws IOException {
-        server = new Server(TEST_CLUSTER_NAME, new File("./target/es_photon_test").getAbsolutePath(), "en", "").setMaxShards(1).start();
+        server = new Server(new File("./target/es_photon_test").getAbsolutePath()).setMaxShards(1).start(TEST_CLUSTER_NAME, "");
         deleteIndex(); // just in case of an abnormal abort previously
-        server.recreateIndex();
+        server.recreateIndex(new String[]{"en"});
         refresh();
     }
 

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -43,6 +43,7 @@ public class ESBaseTester {
 
     @After
     public void tearDown() {
+        deleteIndex();
         shutdownES();
     }
 

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -5,8 +5,10 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.PrecisionModel;
+import de.komoot.photon.elasticsearch.Importer;
 import de.komoot.photon.elasticsearch.PhotonIndex;
 import de.komoot.photon.elasticsearch.Server;
+import de.komoot.photon.elasticsearch.Updater;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -54,6 +56,22 @@ public class ESBaseTester {
         deleteIndex(); // just in case of an abnormal abort previously
         server.recreateIndex(new String[]{"en"});
         refresh();
+    }
+
+    protected Importer makeImporter() {
+        return new Importer(getClient(), new String[]{"en"}, "");
+    }
+
+    protected Importer makeImporterWithExtra(String extraTags) {
+        return new Importer(getClient(), new String[]{"en"}, extraTags);
+    }
+
+    protected Updater makeUpdater() {
+        return new Updater(getClient(), new String[]{"en"}, "");
+    }
+
+    protected Updater makeUpdaterWithExtra(String extraTags) {
+        return new Updater(getClient(), new String[]{"en"}, extraTags);
     }
 
     protected Client getClient() {

--- a/src/test/java/de/komoot/photon/elasticsearch/DatabasePropertiesTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/DatabasePropertiesTest.java
@@ -1,0 +1,69 @@
+package de.komoot.photon.elasticsearch;
+
+import de.komoot.photon.ESBaseTester;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the database-global property store.
+ */
+public class DatabasePropertiesTest extends ESBaseTester {
+
+    /**
+     * setLanguages() overwrites the language settings.
+     */
+    @Test
+    public void testSetLanguages() {
+        DatabaseProperties prop = new DatabaseProperties();
+
+        prop.setLanguages(new String[]{"en", "bg", "de"});
+        assertArrayEquals(new String[]{"en", "bg", "de"}, prop.getLanguages());
+
+        prop.setLanguages(new String[]{"ru"});
+        assertArrayEquals(new String[]{"ru"}, prop.getLanguages());
+    }
+
+    /**
+     * If languages is not set, then the restricted language set is used as is.
+     */
+    @Test
+    public void testRestrictLanguagesUnsetLanguages() {
+        DatabaseProperties prop = new DatabaseProperties();
+        prop.restrictLanguages(new String[]{"en", "bg", "de"});
+
+        assertArrayEquals(new String[]{"en", "bg", "de"}, prop.getLanguages());
+    }
+
+    /**
+     * When languages are set, then only the languages of the restricted set are used
+     * that already exist and the order of the input is preserved.
+     */
+    @Test
+    public void testRestrictLanguagesAlreadySet() {
+        DatabaseProperties prop = new DatabaseProperties();
+        prop.setLanguages(new String[]{"en", "de", "fr"});
+
+        prop.restrictLanguages(new String[]{"cn", "de", "en", "es"});
+
+        assertArrayEquals(new String[]{"de", "en"}, prop.getLanguages());
+    }
+
+    @Test
+    public void testSaveAndLoadFromDatabase() throws IOException {
+        setUpES();
+
+        DatabaseProperties prop = new DatabaseProperties();
+        prop.setLanguages(new String[]{"en", "de", "fr"});
+        prop.saveToDatabase(getClient());
+
+        prop = new DatabaseProperties();
+        prop.loadFromDatabase(getClient());
+
+        assertArrayEquals(new String[]{"en", "de", "fr"}, prop.getLanguages());
+
+
+    }
+}

--- a/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
@@ -21,12 +21,6 @@ public class ImporterTest extends ESBaseTester {
         setUpES();
     }
 
-    @After
-    public void tearDown() {
-        deleteIndex();
-        shutdownES();
-    }
-
     @Test
     public void testAddSimpleDoc() {
         Importer instance = makeImporterWithExtra("");

--- a/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
@@ -4,6 +4,7 @@ import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import org.elasticsearch.action.get.GetResponse;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -15,6 +16,11 @@ import static org.junit.Assert.*;
 
 public class ImporterTest extends ESBaseTester {
 
+    @Before
+    public void setUp() throws IOException {
+        setUpES();
+    }
+
     @After
     public void tearDown() {
         deleteIndex();
@@ -22,9 +28,9 @@ public class ImporterTest extends ESBaseTester {
     }
 
     @Test
-    public void testAddSimpleDoc() throws IOException {
-        setUpES();
-        Importer instance = new Importer(getClient(), "en", "");
+    public void testAddSimpleDoc() {
+        Importer instance = makeImporterWithExtra("");
+
         instance.add(new PhotonDoc(1234, "N", 1000, "place", "city")
                 .extraTags(Collections.singletonMap("maxspeed", "100")));
         instance.finish();
@@ -45,9 +51,8 @@ public class ImporterTest extends ESBaseTester {
     }
 
     @Test
-    public void testSelectedExtraTagsCanBeIncluded() throws IOException {
-        setUpES();
-        Importer instance = new Importer(getClient(), "en", "maxspeed,website");
+    public void testSelectedExtraTagsCanBeIncluded() {
+        Importer instance = makeImporterWithExtra("maxspeed,website");
 
         Map<String, String> extratags = new HashMap<>();
         extratags.put("website", "foo");

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -29,13 +29,13 @@ public class UpdaterTest extends ESBaseTester {
         PhotonDoc doc = new PhotonDoc(1234, "N", 1000, "place", "city").names(names);
 
         setUpES();
-        Importer instance = new Importer(getClient(), "en", "");
+        Importer instance = makeImporter();
         instance.add(doc);
         instance.finish();
         refresh();
 
         names.put("name:en", "Enfoo");
-        Updater updater = new Updater(getClient(), "en,de", "");
+        Updater updater = makeUpdater();
         updater.create(doc);
         updater.finish();
         refresh();
@@ -56,13 +56,13 @@ public class UpdaterTest extends ESBaseTester {
         PhotonDoc doc = new PhotonDoc(1234, "N", 1000, "place", "city").names(names);
 
         setUpES();
-        Importer instance = new Importer(getClient(), "en", "");
+        Importer instance = makeImporter();
         instance.add(doc);
         instance.finish();
         refresh();
 
         names.remove("name");
-        Updater updater = new Updater(getClient(), "en,de", "");
+        Updater updater = makeUpdater();
         updater.create(doc);
         updater.finish();
         refresh();
@@ -82,7 +82,7 @@ public class UpdaterTest extends ESBaseTester {
         PhotonDoc doc = new PhotonDoc(1234, "N", 1000, "place", "city").names(names);
 
         setUpES();
-        Importer instance = new Importer(getClient(), "en", "website");
+        Importer instance = makeImporterWithExtra("website");
         instance.add(doc);
         instance.finish();
         refresh();
@@ -93,7 +93,7 @@ public class UpdaterTest extends ESBaseTester {
         assertNull(response.getSource().get("extra"));
 
         doc.extraTags(Collections.singletonMap("website", "http://site.foo"));
-        Updater updater = new Updater(getClient(), "en,de", "website");
+        Updater updater = makeUpdaterWithExtra("website");
         updater.create(doc);
         updater.finish();
         refresh();

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -15,13 +15,6 @@ import static org.junit.Assert.*;
 
 public class UpdaterTest extends ESBaseTester {
 
-    @After
-    public void tearDown() {
-        deleteIndex();
-        shutdownES();
-    }
-
-
     @Test
     public void addNameToDoc() throws IOException {
         Map<String, String> names = new HashMap<>();

--- a/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
@@ -30,7 +30,7 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         setUpES();
         ImmutableList<String> tags = ImmutableList.of("tourism", "attraction", "tourism", "hotel", "tourism", "museum", "tourism", "information", "amenity",
                 "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station");
-        Importer instance = new Importer(getClient(), "en", "");
+        Importer instance = makeImporter();
         double lon = 13.38886;
         double lat = 52.51704;
         for (int i = 0; i < tags.size(); i++) {

--- a/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonQueryBuilderSearchTest.java
@@ -63,8 +63,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(2l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -77,8 +75,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(2l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -91,8 +87,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(8l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -106,8 +100,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(16l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -120,8 +112,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(12l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -134,8 +124,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(10l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -151,8 +139,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(6l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -169,8 +155,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(6l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -183,8 +167,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(4l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -199,8 +181,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(8l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -213,8 +193,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(4l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     /**
@@ -228,8 +206,6 @@ public class PhotonQueryBuilderSearchTest extends ESBaseTester {
         QueryBuilder queryBuilder = tagFilterQueryBuilder.buildQuery();
         SearchResponse searchResponse = search(client, queryBuilder);
         assertEquals(16l, searchResponse.getHits().getTotalHits());
-
-        deleteIndex();
     }
 
     private SearchResponse search(Client client, QueryBuilder queryBuilder) {

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -2,7 +2,9 @@ package de.komoot.photon.utils;
 
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.elasticsearch.DatabaseProperties;
 import de.komoot.photon.elasticsearch.Importer;
+import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -16,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class ConvertToJsonTest extends ESBaseTester {
 
     @After
@@ -33,7 +36,8 @@ public class ConvertToJsonTest extends ESBaseTester {
 
         return getClient().prepareSearch("photon")
                 .setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setQuery(QueryBuilders.matchAllQuery())
+                .setQuery(QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery())
+                        .filter(QueryBuilders.boolQuery().mustNot(QueryBuilders.idsQuery().addIds(DatabaseProperties.PROPERTY_DOCUMENT_ID))))
                 .execute()
                 .actionGet();
     }
@@ -46,6 +50,7 @@ public class ConvertToJsonTest extends ESBaseTester {
 
         SearchResponse response = databaseFromDoc(new PhotonDoc(1234, "N", 1000, "place", "city").extraTags(extratags));
 
+        log.warn(response.toString());
         List<JSONObject> json = new ConvertToJson("de").convert(response, false);
 
         JSONObject extra = json.get(0).getJSONObject("properties").getJSONObject("extra");

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
 public class ConvertToJsonTest extends ESBaseTester {
 
     @After
@@ -29,7 +28,7 @@ public class ConvertToJsonTest extends ESBaseTester {
 
     private SearchResponse databaseFromDoc(PhotonDoc doc) throws IOException {
         setUpES();
-        Importer instance = new Importer(getClient(), "en", "maxspeed,website");
+        Importer instance = makeImporterWithExtra("maxspeed,website");
         instance.add(doc);
         instance.finish();
         refresh();
@@ -50,7 +49,6 @@ public class ConvertToJsonTest extends ESBaseTester {
 
         SearchResponse response = databaseFromDoc(new PhotonDoc(1234, "N", 1000, "place", "city").extraTags(extratags));
 
-        log.warn(response.toString());
         List<JSONObject> json = new ConvertToJson("de").convert(response, false);
 
         JSONObject extra = json.get(0).getJSONObject("properties").getJSONObject("extra");

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -20,12 +20,6 @@ import java.util.Map;
 
 public class ConvertToJsonTest extends ESBaseTester {
 
-    @After
-    public void tearDown() {
-        deleteIndex();
-        shutdownES();
-    }
-
     private SearchResponse databaseFromDoc(PhotonDoc doc) throws IOException {
         setUpES();
         Importer instance = makeImporterWithExtra("maxspeed,website");


### PR DESCRIPTION
With this change import settings can be saved in the database and retrieved at update time and when running the server. The settings are saved in a document with a special ID in an non-indexed field. They can only be retrieved via the ID or matchAll(). Currently two properties are saved: database version and language settings.

With the database version it is now possible to check that the right version of Photon is used against the database. If we have incompatible changes to the mapping schema in the future then Photon will refuse to run when software version and database version do not match.

The language settings are saved so that it is no longer necessary to supply the '-language' parameter each time Photon is started in server mode. The server will simply use the settings from the import. '-language' can still be used to reduce the set of available languages. It is no longer possible to add a language that was not imported. When running updates from the command line then the '-language' parameter is ignored completely and the database setting used.

This PR also removes the `-recreate-index' command line option. It is not very useful anymore as the import will always start with wiping the database now. If somebody was still using this command, please shout.