### PR TITLE
Filtering of extra tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ nbactions.xml
 .classpath
 .project
 .settings/
+.factorypath
+
+##############################
+## Visual Studio Code
+##############################
+.vscode/
+.code-workspace

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -46,6 +46,16 @@
 					}
 				}
 			},
+			"extra": {
+				"properties": {
+					"wikidata": {
+						"type": "text"
+					},
+					"wikipedia": {
+						"type": "text"
+					}
+				}
+			},
 			"coordinate": {
 				"type": "geo_point"
 			},
@@ -228,7 +238,7 @@
 					}
 				}
 			},
-	  		"locality": {
+			"locality": {
 				"properties": {
 					"default": {
 						"type": "text",

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -213,6 +213,20 @@ public class PhotonQueryBuilder {
         return this;
     }
 
+    public PhotonQueryBuilder withExtraKeys(Set<String> keys) {
+        if (!checkTags(keys)) return this;
+
+        ensureFiltered();
+
+        List<ExistsQueryBuilder> termQueries = new ArrayList<ExistsQueryBuilder>(keys.size());    
+        for (String key : keys) {
+            termQueries.add(QueryBuilders.existsQuery("extra." + key));
+        }
+        this.appendIncludeTermQueries(termQueries);
+
+        return this;
+    }
+
 
     public PhotonQueryBuilder withValues(Set<String> values) {
         if (!checkTags(values)) return this;

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -4,6 +4,7 @@ import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -29,9 +30,10 @@ public class PhotonRequest implements Serializable {
     private Map<String, Set<String>> includeTags;
     private Map<String, Set<String>> excludeTags;
     private Map<String, Set<String>> excludeTagValues;
+    private Set<String> includeExtraKeys;
 
 
-    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, int zoom, String language, boolean debug) {
+    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, int zoom, String language, boolean debug, String[] extraKeys) {
         this.query = query;
         this.limit = limit;
         this.locationForBias = locationForBias;
@@ -40,6 +42,7 @@ public class PhotonRequest implements Serializable {
         this.language = language;
         this.bbox = bbox;
         this.debug = debug;
+        this.includeExtraKeys = new HashSet<String>(Arrays.asList(extraKeys));
     }
 
     public String getQuery() {
@@ -99,6 +102,10 @@ public class PhotonRequest implements Serializable {
     public Map<String, Set<String>> tagNotValues() {
         return excludeTagValues;
 
+    }
+
+    public Set<String> extraKeys() {
+        return includeExtraKeys;
     }
 
     private void addExcludeValues(String value) {

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -19,7 +19,7 @@ public class PhotonRequestFactory {
     private final BoundingBoxParamConverter bboxParamConverter;
 
     private static final HashSet<String> REQUEST_QUERY_PARAMS = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
-            "limit", "osm_tag", "location_bias_scale", "bbox", "debug", "zoom"));
+            "limit", "osm_tag", "location_bias_scale", "bbox", "debug", "zoom", "extra_key"));
 
     public PhotonRequestFactory(List<String> supportedLanguages, String defaultLanguage) {
         this.languageResolver = new RequestLanguageResolver(supportedLanguages, defaultLanguage);
@@ -68,7 +68,10 @@ public class PhotonRequestFactory {
 
         boolean debug = webRequest.queryParams("debug") != null;
 
-        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, zoom, language, debug);
+        QueryParamsMap extraKeyQueryMap = webRequest.queryMap("extra_key");
+        String[] extraKeyValues = (extraKeyQueryMap.hasValue()) ? extraKeyQueryMap.values() : new String[0];
+
+        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, zoom, language, debug, extraKeyValues);
 
         QueryParamsMap tagFiltersQueryMap = webRequest.queryMap("osm_tag");
         if (new CheckIfFilteredRequest().execute(tagFiltersQueryMap)) {

--- a/src/main/java/de/komoot/photon/query/ReverseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/ReverseQueryBuilder.java
@@ -29,20 +29,6 @@ public class ReverseQueryBuilder {
         return !(keys == null || keys.isEmpty());
     }
 
-    public PhotonQueryBuilder withExtraKeys(Set<String> keys) {
-        if (!checkTags(keys)) return this;
-
-        ensureFiltered();
-
-        List<ExistsQueryBuilder> termQueries = new ArrayList<ExistsQueryBuilder>(keys.size());    
-        for (String key : keys) {
-            termQueries.add(QueryBuilders.existsQuery("extra." + key));
-        }
-        this.appendIncludeTermQueries(termQueries);
-
-        return this;
-    }
-
     public static ReverseQueryBuilder builder(Point location, Double radius, String queryStringFilter, Set<String> extraKeys) {
         return new ReverseQueryBuilder(location, radius, queryStringFilter, extraKeys);
     }

--- a/src/main/java/de/komoot/photon/query/ReverseRequest.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequest.java
@@ -3,6 +3,9 @@ package de.komoot.photon.query;
 import com.vividsolutions.jts.geom.Point;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author svantulden
@@ -15,13 +18,16 @@ public class ReverseRequest implements Serializable {
     private String queryStringFilter;
     private Boolean locationDistanceSort = true;
 
-    public ReverseRequest(Point location, String language, Double radius, String queryStringFilter, Integer limit, Boolean locationDistanceSort) {
+    private Set<String> includeExtraKeys;
+
+    public ReverseRequest(Point location, String language, Double radius, String queryStringFilter, Integer limit, Boolean locationDistanceSort, String[] extraKeys) {
         this.location = location;
         this.language = language;
         this.radius = radius;
         this.limit = limit;
         this.queryStringFilter = queryStringFilter;
         this.locationDistanceSort = locationDistanceSort;
+        this.includeExtraKeys = new HashSet<String>(Arrays.asList(extraKeys));
     }
 
     public Point getLocation() {
@@ -46,5 +52,9 @@ public class ReverseRequest implements Serializable {
 
     public Boolean getLocationDistanceSort() {
         return locationDistanceSort;
+    }
+
+    public Set<String> extraKeys() {
+        return includeExtraKeys;
     }
 }

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -1,6 +1,7 @@
 package de.komoot.photon.query;
 
 import com.vividsolutions.jts.geom.Point;
+import spark.QueryParamsMap;
 import spark.Request;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ public class ReverseRequestFactory {
     private final RequestLanguageResolver languageResolver;
     private static final LocationParamConverter mandatoryLocationParamConverter = new LocationParamConverter(true);
 
-    private static final HashSet<String> REQUEST_QUERY_PARAMS = new HashSet<>(Arrays.asList("lang", "lon", "lat", "radius", "query_string_filter", "distance_sort", "limit"));
+    private static final HashSet<String> REQUEST_QUERY_PARAMS = new HashSet<>(Arrays.asList("lang", "lon", "lat", "radius", "query_string_filter", "distance_sort", "limit", "extra_key"));
 
     public ReverseRequestFactory(List<String> supportedLanguages, String defaultLanguage) {
         this.languageResolver = new RequestLanguageResolver(supportedLanguages, defaultLanguage);
@@ -70,6 +71,10 @@ public class ReverseRequestFactory {
         }
 
         String queryStringFilter = webRequest.queryParams("query_string_filter");
-        return new ReverseRequest(location, language, radius, queryStringFilter, limit, locationDistanceSort);
+
+        QueryParamsMap extraKeyQueryMap = webRequest.queryMap("extra_key");
+        String[] extraKeyValues = (extraKeyQueryMap.hasValue()) ? extraKeyQueryMap.values() : new String[0];
+
+        return new ReverseRequest(location, language, radius, queryStringFilter, limit, locationDistanceSort, extraKeyValues);
     }
 }

--- a/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
@@ -60,6 +60,7 @@ public class PhotonRequestHandler {
                 withoutValues(photonRequest.notValues()).
                 withTagsNotValues(photonRequest.tagNotValues()).
                 withLocationBias(photonRequest.getLocationForBias(), photonRequest.getScaleForBias(), photonRequest.getZoomForBias()).
-                withBoundingBox(photonRequest.getBbox());
+                withBoundingBox(photonRequest.getBbox()).
+                withExtraKeys(photonRequest.extraKeys());
     }
 }

--- a/src/main/java/de/komoot/photon/searcher/ReverseRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/ReverseRequestHandler.java
@@ -27,6 +27,6 @@ public class ReverseRequestHandler {
     }
 
     public ReverseQueryBuilder buildQuery(ReverseRequest photonRequest) {
-        return ReverseQueryBuilder.builder(photonRequest.getLocation(), photonRequest.getRadius(), photonRequest.getQueryStringFilter());
+        return ReverseQueryBuilder.builder(photonRequest.getLocation(), photonRequest.getRadius(), photonRequest.getQueryStringFilter(), photonRequest.extraKeys());
     }
 }


### PR DESCRIPTION
Draft PR for filtering of extra tags, related to #592.

So far it only enables filtering on the existence of keys inside the extra-tag object. Extra tags has been introduced via #576.

Example: http://localhost:2322/api?q=monaco&extra_key=wikidata&extra_key=wikipedia
Will only return elements with `wikidata` or `wikipedia` tags in extra. Behavior is similar to `osm_key`.

ToDo:
- So far only `wikipedia` and `wikidata` gets indexed in elastic, because I don't know how to make it dynamic for all properties inside `extra`. If the mapping has to get done explicitly, all the extra tags can be found here: https://taginfo.openstreetmap.org/projects/nominatim#tags
- No tests has been written yet (I'm not a java developer and don't want to deal with the tests for now...)