### PR TITLE
Update index mappings and settings on startup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,3 +27,21 @@ it should be simple to match:
  * Unix line endings (should be handled via git)
 
 And in case we didn't emphasize it enough: we love tests!
+
+## Changes to mapping and index settings
+
+It is possible to change the mapping layout or index settings any time as
+long as they are compatible with the current layout. Photon reapplies the
+mapping and index settings on startup to make sure it conforms to the latest
+code.
+
+**Warning:** the kind of modifications that can be done on an existing
+index are limited. Always test if your modifications are compatible by importing
+a database with the version before your changes and then running Photon with
+the version with your changes applied.
+
+If the mappings or the settings are changed in an incompatible way that
+requires a reimport, then you must increase the database version in
+`src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java`.
+For major/minor/patch always use the version of the next release. If the
+version number already points to the next release, increase the dev-version.

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -63,6 +63,11 @@ public class App {
                 return;
             }
 
+            // Working on an existing installation.
+            // Update the index settings in case there are any changes.
+            esServer.updateIndexSettings();
+            esClient.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
+
             if (args.isNominatimUpdate()) {
                 shutdownES = true;
                 final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, esClient);

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
@@ -1,0 +1,101 @@
+package de.komoot.photon.elasticsearch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.InputStream;
+
+/**
+ * Encapsulates the ES index mapping for the photon index.
+ */
+@Slf4j
+public class IndexMapping {
+    private final JSONObject mappings;
+
+    /**
+     * Create a new settings object and initialize it with the index settings
+     * from the resources.
+     */
+    public IndexMapping() {
+        final InputStream indexSettings = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("mappings.json");
+
+        mappings = new JSONObject(new JSONTokener(indexSettings));
+    }
+
+    public void putMapping(Client client, String indexName, String indexType) {
+        client.admin().indices().preparePutMapping(indexName)
+                .setType(indexType)
+                .setSource(mappings.toString(), XContentType.JSON)
+                .execute()
+                .actionGet();
+    }
+
+
+    public IndexMapping addLanguages(String[] languages) {
+        // define collector json strings
+        String copyToCollectorString = "{\"type\":\"text\",\"index\":false,\"copy_to\":[\"collector.{lang}\"]}";
+        String nameToCollectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
+        String collectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}}},\"street\":{\"type\":\"object\",\"properties\":{\"default\":{\"text\":false,\"type\":\"text\",\"copy_to\":[\"collector.default\"]}";
+
+        JSONObject placeObject = mappings.optJSONObject("place");
+        JSONObject propertiesObject = placeObject == null ? null : placeObject.optJSONObject("properties");
+
+        if (propertiesObject == null) {
+            log.error("cannot add languages to mapping.json, please double-check the mappings.json or the language values supplied");
+            return this;
+        }
+
+        for (String lang : languages) {
+            // create lang-specific json objects
+            JSONObject copyToCollectorObject = new JSONObject(copyToCollectorString.replace("{lang}", lang));
+            JSONObject nameToCollectorObject = new JSONObject(nameToCollectorString.replace("{lang}", lang));
+            JSONObject collectorObject = new JSONObject(collectorString.replace("{lang}", lang));
+
+            // add language specific tags to the collector
+            addToCollector("city", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("context", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("country", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("state", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("street", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("district", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("name", propertiesObject, nameToCollectorObject, lang);
+
+            // add language specific collector to default for name
+            JSONObject name = propertiesObject.optJSONObject("name");
+            JSONObject nameProperties = name == null ? null : name.optJSONObject("properties");
+            if (nameProperties != null) {
+                JSONObject defaultObject = nameProperties.optJSONObject("default");
+                JSONArray copyToArray = defaultObject.optJSONArray("copy_to");
+                copyToArray.put("name." + lang);
+
+                defaultObject.put("copy_to", copyToArray);
+                nameProperties.put("default", defaultObject);
+                name.put("properties", nameProperties);
+                propertiesObject.put("name", name);
+            }
+
+            // add language specific collector
+            addToCollector("collector", propertiesObject, collectorObject, lang);
+        }
+
+        return this;
+    }
+
+    private void addToCollector(String key, JSONObject properties, JSONObject collectorObject, String lang) {
+        JSONObject keyObject = properties.optJSONObject(key);
+        JSONObject keyProperties = keyObject == null ? null : keyObject.optJSONObject("properties");
+        if (keyProperties != null) {
+            if (!keyProperties.has(lang)) {
+                keyProperties.put(lang, collectorObject);
+            }
+            keyObject.put("properties", keyProperties);
+            properties.put(key, keyObject);
+        }
+    }
+}

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
@@ -1,0 +1,68 @@
+package de.komoot.photon.elasticsearch;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.InputStream;
+
+/**
+ * Encapsulates the ES index settings for the photon index. Adds functions to
+ * manipulate and apply the settings.
+ *
+ */
+public class IndexSettings {
+    private final JSONObject settings;
+
+    /**
+     * Create a new settings object and initialize it with the index settings
+     * from the resources.
+     */
+    public IndexSettings() {
+        final InputStream indexSettings = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("index_settings.json");
+
+        settings = new JSONObject(new JSONTokener(indexSettings));
+    }
+
+    /**
+     * Set the number of shards to use for the index.
+     *
+     * @param numShards Number of shards to use.
+     *
+     * @return Return this object for chaining.
+     */
+    public IndexSettings setShards(Integer numShards) {
+        if (numShards != null) {
+            settings.put("index", new JSONObject().put("number_of_shards", numShards));
+        }
+
+        return this;
+    }
+
+    /**
+     * Create a new index using the current index settings.
+     *
+     * @param client Client connection to use for creating the index.
+     * @param indexName Name of the new index
+     */
+    public void createIndex(Client client, String indexName) {
+        client.admin().indices().prepareCreate(indexName)
+                .setSettings(settings.toString(), XContentType.JSON)
+                .execute()
+                .actionGet();
+    }
+
+    /**
+     * Update the index settings for an existing index.
+     *
+     * @param client Client connection to use for creating the index.
+     * @param indexName Name of the index to update
+     */
+    public void updateIndex(Client client, String indexName) {
+        client.admin().indices().prepareClose(PhotonIndex.NAME).execute().actionGet();
+        client.admin().indices().prepareUpdateSettings(PhotonIndex.NAME).setSettings(settings.toString(), XContentType.JSON).execute().actionGet();
+        client.admin().indices().prepareOpen(PhotonIndex.NAME).execute().actionGet();
+    }
+}

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -167,22 +167,10 @@ public class Server {
         deleteIndex();
 
         final Client client = this.getClient();
-        final InputStream mappings = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("mappings.json");
-        final InputStream indexSettings = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("index_settings.json");
-        final Charset utf8Charset = Charset.forName("utf-8");
-
-        String mappingsString = IOUtils.toString(mappings, utf8Charset);
-        JSONObject mappingsJSON = new JSONObject(mappingsString);
-
-        // add all langs to the mapping
-        addLangsToMapping(mappingsJSON, languages);
 
         loadIndexSettings().createIndex(client, PhotonIndex.NAME);
 
-        client.admin().indices().preparePutMapping(PhotonIndex.NAME).setType(PhotonIndex.TYPE).setSource(mappingsJSON.toString(), XContentType.JSON).execute().actionGet();
-        log.info("mapping created: " + mappingsJSON.toString());
+        new IndexMapping().addLanguages(languages).putMapping(client, PhotonIndex.NAME, PhotonIndex.TYPE);
 
         DatabaseProperties dbProperties = new DatabaseProperties().setLanguages(languages);
         dbProperties.saveToDatabase(client);
@@ -194,8 +182,11 @@ public class Server {
         // Load the settings from the database to make sure it is at the right
         // version. If the version is wrong, we should not be messing with the
         // index.
-        new DatabaseProperties().loadFromDatabase(getClient());
+        DatabaseProperties dbProperties = new DatabaseProperties();
+        dbProperties.loadFromDatabase(getClient());
+
         loadIndexSettings().updateIndex(getClient(), PhotonIndex.NAME);
+        new IndexMapping().addLanguages(dbProperties.getLanguages()).putMapping(getClient(), PhotonIndex.NAME, PhotonIndex.TYPE);
     }
 
     private IndexSettings loadIndexSettings() {
@@ -210,70 +201,6 @@ public class Server {
         }
     }
 
-    private void addLangsToMapping(JSONObject mappingsObject, String[] languages) {
-        // define collector json strings
-        String copyToCollectorString = "{\"type\":\"text\",\"index\":false,\"copy_to\":[\"collector.{lang}\"]}";
-        String nameToCollectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
-        String collectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}}},\"street\":{\"type\":\"object\",\"properties\":{\"default\":{\"text\":false,\"type\":\"text\",\"copy_to\":[\"collector.default\"]}";
-
-        JSONObject placeObject = mappingsObject.optJSONObject("place");
-        JSONObject propertiesObject = placeObject == null ? null : placeObject.optJSONObject("properties");
-
-        if (propertiesObject == null) {
-            log.error("cannot add languages to mapping.json, please double-check the mappings.json or the language values supplied");
-            return;
-        }
-
-        for (String lang : languages) {
-            // create lang-specific json objects
-            JSONObject copyToCollectorObject = new JSONObject(copyToCollectorString.replace("{lang}", lang));
-            JSONObject nameToCollectorObject = new JSONObject(nameToCollectorString.replace("{lang}", lang));
-            JSONObject collectorObject = new JSONObject(collectorString.replace("{lang}", lang));
-
-            // add language specific tags to the collector
-            propertiesObject = addToCollector("city", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("context", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("country", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("state", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("street", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("district", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("locality", propertiesObject, copyToCollectorObject, lang);
-            propertiesObject = addToCollector("name", propertiesObject, nameToCollectorObject, lang);
-
-            // add language specific collector to default for name
-            JSONObject name = propertiesObject.optJSONObject("name");
-            JSONObject nameProperties = name == null ? null : name.optJSONObject("properties");
-            if (nameProperties != null) {
-                JSONObject defaultObject = nameProperties.optJSONObject("default");
-                JSONArray copyToArray = defaultObject.optJSONArray("copy_to");
-                copyToArray.put("name." + lang);
-
-                defaultObject.put("copy_to", copyToArray);
-                nameProperties.put("default", defaultObject);
-                name.put("properties", nameProperties);
-                propertiesObject.put("name", name);
-            }
-
-            // add language specific collector
-            propertiesObject = addToCollector("collector", propertiesObject, collectorObject, lang);
-        }
-
-        placeObject.put("properties", propertiesObject);
-        mappingsObject.put("place", placeObject);
-    }
-
-    private JSONObject addToCollector(String key, JSONObject properties, JSONObject collectorObject, String lang) {
-        JSONObject keyObject = properties.optJSONObject(key);
-        JSONObject keyProperties = keyObject == null ? null : keyObject.optJSONObject("properties");
-        if (keyProperties != null) {
-            if (!keyProperties.has(lang)) {
-                keyProperties.put(lang, collectorObject);
-            }
-            keyObject.put("properties", keyProperties);
-            return properties.put(key, keyObject);
-        }
-        return properties;
-    }
 
     /**
      * Set the maximum number of shards for the embedded node

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -186,7 +186,14 @@ public class Server {
         dbProperties.loadFromDatabase(getClient());
 
         loadIndexSettings().updateIndex(getClient(), PhotonIndex.NAME);
-        new IndexMapping().addLanguages(dbProperties.getLanguages()).putMapping(getClient(), PhotonIndex.NAME, PhotonIndex.TYPE);
+
+        // Sanity check: legacy databases don't save the languages, so there is no way to update
+        //               the mappings consistently.
+        if (dbProperties.getLanguages() != null) {
+            new IndexMapping()
+                    .addLanguages(dbProperties.getLanguages())
+                    .putMapping(getClient(), PhotonIndex.NAME, PhotonIndex.TYPE);
+        }
     }
 
     private IndexSettings loadIndexSettings() {

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -47,15 +47,18 @@ public class ESBaseTester {
         shutdownES();
     }
 
+    public void setUpES() throws IOException {
+        setUpES("en");
+    }
     /**
      * Setup the ES server
      *
      * @throws IOException
      */
-    public void setUpES() throws IOException {
+    public void setUpES(String... languages) throws IOException {
         server = new Server(new File("./target/es_photon_test").getAbsolutePath()).setMaxShards(1).start(TEST_CLUSTER_NAME, "");
         deleteIndex(); // just in case of an abnormal abort previously
-        server.recreateIndex(new String[]{"en"});
+        server.recreateIndex(languages);
         refresh();
     }
 
@@ -65,6 +68,10 @@ public class ESBaseTester {
 
     protected Importer makeImporterWithExtra(String extraTags) {
         return new Importer(getClient(), new String[]{"en"}, extraTags);
+    }
+
+    protected Importer makeImporterWithLanguages(String... languages) {
+        return new Importer(getClient(), languages, "");
     }
 
     protected Updater makeUpdater() {

--- a/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
@@ -1,0 +1,68 @@
+package de.komoot.photon.query;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.elasticsearch.Importer;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Tests for queries in different languages.
+ */
+public class QueryByLanguageTest extends ESBaseTester {
+    private int testDocId = 10001;
+    private List<String> languageList;
+
+    private Importer setup(String... languages) throws IOException {
+        languageList = Arrays.asList(languages);
+        setUpES(languages);
+        return makeImporterWithLanguages(languages);
+    }
+
+    private PhotonDoc createDoc(String... names) {
+        Map<String, String> nameMap = new HashMap<>();
+
+        for (int i = 0; i < names.length - 1; i += 2) {
+            nameMap.put(names[i], names[i+1]);
+        }
+
+        ++testDocId;
+        return new PhotonDoc(testDocId, "W", testDocId, "place", "city").names(nameMap);
+    }
+
+    private SearchResponse search(String query, String lang) {
+        QueryBuilder builder = PhotonQueryBuilder.builder(query, lang, languageList, false).buildQuery();
+        return getClient().prepareSearch("photon")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setQuery(builder)
+                .execute()
+                .actionGet();
+    }
+
+    @Test
+    public void queryNonStandardLanguages() throws IOException {
+        Importer instance = setup("en", "fi");
+
+        instance.add(createDoc("name", "original", "name:fi", "finish", "name:ru", "russian"));
+
+        instance.finish();
+        refresh();
+
+        assertEquals(1, search("original", "en").getHits().getTotalHits());
+        assertEquals(1, search("finish", "en").getHits().getTotalHits());
+        assertEquals(0, search("russian", "en").getHits().getTotalHits());
+
+        float enScore = search("finish", "en").getHits().getHits()[0].getScore();
+        float fiScore = search("finish", "fi").getHits().getHits()[0].getScore();
+
+        assertTrue(fiScore > enScore);
+    }
+
+}

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -4,7 +4,6 @@ import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.elasticsearch.DatabaseProperties;
 import de.komoot.photon.elasticsearch.Importer;
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;


### PR DESCRIPTION
Now that there is some versioning of the database, we can safely update the index settings and mappings on startup of the Photon server. This allows to use the same database dump for different versions of Photon that might use different search analyzers. The synonym analyser in #581 already applied a similar tactics.

I've added some hints for developers in CONTRIBUTING.md how to handle settings and mapping changes.