### PR TITLE
Cleanup language sections in mappings

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -12,63 +12,17 @@
 		"properties": {
 			"city": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
 						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
-						]
 					}
 				}
 			},
 			"collector": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"analyzer": "index_ngram",
@@ -78,98 +32,16 @@
 								"analyzer": "index_raw"
 							}
 						}
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.it"
-						]
 					}
 				}
 			},
 			"context": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
@@ -179,39 +51,11 @@
 			},
 			"country": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
@@ -247,24 +91,6 @@
 							"collector.default"
 						]
 					},
-					"de": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
@@ -274,42 +100,6 @@
 							"name.de",
 							"name.fr",
 							"name.it"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.fr"
 						]
 					},
 					"int": {
@@ -323,24 +113,6 @@
 						},
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "index_ngram",
-								"search_analyzer": "search_ngram"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "index_raw"
-							}
-						},
-						"copy_to": [
-							"collector.it"
 						]
 					},
 					"loc": {
@@ -425,195 +197,55 @@
 			},
 			"state": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
 			},
 			"street": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
 			},
 			"district": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
 			},
 	  		"locality": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}
 			},
 			"county": {
 				"properties": {
-					"de": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.de"
-						]
-					},
 					"default": {
 						"type": "text",
 						"index": false,
 						"copy_to": [
 							"collector.default"
-						]
-					},
-					"en": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.en"
-						]
-					},
-					"fr": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.fr"
-						]
-					},
-					"it": {
-						"type": "text",
-						"index": false,
-						"copy_to": [
-							"collector.it"
 						]
 					}
 				}

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
@@ -40,7 +40,7 @@ public class IndexMapping {
         // define collector json strings
         String copyToCollectorString = "{\"type\":\"text\",\"index\":false,\"copy_to\":[\"collector.{lang}\"]}";
         String nameToCollectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
-        String collectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}}},\"street\":{\"type\":\"object\",\"properties\":{\"default\":{\"text\":false,\"type\":\"text\",\"copy_to\":[\"collector.default\"]}";
+        String collectorString = "{\"type\":\"text\",\"index\":false,\"fields\":{\"ngrams\":{\"type\":\"text\",\"analyzer\":\"index_ngram\"},\"raw\":{\"type\":\"text\",\"analyzer\":\"index_raw\"}},\"copy_to\":[\"collector.{lang}\"]}";
 
         JSONObject placeObject = mappings.optJSONObject("place");
         JSONObject propertiesObject = placeObject == null ? null : placeObject.optJSONObject("properties");
@@ -73,11 +73,6 @@ public class IndexMapping {
                 JSONObject defaultObject = nameProperties.optJSONObject("default");
                 JSONArray copyToArray = defaultObject.optJSONArray("copy_to");
                 copyToArray.put("name." + lang);
-
-                defaultObject.put("copy_to", copyToArray);
-                nameProperties.put("default", defaultObject);
-                name.put("properties", nameProperties);
-                propertiesObject.put("name", name);
             }
 
             // add language specific collector
@@ -90,12 +85,8 @@ public class IndexMapping {
     private void addToCollector(String key, JSONObject properties, JSONObject collectorObject, String lang) {
         JSONObject keyObject = properties.optJSONObject(key);
         JSONObject keyProperties = keyObject == null ? null : keyObject.optJSONObject("properties");
-        if (keyProperties != null) {
-            if (!keyProperties.has(lang)) {
-                keyProperties.put(lang, collectorObject);
-            }
-            keyObject.put("properties", keyProperties);
-            properties.put(key, keyObject);
+        if (keyProperties != null && !keyProperties.has(lang)) {
+            keyProperties.put(lang, collectorObject);
         }
     }
 }


### PR DESCRIPTION
* Removes unnecessary assignments in the language patch code.
* Removes all language-specific mappings from the general `es/mappings.json`. Having the mappings for some languages there and others added created on the fly simply asks for inconsistency. Also makes the mapping file 60% shorter.

It is still possible to add back language-specific mappings for `collector` and `name`, when we need special analysers for them as in #563.