### PR TITLE
Adds support of search_languages so that we can limit the list of lan…

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -17,6 +17,8 @@ public class PhotonRequest implements Serializable {
     private Integer limit;
     private Point locationForBias;
     private String language;
+    private String[] searchLanguages;
+	
     private final double scale;
     private final int zoom;
     private Envelope bbox;
@@ -30,14 +32,14 @@ public class PhotonRequest implements Serializable {
     private Map<String, Set<String>> excludeTags;
     private Map<String, Set<String>> excludeTagValues;
 
-
-    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, int zoom, String language, boolean debug) {
+    public PhotonRequest(String query, int limit, Envelope bbox, Point locationForBias, double scale, int zoom, String language, String[] searchLanguages, boolean debug) {
         this.query = query;
         this.limit = limit;
         this.locationForBias = locationForBias;
         this.scale = scale;
         this.zoom = zoom;
         this.language = language;
+        this.searchLanguages = searchLanguages;
         this.bbox = bbox;
         this.debug = debug;
     }
@@ -68,6 +70,10 @@ public class PhotonRequest implements Serializable {
 
     public String getLanguage() {
         return language;
+    }
+
+    public String[] getSearchLanguages() {
+        return searchLanguages;
     }
 
     public boolean getDebug() { return debug; }

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -19,7 +19,7 @@ public class PhotonRequestFactory {
     private final BoundingBoxParamConverter bboxParamConverter;
 
     private static final HashSet<String> REQUEST_QUERY_PARAMS = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
-            "limit", "osm_tag", "location_bias_scale", "bbox", "debug", "zoom"));
+            "limit", "osm_tag", "location_bias_scale", "bbox", "debug", "zoom", "search_languages"));
 
     public PhotonRequestFactory(List<String> supportedLanguages, String defaultLanguage) {
         this.languageResolver = new RequestLanguageResolver(supportedLanguages, defaultLanguage);
@@ -43,6 +43,9 @@ public class PhotonRequestFactory {
         } catch (NumberFormatException e) {
             limit = 15;
         }
+		
+        String searchLanguagesStr = webRequest.queryParams("search_languages");
+	String[] searchLanguages = (searchLanguagesStr != null && !searchLanguagesStr.isEmpty()) ? searchLanguagesStr.split(",") : null;
 
         Point locationForBias = optionalLocationParamConverter.apply(webRequest);
         Envelope bbox = bboxParamConverter.apply(webRequest);
@@ -68,7 +71,7 @@ public class PhotonRequestFactory {
 
         boolean debug = webRequest.queryParams("debug") != null;
 
-        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, zoom, language, debug);
+        PhotonRequest request = new PhotonRequest(query, limit, bbox, locationForBias, scale, zoom, language, searchLanguages, debug);
 
         QueryParamsMap tagFiltersQueryMap = webRequest.queryMap("osm_tag");
         if (new CheckIfFilteredRequest().execute(tagFiltersQueryMap)) {

--- a/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonRequestHandler.java
@@ -7,6 +7,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.json.JSONObject;
 
 import java.util.List;
+import java.util.Arrays;
 
 /**
  * Given a {@link PhotonRequest photon request}, execute the search, process it (for example, de-duplicate) and respond with results formatted in a list of {@link JSONObject json
@@ -52,6 +53,7 @@ public class PhotonRequestHandler {
    public PhotonQueryBuilder buildQuery(PhotonRequest photonRequest, boolean lenient) {
         return PhotonQueryBuilder.
                 builder(photonRequest.getQuery(), photonRequest.getLanguage(), supportedLanguages, lenient).
+		builder(photonRequest.getQuery(), photonRequest.getLanguage(), photonRequest.getSearchLanguages() != null ? Arrays.asList(photonRequest.getSearchLanguages()) : supportedLanguages, lenient).				
                 withTags(photonRequest.tags()).
                 withKeys(photonRequest.keys()).
                 withValues(photonRequest.values()).

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -207,6 +207,35 @@ public class PhotonRequestFactoryTest {
     }
     
     @Test
+    public void testWithSearchLanguages() throws Exception {
+        Request mockRequest = Mockito.mock(Request.class);
+        Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
+        Mockito.when(mockRequest.queryParams("search_languages")).thenReturn("en,es,pt");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
+        Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
+        photonRequest = photonRequestFactory.create(mockRequest);
+        Assert.assertEquals("berlin", photonRequest.getQuery());
+        Assert.assertArrayEquals(new String[]{"en", "es", "pt"}, photonRequest.getSearchLanguages());
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("search_languages");
+    }
+    
+    @Test
+    public void testWithoutSearchLanguages() throws Exception {
+        Request mockRequest = Mockito.mock(Request.class);
+        Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
+        Mockito.when(mockRequest.queryParams("search_languages")).thenReturn(null);
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
+        Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
+        photonRequest = photonRequestFactory.create(mockRequest);
+        Assert.assertEquals("berlin", photonRequest.getQuery());
+        Assert.assertNull(photonRequest.getSearchLanguages());
+        Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
+    }
+    
+    @Test
     public void testWithBboxFilter() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
         Mockito.when(mockRequest.queryParams("q")).thenReturn("hanover");

--- a/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class PhotonRequestTest {
 
     private PhotonRequest simpleRequest() {
-        return new PhotonRequest("foo", 1, null, null, 1.6, 16, "de", false);
+        return new PhotonRequest("foo", 1, null, null, 1.6, 16, "de", null, false);
     }
 
     @Test


### PR DESCRIPTION
We have a perfomance issue when running photon with multiple languages like so:

-languages ru,en,de,uk,es,pt,fr,zh,pl,it,tr,ja,vi,id,ms,th,hi

we don't know exactly what the client langauge will be. It might be any language.

In this case when a new request comes in, photon builds a query that tries to search across all supported langues but this is too slow and unnecessary. In our case, we know exactly that for a client, say, from Brazil we only need to search across pt, es, en languages, but we do not have this possibility.

This commit adds a new "search_languages" parameter that can be utilized in API to specify a comma-separated list of languages that ES should search through. If the parameter is not specified photon will use the list of supported languages  from the -languages param (the old logic applies).