### PR TITLE
Support for the changed schema of Nominatim's interpolation tables

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -175,11 +175,13 @@ public class App {
         get("reverse", new ReverseSearchRequestHandler("reverse", esNodeClient, dbProperties.getLanguages(), args.getDefaultLanguage()));
         get("reverse/", new ReverseSearchRequestHandler("reverse/", esNodeClient, dbProperties.getLanguages(), args.getDefaultLanguage()));
 
-        // setup update API
-        final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, esNodeClient);
-        get("/nominatim-update", (Request request, Response response) -> {
-            new Thread(() -> nominatimUpdater.update()).start();
-            return "nominatim update started (more information in console output) ...";
-        });
+        if (args.isEnableUpdateApi()) {
+            // setup update API
+            final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, esNodeClient);
+            get("/nominatim-update", (Request request, Response response) -> {
+                new Thread(() -> nominatimUpdater.update()).start();
+                return "nominatim update started (more information in console output) ...";
+            });
+        }
     }
 }

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -71,6 +71,9 @@ public class CommandLineArgs {
     @Parameter(names = "-cors-origin", description = "enable cross-site resource sharing for the specified origin (default CORS not supported)")
     private String corsOrigin = null;
 
+    @Parameter(names = "-enable-update-api", description = "Enable the additional endpoint /nominatim-update, which allows to trigger updates from a nominatim database")
+    private boolean enableUpdateApi = false;
+
     @Parameter(names = "-h", description = "show help / usage")
     private boolean usage = false;
 

--- a/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
@@ -1,6 +1,7 @@
 package de.komoot.photon.nominatim;
 
 import com.vividsolutions.jts.geom.Geometry;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.annotation.Nullable;
 import java.sql.ResultSet;
@@ -21,4 +22,9 @@ public interface DBDataAdapter {
      */
     @Nullable
     Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException;
+
+    /**
+     * Check if a table has the given column.
+     */
+    boolean hasColumn(JdbcTemplate template, String table, String column);
 }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -26,37 +26,20 @@ import java.util.Map;
 @Slf4j
 public class NominatimConnector {
     private static final String SELECT_COLS_PLACEX = "SELECT place_id, osm_type, osm_id, class, type, name, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_address, rank_search, importance, country_code, centroid";
-    private static final String SELECT_COLS_OSMLINE = "SELECT place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
     private static final String SELECT_COLS_ADDRESS = "SELECT p.name, p.class, p.type, p.rank_address";
 
     private final DBDataAdapter dbutils;
     private final JdbcTemplate template;
     private Map<String, Map<String, String>> countryNames;
+
     /**
-     * Maps a row from location_property_osmline (address interpolation lines) to a photon doc.
+     * Maps a row from location_property_osmline (address interpolation lines)
+     * with old-style intepolation (using interpolationtype) to a photon doc.
      */
-    private final RowMapper<NominatimResult> osmlineRowMapper = new RowMapper<NominatimResult>() {
-        @Override
-        public NominatimResult mapRow(ResultSet rs, int rownum) throws SQLException {
-            Geometry geometry = dbutils.extractGeometry(rs, "linegeo");
+    private final RowMapper<NominatimResult> osmlineRowMapper;
+    private final String selectOsmlineSql;
 
-            PhotonDoc doc = new PhotonDoc(rs.getLong("place_id"), "W", rs.getLong("osm_id"),
-                                          "place", "house_number")
-                    .parentPlaceId(rs.getLong("parent_place_id"))
-                    .countryCode(rs.getString("country_code"))
-                    .postcode(rs.getString("postcode"));
 
-            completePlace(doc);
-
-            doc.setCountry(getCountryNames(rs.getString("country_code")));
-
-            NominatimResult result = new NominatimResult(doc);
-            result.addHouseNumbersFromInterpolation(rs.getLong("startnumber"), rs.getLong("endnumber"),
-                    rs.getString("interpolationtype"), geometry);
-
-            return result;
-        }
-    };
     /**
      * maps a placex row in nominatim to a photon doc, some attributes are still missing and can be derived by connected address items.
      */
@@ -112,6 +95,53 @@ public class NominatimConnector {
         template.setFetchSize(100000);
 
         dbutils = dataAdapter;
+
+        // Setup handling of interpolation table. It has changed its format. Need to find out which one to use.
+        if (dbutils.hasColumn(template, "location_property_osmline", "step")) {
+            // new-style interpolations
+            selectOsmlineSql = "SELECT place_id, osm_id, parent_place_id, startnumber, endnumber, step, postcode, country_code, linegeo";
+            osmlineRowMapper = (rs, rownum) -> {
+                Geometry geometry = dbutils.extractGeometry(rs, "linegeo");
+
+                PhotonDoc doc = new PhotonDoc(rs.getLong("place_id"), "W", rs.getLong("osm_id"),
+                        "place", "house_number")
+                        .parentPlaceId(rs.getLong("parent_place_id"))
+                        .countryCode(rs.getString("country_code"))
+                        .postcode(rs.getString("postcode"));
+
+                completePlace(doc);
+
+                doc.setCountry(getCountryNames(rs.getString("country_code")));
+
+                NominatimResult result = new NominatimResult(doc);
+                result.addHouseNumbersFromInterpolation(rs.getLong("startnumber"), rs.getLong("endnumber"),
+                        rs.getLong("step"), geometry);
+
+                return result;
+            };
+        } else {
+            // old-style interpolations
+            selectOsmlineSql = "SELECT place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
+            osmlineRowMapper = (rs, rownum) -> {
+                Geometry geometry = dbutils.extractGeometry(rs, "linegeo");
+
+                PhotonDoc doc = new PhotonDoc(rs.getLong("place_id"), "W", rs.getLong("osm_id"),
+                        "place", "house_number")
+                        .parentPlaceId(rs.getLong("parent_place_id"))
+                        .countryCode(rs.getString("country_code"))
+                        .postcode(rs.getString("postcode"));
+
+                completePlace(doc);
+
+                doc.setCountry(getCountryNames(rs.getString("country_code")));
+
+                NominatimResult result = new NominatimResult(doc);
+                result.addHouseNumbersFromInterpolation(rs.getLong("startnumber"), rs.getLong("endnumber"),
+                        rs.getString("interpolationtype"), geometry);
+
+                return result;
+            };
+        }
     }
 
 
@@ -150,7 +180,7 @@ public class NominatimConnector {
     }
 
     public List<PhotonDoc> getInterpolationsByPlaceId(long placeId) {
-        NominatimResult result = template.queryForObject(SELECT_COLS_OSMLINE
+        NominatimResult result = template.queryForObject(selectOsmlineSql
                                                           + " FROM location_property_osmline WHERE place_id = ?",
                                                           osmlineRowMapper, placeId);
         assert(result != null);
@@ -250,7 +280,7 @@ public class NominatimConnector {
                     }
                 });
 
-        template.query(SELECT_COLS_OSMLINE + " FROM location_property_osmline " +
+        template.query(selectOsmlineSql + " FROM location_property_osmline " +
                 whereCountryCodeStr +
                 " ORDER BY geometry_sector, parent_place_id; ", rs -> {
                     NominatimResult docs = osmlineRowMapper.mapRow(rs, 0);

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -257,11 +257,9 @@ public class NominatimConnector {
      */
     public void readEntireDatabase(String... countryCodes) {
         String andCountryCodeStr = "";
-        String whereCountryCodeStr = "";
         String countryCodeStr = convertCountryCode(countryCodes);
         if (!countryCodeStr.isEmpty()) {
             andCountryCodeStr = "AND country_code in (" + countryCodeStr + ")";
-            whereCountryCodeStr = "WHERE country_code in (" + countryCodeStr + ")";
         }
 
         log.info("start importing documents from nominatim (" + (countryCodeStr.isEmpty() ? "global" : countryCodeStr) + ")");
@@ -281,7 +279,8 @@ public class NominatimConnector {
                 });
 
         template.query(selectOsmlineSql + " FROM location_property_osmline " +
-                whereCountryCodeStr +
+                "WHERE startnumber is not null " +
+                andCountryCodeStr +
                 " ORDER BY geometry_sector, parent_place_id; ", rs -> {
                     NominatimResult docs = osmlineRowMapper.mapRow(rs, 0);
                     assert(docs != null);

--- a/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
@@ -3,6 +3,8 @@ package de.komoot.photon.nominatim;
 import com.google.common.collect.Maps;
 import com.vividsolutions.jts.geom.Geometry;
 import org.postgis.jts.JtsGeometry;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
 import javax.annotation.Nullable;
 import java.sql.ResultSet;
@@ -34,5 +36,16 @@ public class PostgisDataAdapter implements DBDataAdapter {
             return null;
         }
         return geom.getGeometry();
+    }
+
+    @Override
+    public boolean hasColumn(JdbcTemplate template, String table, String column) {
+        return template.query("SELECT count(*) FROM information_schema.columns WHERE table_name = ? and column_name = ?",
+                new RowMapper<Boolean>() {
+                    @Override
+                    public Boolean mapRow(ResultSet resultSet, int i) throws SQLException {
+                        return resultSet.getInt(1) > 0;
+                    }
+                }, table, column).get(0);
     }
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -5,6 +5,7 @@ import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.nominatim.DBDataAdapter;
 import org.json.JSONObject;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.annotation.Nullable;
 import java.sql.ResultSet;
@@ -41,5 +42,10 @@ public class H2DataAdapter implements DBDataAdapter {
         }
 
         return null;
+    }
+
+    @Override
+    public boolean hasColumn(JdbcTemplate template, String table, String column) {
+        return false;
     }
 }


### PR DESCRIPTION
The table with house number interpolations in Nominatim has changed its style replacing the `interpolationtype` with a simpler `step` column and excluding duplicate house numbers with the placex tables. See https://github.com/osm-search/Nominatim/pull/2597 for details.

This PR adds support for the new style while keeping compatibility with the old style. Photon checks on startup which of the columns is available and uses the appropriate SQL for getting the data.

The change highlighted an issue we've been having for a while: the API endpoint to update Nominatim is always available, no matter if Nominatim is installed. Given that most users never want to run updates via Photon, this isn't an API that should be there unless explicitly requested. The PR adds a new command-line option `-enable-update-api` which needs to be added to set up the update endpoint. **This is a change in behaviour** for everybody who runs updates. You need to add the new option to continue to run updates.