### PR TITLE
Synonym list + classification terms

### DIFF
--- a/docs/synonyms.md
+++ b/docs/synonyms.md
@@ -1,0 +1,83 @@
+# Using Synonyms and Classification Terms
+
+Photon has built-in support for using custom query-time synonyms and
+special phrases for searching a place by its type. This document explains
+how to configure this feature.
+
+## Configuration
+
+Synonyms and classification terms are configured with a JSON file which can
+be added to a Photon server instance using the command line parameter
+`-synonym-file`. Synonyms are a run-time feature. Handing in a synonym list
+at import time has no effect. The list of synonyms in use can simply be
+changed by restarting the Photon server with a different synonym list (or
+not at all, if you want to completely disable the feature again).
+
+Here is a simple example of a synonym configuration file:
+
+```
+{
+  "search_synonyms": [
+    "first,1st",
+    "second,2nd"
+  ],
+  "classification_terms": [
+    {
+      "key": "aeroway",
+      "value": "aerodrome",
+      "terms": ["airport", "airfield"]
+    },
+    {
+      "key": "railway",
+      "value": "station",
+      "terms": ["station"]
+    }
+  ]
+}
+```
+
+The file has two main sections: `search_synonyms` allows for simple synonym
+replacements in the query. `classification_term` defines descriptive terms
+for a OSM key/value pair.
+
+## Synonyms
+
+The `search_synonyms` section must contain a list of synonym replacements.
+Each entry contains a comma-separated of terms that may be replaced with each
+other in the query. Only single-word terms are allowed. That means the terms
+must neither contain spaces nor hyphens or the like.[^1]
+
+[^1] This is a restriction of ElasticSearch 5. Synonym replacement does not
+     create correct term positions when multi-word synonyms are involved.
+
+## Classification Terms
+
+The second section `classification_terms` defines a list of OSM key/value
+pairs with their descriptive terms. `place` and `building` may not be used as
+keys. Neither will `highway=residential` nor `highway=unclassified` work.
+There may be multiple entries for the same key/value pair (for example,
+if you have extra entries for each supported language).
+
+The classification terms can help improve search when the type of an object
+is used in the query but does not appear in the name. For example, with the
+configuration given above a query of "Berlin Station" will find a railway
+station which in OpenStreetMap has the name "Berlin" and also one with
+the name "Berlin Hauptbahnhof".
+
+Classification terms do not enable searching for objects of a certain type.
+"Station London" will not get you all railway stations in London but a
+railway station _named_ London.
+
+## Usage Advice
+
+Use synonyms and classification terms sparingly and only if you can be
+reasonably sure that they will target the intended part of the address.
+Short or frequent terms can have unexpected side-effects and worsen the
+search results. For example, it might sound like a good idea to use synonyms
+to handle the abbreviation from 'Saint' to 'St'. The problem here is that
+'St' is also used as an abbreviation for 'Street'. So all searches that
+involve a 'Street' will suddenly also search for places containing 'Saint'.
+
+Do not create synonyms for terms that are used as classification terms.
+Photon will not complain but again there might be unintended side effects.
+

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -61,6 +61,12 @@
 					"lowercase",
 					"preserving_word_delimiter"],
 				"tokenizer": "standard" 
