### PR TITLE
Remove JndiLookup class from shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,14 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                                <!--
+                                    This mitigates against the log4j JNDI lookup vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+
+                                    Since we are using an old version of elastic search that is incompatible with a patched, newer version of log4j we
+                                    have to remove the class JndiLookup from the fat jar. This is the recommended course of action when you cannot upgrade
+                                    as per https://logging.apache.org/log4j/2.x/security.html
+                                -->
+                                <exclude>org/apache/logging/log4j/core/lookup/JndiLookup.class</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
As per the recommendation by the log4j security team, removing the class is the best way to move forward: https://logging.apache.org/log4j/2.x/security.html

This filters out the class when building the shaded jar.

## Before
```
zipinfo -1 target/photon-0.3.5.jar | grep Jndi
org/apache/logging/log4j/core/lookup/JndiLookup.class
org/apache/logging/log4j/core/net/JndiManager.class
org/apache/logging/log4j/core/net/JndiManager$JndiManagerFactory.class
org/apache/logging/log4j/core/selector/JndiContextSelector.class
org/apache/logging/log4j/core/net/JndiManager$1.class
org/apache/logging/log4j/core/util/JndiCloser.class
org/springframework/jdbc/datasource/lookup/JndiDataSourceLookup.class
```


## After
```
zipinfo -1 target/photon-0.3.5.jar | grep Jndi
org/apache/logging/log4j/core/net/JndiManager.class
org/apache/logging/log4j/core/net/JndiManager$JndiManagerFactory.class
org/apache/logging/log4j/core/selector/JndiContextSelector.class
org/apache/logging/log4j/core/net/JndiManager$1.class
org/apache/logging/log4j/core/util/JndiCloser.class
org/springframework/jdbc/datasource/lookup/JndiDataSourceLookup.class
```

What this doesn't protect against is when someone doesn't use the compiled jar file, for example when doing local development.

Relates to #620 

cc @hbruch 