### PR TITLE
Change default for search parameter zoom to 14

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -56,7 +56,7 @@ public class PhotonRequestFactory {
                 throw new BadRequestException(400, "invalid parameter 'location_bias_scale' must be a number");
             }
 
-        int zoom = 16;
+        int zoom = 14;
         String zoomStr = webRequest.queryParams("zoom");
         if (zoomStr != null && !zoomStr.isEmpty()) {
             try {

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -98,7 +98,7 @@ public class ApiIntegrationTest extends ESBaseTester {
     public void testApiWithLocationBias() throws Exception {
         App.main(new String[]{"-cluster", TEST_CLUSTER_NAME, "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1"});
         awaitInitialization();
-        HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin&limit=1&lat=52.54714&lon=13.39026")
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=16")
                 .openConnection();
         JSONObject json = new JSONObject(
                 new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n")));


### PR DESCRIPTION
The previous default of 16 yields results that are already very focused. While useful when actively selected, it turned out to be a bit too narrow for a results.

In any case, it is always better to add an explicit zoom parameter when using location bias.