### PR TITLE
Map equality check should use equal

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -216,7 +216,8 @@ public class PhotonDoc {
      * @return True, if the address was inserted.
      */
     public boolean setAddressPartIfNew(AddressType addressType, Map<String, String> names) {
-        return addressParts.computeIfAbsent(addressType, k -> names) == names;
+        Map<String, String> value = addressParts.computeIfAbsent(addressType, k -> names);
+        return value != null && value.equals(names);
     }
 
     public void setCountry(Map<String, String> names) {

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -40,6 +40,51 @@ public class PhotonDocTest {
         Assert.assertEquals("DE", doc.getCountryCode().getAlpha2());
     }
 
+    @Test
+    public void testSetNewAddressPart() {
+        PhotonDoc doc = simplePhotonDoc();
+
+        HashMap<String, String> streetNames = new HashMap<>();
+        streetNames.put("name", "parent place street");
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames));
+    }
+
+    @Test
+    public void testSetOtherAddressPart() {
+        PhotonDoc doc = simplePhotonDoc();
+
+        HashMap<String, String> streetNames = new HashMap<>();
+        streetNames.put("name", "parent place street");
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames));
+
+        HashMap<String, String> streetNames2 = new HashMap<>();
+        streetNames2.put("name", "parent place street 2");
+        Assert.assertFalse(doc.setAddressPartIfNew(AddressType.STREET, streetNames2));
+    }
+
+    @Test
+    public void testSetNewAddressPartTwice() {
+        PhotonDoc doc = simplePhotonDoc();
+
+        HashMap<String, String> streetNames = new HashMap<>();
+        streetNames.put("name", "parent place street");
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames));
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames));
+    }
+
+    @Test
+    public void testSetNewAddressPartTwiceWithOtherObject() {
+        PhotonDoc doc = simplePhotonDoc();
+
+        HashMap<String, String> streetNames1 = new HashMap<>();
+        streetNames1.put("name", "parent place street");
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames1));
+
+        HashMap<String, String> streetNames2 = new HashMap<>();
+        streetNames2.put("name", "parent place street");
+        Assert.assertTrue(doc.setAddressPartIfNew(AddressType.STREET, streetNames2));
+    }
+
     private PhotonDoc simplePhotonDoc() {
         return new PhotonDoc(1, "W", 2, "highway", "residential").houseNumber("4");
     }


### PR DESCRIPTION
It seem this compare is not always right. `==` compares the same object, but sometimes it a different object with the same contents.

So it's beter to use `.equals` on the map.

All tests seems to work, and I've added some extra tests to prove it.