+			},
+			"search_classification": {
+				"filter": [
+					"lowercase"
+				],
+				"tokenizer": "whitespace"
 			}
 		},
 		"tokenizer": {

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -76,6 +76,15 @@
 			"importance": {
 				"type": "float"
 			},
+			"classification": {
+				"type": "text",
+				"index": "true",
+				"analyzer": "keyword",
+				"search_analyzer": "search_classification",
+				"copy_to": [
+					"collector.default"
+				]
+			},
 			"name": {
 				"properties": {
 					"alt": {

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -65,7 +65,7 @@ public class App {
 
             // Working on an existing installation.
             // Update the index settings in case there are any changes.
-            esServer.updateIndexSettings();
+            esServer.updateIndexSettings(args.getSynonymFile());
             esClient.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
 
             if (args.isNominatimUpdate()) {

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -35,6 +35,9 @@ public class CommandLineArgs {
     @Parameter(names = "-extra-tags", description = "additional tags to save for each place")
     private String extraTags = "";
 
+    @Parameter(names = "-synonym-file", description = "file with synonym and classification terms")
+    private String synonymFile = null;
+
     @Parameter(names = "-json", description = "import nominatim database and dump it to a json like files in (useful for developing)")
     private String jsonDump = null;
 

--- a/src/main/java/de/komoot/photon/Constants.java
+++ b/src/main/java/de/komoot/photon/Constants.java
@@ -31,4 +31,5 @@ public class Constants {
     public static final String OSM_KEY = "osm_key";
     public static final String OSM_VALUE = "osm_value";
     public static final String OBJECT_TYPE = "object_type";
+    public static final String CLASSIFICATION = "classification";
 }

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -33,6 +33,11 @@ public class Utils {
                 .field(Constants.OBJECT_TYPE, atype == null ? "locality" : atype.getName())
                 .field(Constants.IMPORTANCE, doc.getImportance());
 
+        String classification = buildClassificationString(doc.getTagKey(), doc.getTagValue());
+        if (classification != null) {
+            builder.field(Constants.CLASSIFICATION, classification);
+        }
+
         if (doc.getCentroid() != null) {
             builder.startObject("coordinate")
                     .field("lat", doc.getCentroid().getY())
@@ -199,5 +204,27 @@ public class Utils {
             }
         }
         return sb.toString();
+    }
+
+    public static String buildClassificationString(String key, String value) {
+        if ("place".equals(key) || "building".equals(key)) {
+            return null;
+        }
+
+        if ("highway".equals(key)
+            && ("unclassified".equals(value) || "residential".equals(value))) {
+            return null;
+        }
+
+        for (char c : value.toCharArray()) {
+            if (!(c == '_'
+                  || ((c >= 'a') && (c <= 'z'))
+                  || ((c >= 'A') && (c <= 'Z'))
+                  || ((c >= '0') && (c <= '9')))) {
+                return null;
+            }
+        }
+
+        return "tpfld" + value.replaceAll("_", "").toLowerCase() + "clsfld" + key.replaceAll("_", "").toLowerCase();
     }
 }

--- a/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/DatabaseProperties.java
@@ -26,7 +26,7 @@ public class DatabaseProperties {
      * changes in an incompatible way. If it is alredy at the next released
      * version, increase the dev version.
      */
-    private static final String DATABASE_VERSION = "0.3.4-0";
+    private static final String DATABASE_VERSION = "0.3.6-0";
     public static final String PROPERTY_DOCUMENT_ID = "DATABASE_PROPERTIES";
 
     private static final String BASE_FIELD = "document_properties";

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
@@ -95,6 +95,9 @@ public class IndexSettings {
                 JSONArray jsonTerms = descr.getJSONArray("terms");
                 for (int j = 0; j < jsonTerms.length(); j++) {
                     String term = jsonTerms.getString(j).toLowerCase().trim();
+                    if (term.indexOf(' ') >= 0) {
+                        throw new RuntimeException("Syntax error in synonym file: only single word classification terms allowed.");
+                    }
 
                     if (term.length() > 1) {
                         collector.computeIfAbsent(term, k -> new HashSet<>()).add(classString);

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexSettings.java
@@ -112,6 +112,7 @@ public class IndexSettings {
             synonyms.put(term + " => " + term + "," + String.join(",", classificators)));
 
         insertSynonymFilter("classification_synonyms", synonyms);
+        insertJsonArrayAfter("/analysis/analyzer/search_classification", "filter", "lowercase", "classification_synonyms");
 
         return this;
     }

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -1,13 +1,11 @@
 package de.komoot.photon.elasticsearch;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.node.InternalSettingsPreparer;
 import org.elasticsearch.node.Node;
@@ -15,16 +13,12 @@ import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -178,14 +172,14 @@ public class Server {
         return dbProperties;
     }
 
-    public void updateIndexSettings() {
+    public void updateIndexSettings(String synonymFile) throws IOException {
         // Load the settings from the database to make sure it is at the right
         // version. If the version is wrong, we should not be messing with the
         // index.
         DatabaseProperties dbProperties = new DatabaseProperties();
         dbProperties.loadFromDatabase(getClient());
 
-        loadIndexSettings().updateIndex(getClient(), PhotonIndex.NAME);
+        loadIndexSettings().setSynonymFile(synonymFile).updateIndex(getClient(), PhotonIndex.NAME);
 
         // Sanity check: legacy databases don't save the languages, so there is no way to update
         //               the mappings consistently.

--- a/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
@@ -2,10 +2,14 @@ package de.komoot.photon.query;
 
 import com.google.common.collect.ImmutableMap;
 import de.komoot.photon.*;
+import de.komoot.photon.elasticsearch.IndexSettings;
+import de.komoot.photon.elasticsearch.PhotonIndex;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,8 +27,8 @@ public class QueryByClassificationTest extends ESBaseTester {
         setUpES();
     }
 
-    private PhotonDoc createDoc(String key, String value) {
-       ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "curliflower");
+    private PhotonDoc createDoc(String key, String value, String name) {
+       ImmutableMap<String, String> nameMap = ImmutableMap.of("name", name);
 
         ++testDocId;
         return new PhotonDoc(testDocId, "W", testDocId, key, value).names(nameMap);
@@ -42,7 +46,7 @@ public class QueryByClassificationTest extends ESBaseTester {
     @Test
     public void testQueryByClassificationString() {
         Importer instance = makeImporter();
-        instance.add(createDoc("amenity", "restaurant"));
+        instance.add(createDoc("amenity", "restaurant", "curliflower"));
         instance.finish();
         refresh();
 
@@ -51,12 +55,65 @@ public class QueryByClassificationTest extends ESBaseTester {
         assertNotNull(class_term);
 
         GetResponse response = getById(testDocId);
-
         String classification = (String) response.getSource().get(Constants.CLASSIFICATION);
         assertEquals(classification, class_term);
 
         SearchResponse result = search(class_term + " curli");
 
+        assertTrue(result.getHits().getTotalHits() > 0);
+        assertEquals(Integer.toString(testDocId), result.getHits().getHits()[0].getId());
+    }
+
+    @Test
+    public void testQueryByClassificationSynonym() {
+        Importer instance = makeImporter();
+        instance.add(createDoc("amenity", "restaurant", "curliflower"));
+        instance.finish();
+        refresh();
+
+        JSONArray terms = new JSONArray()
+                .put(new JSONObject()
+                        .put("key", "amenity")
+                        .put("value", "restaurant")
+                        .put("terms", new JSONArray().put("pub").put("kneipe"))
+                );
+        new IndexSettings().setClassificationTerms(terms).updateIndex(getClient(), PhotonIndex.NAME);
+        getClient().admin().cluster().prepareHealth().setWaitForYellowStatus().get();
+
+        SearchResponse result = search("pub curli");
+        assertTrue(result.getHits().getTotalHits() > 0);
+        assertEquals(Integer.toString(testDocId), result.getHits().getHits()[0].getId());
+
+
+        result = search("curliflower kneipe");
+        assertTrue(result.getHits().getTotalHits() > 0);
+        assertEquals(Integer.toString(testDocId), result.getHits().getHits()[0].getId());
+    }
+
+
+    @Test
+    public void testSynonymDoNotInterfereWithWords() {
+        Importer instance = makeImporter();
+        instance.add(createDoc("amenity", "restaurant", "airport"));
+        instance.add(createDoc("aeroway", "terminal", "Houston"));
+        instance.finish();
+        refresh();
+
+        JSONArray terms = new JSONArray()
+                .put(new JSONObject()
+                        .put("key", "aeroway")
+                        .put("value", "terminal")
+                        .put("terms", new JSONArray().put("airport"))
+                );
+        new IndexSettings().setClassificationTerms(terms).updateIndex(getClient(), PhotonIndex.NAME);
+        getClient().admin().cluster().prepareHealth().setWaitForYellowStatus().get();
+
+        SearchResponse result = search("airport");
+        assertTrue(result.getHits().getTotalHits() > 0);
+        assertEquals(Integer.toString(testDocId - 1), result.getHits().getHits()[0].getId());
+
+
+        result = search("airport houston");
         assertTrue(result.getHits().getTotalHits() > 0);
         assertEquals(Integer.toString(testDocId), result.getHits().getHits()[0].getId());
     }

--- a/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
@@ -1,0 +1,63 @@
+package de.komoot.photon.query;
+
+import com.google.common.collect.ImmutableMap;
+import de.komoot.photon.*;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+
+public class QueryByClassificationTest extends ESBaseTester {
+    private int testDocId = 10000;
+
+    @Before
+    public void setup() throws IOException {
+        setUpES();
+    }
+
+    private PhotonDoc createDoc(String key, String value) {
+       ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "curliflower");
+
+        ++testDocId;
+        return new PhotonDoc(testDocId, "W", testDocId, key, value).names(nameMap);
+    }
+
+    private SearchResponse search(String query) {
+        QueryBuilder builder = PhotonQueryBuilder.builder(query, "en", Collections.singletonList("en"), false).buildQuery();
+        return getClient().prepareSearch("photon")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setQuery(builder)
+                .execute()
+                .actionGet();
+    }
+
+    @Test
+    public void testQueryByClassificationString() {
+        Importer instance = makeImporter();
+        instance.add(createDoc("amenity", "restaurant"));
+        instance.finish();
+        refresh();
+
+        String class_term = Utils.buildClassificationString("amenity", "restaurant");
+
+        assertNotNull(class_term);
+
+        GetResponse response = getById(testDocId);
+
+        String classification = (String) response.getSource().get(Constants.CLASSIFICATION);
+        assertEquals(classification, class_term);
+
+        SearchResponse result = search(class_term + " curli");
+
+        assertTrue(result.getHits().getTotalHits() > 0);
+        assertEquals(Integer.toString(testDocId), result.getHits().getHits()[0].getId());
+    }
+}


### PR DESCRIPTION
This PR extends #581 and adds classification terms. The classification terms enable searches where the descriptive term of the place is given in addition to the name ('London airport', 'Louvre museum', ...).  Like synonyms, the classification terms are restricted to single word terms. This is a restriction in the synonym module of ES5. See `docs/synonyms.md` for more information on the new format of the synonym file.

Classification terms work by adding a cryptic term that is derived from the OSM key and value and usually does not interfere with any other search terms. The cryptic term is added to the collector and then we define synonyms from the actual classification terms to the cryptic term. This means that we can stay with a single query and have ES decide if a term should be interpreted as a classification term or as part of a name. It also means that classification terms can be changed on an existing database, given that they are just query time synonyms.

As classification terms need to be newly indexed, a mapping schema change and reimport is required and the database version has increased.

Partially implements #557. Classification terms cannot be used for searching by type ('museum in Paris', 'airport near London').

Fixes #318.