### PR TITLE
Take geography into account for address computation

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
@@ -21,4 +21,9 @@ public interface DBDataAdapter {
      */
     @Nullable
     Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException;
+
+    /**
+     * Return the SQL for computing the address terms of a place.
+     */
+    String addressSQL(boolean hasAddressTags, boolean hasCentroid);
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -42,4 +42,21 @@ public class H2DataAdapter implements DBDataAdapter {
 
         return null;
     }
+
+    @Override
+    public String addressSQL(boolean hasAddressTags, boolean hasCentroid) {
+        String sql = "SELECT p.name, p.class, p.type, p.rank_address"
+                     + " FROM placex p, place_addressline pa"
+                     + " WHERE p.place_id = pa.address_place_id and pa.place_id = ?"
+                     + " and pa.cached_rank_address > 4 and pa.address_place_id != ? and pa.isaddress";
+
+        if (hasAddressTags) {
+            sql += "and ? is not null"; //dummy query, not used
+        }
+        if (hasCentroid) {
+            sql += "and ? is not null"; //dummy query, not used
+        }
+
+        return sql + " ORDER BY rank_address desc, fromarea desc, distance asc, rank_search desc";
+    }
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
@@ -5,6 +5,7 @@ import org.springframework.lang.Nullable;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Helper functions used by H2 test database.
@@ -18,6 +19,19 @@ public class Helpers {
             return null;
 
         return geom.getEnvelope();
+    }
+
+    public static Geometry set_srid(Geometry geom, int srid) {
+        if (geom == null)
+            return null;
+
+        geom.setSRID(srid);
+
+        return geom;
+    }
+
+    public static String[] avals(Map<String, String> input) {
+        return input.values().toArray(new String[0]);
     }
 
     @Nullable

--- a/src/test/resources/test-schema.sql
+++ b/src/test/resources/test-schema.sql
@@ -53,6 +53,8 @@ CREATE TABLE location_property_osmline (
 
 
 CREATE ALIAS ST_Envelope FOR "de.komoot.photon.nominatim.testdb.Helpers.envelope";
+CREATE ALIAS ST_SetSRID FOR "de.komoot.photon.nominatim.testdb.Helpers.set_srid";
+CREATE ALIAS avals FOR "de.komoot.photon.nominatim.testdb.Helpers.avals";
 
 CREATE TABLE country_name (
     country_code character varying(2),


### PR DESCRIPTION
Use the more complex way of computing the address from Nominatim for computing the rank 30 address. That makes sure that address parts are not blindly taken from the parent but geographic relations are taken into account. When streets go over boundaries, the addresses along that street will be corrected as necessary according to the administrative entity that contains them. See also Nominatim PR https://github.com/osm-search/Nominatim/pull/2082

Requires advanced SQL which is not supported by H2. Thus use the previous simpler query for tests instead.

Sadly, this PR is incompatible with #547. If it gets merged, then import time will again increase by around 50%. So it  would be useful if others tested this a bit to figure out if it is worth the performance loss. I haven't made up my mind yet if I want to merge it or not.

See also discussion in #609.