### PR TITLE
Move tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,9 +131,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -302,6 +302,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
         <resources>

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -3,9 +3,9 @@ package de.komoot.photon;
 import de.komoot.photon.elasticsearch.Importer;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -13,8 +13,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static spark.Spark.*;
 
 /**
@@ -23,7 +22,7 @@ import static spark.Spark.*;
 public class ApiIntegrationTest extends ESBaseTester {
     private static final int LISTEN_PORT = 30234;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setUpES();
         Importer instance = makeImporter();
@@ -33,7 +32,7 @@ public class ApiIntegrationTest extends ESBaseTester {
         refresh();
     }
 
-    @After
+    @AfterEach
     public void shutdown() {
         stop();
         awaitStop();

--- a/src/test/java/de/komoot/photon/AssertUtil.java
+++ b/src/test/java/de/komoot/photon/AssertUtil.java
@@ -1,17 +1,18 @@
 package de.komoot.photon;
 
 import de.komoot.photon.nominatim.model.AddressType;
-import org.junit.Assert;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AssertUtil {
     private AssertUtil() {}
 
     public static void assertAddressName(String name, PhotonDoc doc, AddressType addressType) {
-        Assert.assertNotNull(doc.getAddressParts().get(addressType));
-        Assert.assertEquals(name, doc.getAddressParts().get(addressType).get("name"));
+        assertNotNull(doc.getAddressParts().get(addressType));
+        assertEquals(name, doc.getAddressParts().get(addressType).get("name"));
     }
 
     public static void assertNoAddress(PhotonDoc doc, AddressType addressType) {
-        Assert.assertNull(doc.getAddressParts().get(addressType));
+        assertNull(doc.getAddressParts().get(addressType));
     }
 }

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +41,7 @@ public class ESBaseTester {
     }
 
 
-    @After
+    @AfterEach
     public void tearDown() {
         deleteIndex();
         shutdownES();

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -3,8 +3,9 @@ package de.komoot.photon;
 import java.util.HashMap;
 
 import de.komoot.photon.nominatim.model.AddressType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PhotonDocTest {
 
@@ -36,8 +37,8 @@ public class PhotonDocTest {
     public void testAddCountryCode() {
         PhotonDoc doc = new PhotonDoc(1, "W", 2, "highway", "residential").countryCode("de");
 
-        Assert.assertNotNull(doc.getCountryCode());
-        Assert.assertEquals("DE", doc.getCountryCode().getAlpha2());
+        assertNotNull(doc.getCountryCode());
+        assertEquals("DE", doc.getCountryCode().getAlpha2());
     }
 
     private PhotonDoc simplePhotonDoc() {

--- a/src/test/java/de/komoot/photon/elasticsearch/DatabasePropertiesTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/DatabasePropertiesTest.java
@@ -1,11 +1,11 @@
 package de.komoot.photon.elasticsearch;
 
 import de.komoot.photon.ESBaseTester;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the database-global property store.

--- a/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ImporterTest.java
@@ -3,20 +3,19 @@ package de.komoot.photon.elasticsearch;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import org.elasticsearch.action.get.GetResponse;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ImporterTest extends ESBaseTester {
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpES();
     }

--- a/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/UpdaterTest.java
@@ -3,15 +3,14 @@ package de.komoot.photon.elasticsearch;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import org.elasticsearch.action.get.GetResponse;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UpdaterTest extends ESBaseTester {
 

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -9,9 +9,9 @@ import de.komoot.photon.nominatim.testdb.CollectingImporter;
 import de.komoot.photon.nominatim.testdb.H2DataAdapter;
 import de.komoot.photon.nominatim.testdb.OsmlineTestRow;
 import de.komoot.photon.nominatim.testdb.PlacexTestRow;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -24,7 +24,7 @@ public class NominatimConnectorDBTest {
     private CollectingImporter importer;
     private JdbcTemplate jdbc;
 
-    @Before
+    @BeforeEach
     public void setup() {
         db = new EmbeddedDatabaseBuilder()
                 .setType(EmbeddedDatabaseType.H2)
@@ -46,7 +46,7 @@ public class NominatimConnectorDBTest {
         PlacexTestRow place = new PlacexTestRow("amenity", "cafe").name("Spot").add(jdbc);
         connector.readEntireDatabase();
 
-        Assert.assertEquals(1, importer.size());
+        assertEquals(1, importer.size());
         importer.assertContains(place);
     }
 
@@ -57,7 +57,7 @@ public class NominatimConnectorDBTest {
         new PlacexTestRow("amenity", "cafe").name("SpotUS").country("us").add(jdbc);
         connector.readEntireDatabase("uk", "hu", "nl");
 
-        Assert.assertEquals(1, importer.size());
+        assertEquals(1, importer.size());
         importer.assertContains(place);
     }
 
@@ -68,8 +68,8 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(0.5, importer.get(place1.getPlaceId()).getImportance(), 0.00001);
-        Assert.assertEquals(0.3, importer.get(place2.getPlaceId()).getImportance(), 0.00001);
+        assertEquals(0.5, importer.get(place1.getPlaceId()).getImportance(), 0.00001);
+        assertEquals(0.3, importer.get(place2.getPlaceId()).getImportance(), 0.00001);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(6, importer.size());
+        assertEquals(6, importer.size());
         importer.assertContains(place);
 
         PhotonDoc doc = importer.get(place);
@@ -108,7 +108,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(3, importer.size());
+        assertEquals(3, importer.size());
         importer.assertContains(place);
 
         PhotonDoc doc = importer.get(place);
@@ -130,7 +130,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(10, importer.size());
+        assertEquals(10, importer.size());
 
         PlacexTestRow expect = new PlacexTestRow("place", "house_number").id(osmline.getPlaceId()).parent(street).osm("W", 23);
 
@@ -154,12 +154,12 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(3, importer.size());
+        assertEquals(3, importer.size());
 
         PhotonDoc doc = importer.get(place);
 
         AssertUtil.assertAddressName("Dorf", doc, AddressType.CITY);
-        Assert.assertTrue(doc.getContext().contains(munip.getNames()));
+        assertTrue(doc.getContext().contains(munip.getNames()));
     }
 
     /**
@@ -174,12 +174,12 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(2, importer.size());
+        assertEquals(2, importer.size());
 
         PhotonDoc doc = importer.get(village);
 
         AssertUtil.assertNoAddress(doc, AddressType.CITY);
-        Assert.assertTrue(doc.getContext().contains(munip.getNames()));
+        assertTrue(doc.getContext().contains(munip.getNames()));
     }
 
     /**
@@ -192,10 +192,10 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(2, importer.size());
+        assertEquals(2, importer.size());
 
         PhotonDoc doc = importer.get(place);
-        Assert.assertEquals(doc.getHouseNumber(), "123");
+        assertEquals(doc.getHouseNumber(), "123");
     }
 
     /**
@@ -208,7 +208,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(4, importer.size());
+        assertEquals(4, importer.size());
 
         importer.assertContains(place, 1);
         importer.assertContains(place, 2);
@@ -228,7 +228,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(3, importer.size());
+        assertEquals(3, importer.size());
 
         importer.assertContains(place, 34);
         importer.assertContains(place, 99521);
@@ -243,7 +243,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(1, importer.size());
+        assertEquals(1, importer.size());
 
         importer.get(parent);
     }
@@ -258,7 +258,7 @@ public class NominatimConnectorDBTest {
 
         connector.readEntireDatabase();
 
-        Assert.assertEquals(1, importer.size());
+        assertEquals(1, importer.size());
 
         importer.get(parent);
     }

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorTest.java
@@ -1,8 +1,8 @@
 package de.komoot.photon.nominatim;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NominatimConnectorTest {
 

--- a/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
@@ -3,11 +3,11 @@ package de.komoot.photon.nominatim;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NominatimResultTest {
     private final PhotonDoc simpleDoc = new PhotonDoc(10000, "N", 123, "place", "house")

--- a/src/test/java/de/komoot/photon/nominatim/model/AddressTypeTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/model/AddressTypeTest.java
@@ -1,13 +1,13 @@
 package de.komoot.photon.nominatim.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AddressTypeTest {
 
     /**
-     * All ranks coverd by Nominatim must return a corresponding Photon rank.
+     * All ranks covered by Nominatim must return a corresponding Photon rank.
      */
     @Test
     public void testAllRanksAreCovered() {

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -4,10 +4,11 @@ import com.vividsolutions.jts.io.ParseException;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 public class CollectingImporter implements Importer {
@@ -26,7 +27,7 @@ public class CollectingImporter implements Importer {
     }
 
     public void assertFinishCalled(int num) {
-        Assert.assertEquals(num, finishCalled);
+        assertEquals(num, finishCalled);
     }
 
     public int size() {
@@ -44,7 +45,7 @@ public class CollectingImporter implements Importer {
             }
         }
 
-        Assert.fail("No document found with that place_id.");
+        fail("No document found with that place_id.");
         return null;
     }
 
@@ -52,12 +53,12 @@ public class CollectingImporter implements Importer {
         PhotonDoc doc = null;
         for (PhotonDoc outdoc : docs) {
             if (outdoc.getPlaceId() == row.getPlaceId()) {
-                Assert.assertNull("Row is contained multiple times", doc);
+                assertNull(doc, "Row is contained multiple times");
                 doc = outdoc;
             }
         }
 
-        Assert.assertNotNull("Row not found", doc);
+        assertNotNull(doc, "Row not found");
 
         row.assertEquals(doc);
     }
@@ -67,12 +68,12 @@ public class CollectingImporter implements Importer {
         PhotonDoc doc = null;
         for (PhotonDoc outdoc : docs) {
             if (outdoc.getPlaceId() == row.getPlaceId() && hnrstr.equals(outdoc.getHouseNumber())) {
-                Assert.assertNull("Row is contained multiple times", doc);
+                assertNull(doc, "Row is contained multiple times");
                 doc = outdoc;
             }
         }
 
-        Assert.assertNotNull("Row not found", doc);
+        assertNotNull(doc, "Row not found");
 
         row.assertEquals(doc);
     }}

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -5,11 +5,12 @@ import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
 import lombok.Getter;
 import org.json.JSONObject;
-import org.junit.Assert;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
 
 @Getter
 public class PlacexTestRow {
@@ -131,12 +132,12 @@ public class PlacexTestRow {
     }
 
     public void assertEquals(PhotonDoc doc) throws ParseException {
-        Assert.assertEquals(osmType, doc.getOsmType());
-        Assert.assertEquals(osmId, (Long) doc.getOsmId());
-        Assert.assertEquals(key, doc.getTagKey());
-        Assert.assertEquals(value, doc.getTagValue());
-        Assert.assertEquals(rankAddress, (Integer) doc.getRankAddress());
-        Assert.assertEquals(new WKTReader().read(centroid), doc.getCentroid());
-        Assert.assertEquals(names, doc.getName());
+        Assertions.assertEquals(osmType, doc.getOsmType());
+        Assertions.assertEquals(osmId, (Long) doc.getOsmId());
+        Assertions.assertEquals(key, doc.getTagKey());
+        Assertions.assertEquals(value, doc.getTagValue());
+        Assertions.assertEquals(rankAddress, (Integer) doc.getRankAddress());
+        Assertions.assertEquals(new WKTReader().read(centroid), doc.getCentroid());
+        Assertions.assertEquals(names, doc.getName());
     }
 }

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -5,8 +5,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.vividsolutions.jts.geom.Envelope;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import spark.QueryParamsMap;
 import spark.Request;
@@ -29,10 +29,10 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         photonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", photonRequest.getQuery());
-        Assert.assertEquals(-87, photonRequest.getLocationForBias().getX(), 0);
-        Assert.assertEquals(41, photonRequest.getLocationForBias().getY(), 0);
-        Assert.assertEquals(new Integer(5), photonRequest.getLimit());
+        assertEquals("berlin", photonRequest.getQuery());
+        assertEquals(-87, photonRequest.getLocationForBias().getX(), 0);
+        assertEquals(41, photonRequest.getLocationForBias().getY(), 0);
+        assertEquals(new Integer(5), photonRequest.getLimit());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
@@ -48,8 +48,8 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", photonRequest.getQuery());
-        Assert.assertNull(photonRequest.getLocationForBias());
+        assertEquals("berlin", photonRequest.getQuery());
+        assertNull(photonRequest.getLocationForBias());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
@@ -67,9 +67,9 @@ public class PhotonRequestFactoryTest {
         try {
             PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
-            Assert.fail();
+            fail();
         } catch (BadRequestException e) {
-            Assert.assertEquals("invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0", e.getMessage());
+            assertEquals("invalid search term 'lat' and/or 'lon', try instead lat=51.5&lon=8.0", e.getMessage());
         }
         
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
@@ -86,8 +86,8 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", photonRequest.getQuery());
-        Assert.assertEquals(new Integer(15), photonRequest.getLimit());
+        assertEquals("berlin", photonRequest.getQuery());
+        assertEquals(new Integer(15), photonRequest.getLimit());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("limit");
     }
@@ -99,9 +99,9 @@ public class PhotonRequestFactoryTest {
         try {
             PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
-            Assert.fail();
+            fail();
         } catch (BadRequestException e) {
-            Assert.assertEquals("missing search term 'q': /?q=berlin", e.getMessage());
+            assertEquals("missing search term 'q': /?q=berlin", e.getMessage());
         }
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
     }
@@ -116,11 +116,11 @@ public class PhotonRequestFactoryTest {
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.keys());
+        assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.keys());
     }
 
     @Test
@@ -133,10 +133,10 @@ public class PhotonRequestFactoryTest {
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.tags());
+        assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.tags());
     }
 
     @Test
@@ -149,11 +149,11 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.values());
+        assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.values());
     }
 
     @Test
@@ -166,11 +166,11 @@ public class PhotonRequestFactoryTest {
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.notKeys());
+        assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.notKeys());
     }
 
     @Test
@@ -183,10 +183,10 @@ public class PhotonRequestFactoryTest {
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.notTags());
+        assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.notTags());
     }
 
     @Test
@@ -199,11 +199,11 @@ public class PhotonRequestFactoryTest {
         PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
-        Assert.assertEquals("berlin", filteredPhotonRequest.getQuery());
+        assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        Assert.assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.notValues());
+        assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.notValues());
     }
     
     @Test
@@ -218,7 +218,7 @@ public class PhotonRequestFactoryTest {
         PhotonRequest photonRequest = photonRequestFactory.create(mockRequest); 
         
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("bbox");
-        Assert.assertEquals(new Envelope(9.6, 9.8, 52.3, 52.4), photonRequest.getBbox());
+        assertEquals(new Envelope(9.6, 9.8, 52.3, 52.4), photonRequest.getBbox());
     }
 
     @Test
@@ -232,9 +232,9 @@ public class PhotonRequestFactoryTest {
         try {
             PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequestFactory.create(mockRequest);
-            Assert.fail();
+            fail();
         } catch (BadRequestException e) {
-            Assert.assertEquals(BoundingBoxParamConverter.INVALID_BBOX_ERROR_MESSAGE, e.getMessage());
+            assertEquals(BoundingBoxParamConverter.INVALID_BBOX_ERROR_MESSAGE, e.getMessage());
         }
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("bbox");
     }
@@ -270,9 +270,9 @@ public class PhotonRequestFactoryTest {
         try {
             PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
             photonRequestFactory.create(mockRequest);
-            Assert.fail();
+            fail();
         } catch (BadRequestException e) {
-            Assert.assertEquals(BoundingBoxParamConverter.INVALID_BBOX_BOUNDS_MESSAGE, e.getMessage());
+            assertEquals(BoundingBoxParamConverter.INVALID_BBOX_BOUNDS_MESSAGE, e.getMessage());
         }
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("bbox");
     }

--- a/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -20,9 +20,9 @@ public class PhotonRequestTest {
         request.setUpTagFilters(new String[]{"key:value", "12!:34"});
 
         Map<String, Set<String>> tags = request.tags();
-        Assert.assertEquals(2, tags.size());
-        Assert.assertEquals(new HashSet<>(Arrays.asList("value")), tags.get("key"));
-        Assert.assertEquals(new HashSet<>(Arrays.asList("34")), tags.get("12!"));
+        assertEquals(2, tags.size());
+        assertEquals(new HashSet<>(Arrays.asList("value")), tags.get("key"));
+        assertEquals(new HashSet<>(Arrays.asList("34")), tags.get("12!"));
     }
 
     @Test
@@ -31,8 +31,8 @@ public class PhotonRequestTest {
         request.setUpTagFilters(new String[]{"!foo:234", "!foo:!abc"});
 
         Map<String, Set<String>> tags = request.notTags();
-        Assert.assertEquals(1, tags.size());
-        Assert.assertEquals(new HashSet<>(Arrays.asList("234", "abc")), tags.get("foo"));
+        assertEquals(1, tags.size());
+        assertEquals(new HashSet<>(Arrays.asList("234", "abc")), tags.get("foo"));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class PhotonRequestTest {
         PhotonRequest request = simpleRequest();
         request.setUpTagFilters(new String[]{"highway", "path"});
 
-        Assert.assertEquals(new HashSet<>(Arrays.asList("highway", "path")), request.keys());
+        assertEquals(new HashSet<>(Arrays.asList("highway", "path")), request.keys());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class PhotonRequestTest {
         PhotonRequest request = simpleRequest();
         request.setUpTagFilters(new String[]{"!amenity", "!place"});
 
-        Assert.assertEquals(new HashSet<>(Arrays.asList("amenity", "place")), request.notKeys());
+        assertEquals(new HashSet<>(Arrays.asList("amenity", "place")), request.notKeys());
     }
 
 
@@ -57,7 +57,7 @@ public class PhotonRequestTest {
         PhotonRequest request = simpleRequest();
         request.setUpTagFilters(new String[]{":hotel", ":restaurant"});
 
-        Assert.assertEquals(new HashSet<>(Arrays.asList("hotel", "restaurant")), request.values());
+        assertEquals(new HashSet<>(Arrays.asList("hotel", "restaurant")), request.values());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class PhotonRequestTest {
         PhotonRequest request = simpleRequest();
         request.setUpTagFilters(new String[]{":!123", ":!1234"});
 
-        Assert.assertEquals(new HashSet<>(Arrays.asList("123", "1234")), request.notValues());
+        assertEquals(new HashSet<>(Arrays.asList("123", "1234")), request.notValues());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class PhotonRequestTest {
         request.setUpTagFilters(new String[]{"foo:!bar"});
 
         Map<String, Set<String>> tags = request.tagNotValues();
-        Assert.assertEquals(1, tags.size());
-        Assert.assertEquals(new HashSet<>(Arrays.asList("bar")), tags.get("foo"));
+        assertEquals(1, tags.size());
+        assertEquals(new HashSet<>(Arrays.asList("bar")), tags.get("foo"));
     }
 }

--- a/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
@@ -7,15 +7,15 @@ import de.komoot.photon.PhotonDoc;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests that the {@link PhotonQueryBuilder} produces query which can find all
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 public class QueryBasicSearchTest extends ESBaseTester {
     private int testDocId = 10000;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         setUpES();
     }

--- a/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
@@ -10,19 +10,19 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class QueryByClassificationTest extends ESBaseTester {
     private int testDocId = 10000;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         setUpES();
     }

--- a/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
@@ -6,8 +6,9 @@ import de.komoot.photon.elasticsearch.Importer;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 import java.io.IOException;

--- a/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
@@ -3,7 +3,6 @@ package de.komoot.photon.query;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.elasticsearch.Importer;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,15 +11,17 @@ import de.komoot.photon.elasticsearch.PhotonIndex;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class QueryFilterTagValueTest extends ESBaseTester {
     private static final String[] TAGS = new String[]{"tourism", "attraction", "tourism", "hotel", "tourism", "museum", "tourism", "information", "amenity",
             "parking", "amenity", "restaurant", "amenity", "information", "food", "information", "railway", "station"};
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setUpES();
         Importer instance = makeImporter();

--- a/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/RequestLanguageTest.java
@@ -1,15 +1,14 @@
 package de.komoot.photon.query;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spark.Request;
 
 import java.util.List;
 
 import static de.komoot.photon.query.RequestLanguageResolver.ACCEPT_LANGUAGE_HEADER;
 import static java.util.Arrays.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class RequestLanguageTest {
@@ -19,7 +18,7 @@ public class RequestLanguageTest {
 
     private static final String DEFAULT_LANGUAGE = "en";
 
-    @Before
+    @BeforeEach
     public void setup() {
         languageResolver = new RequestLanguageResolver(supportedLangs, DEFAULT_LANGUAGE);
     }

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -6,10 +6,11 @@
 package de.komoot.photon.query;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import spark.Request;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author svantulden
@@ -30,8 +31,8 @@ public class ReverseRequestFactoryTest {
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
         ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
-        Assert.assertEquals(-87, reverseRequest.getLocation().getX(), 0);
-        Assert.assertEquals(41, reverseRequest.getLocation().getY(), 0);
+        assertEquals(-87, reverseRequest.getLocation().getX(), 0);
+        assertEquals(41, reverseRequest.getLocation().getY(), 0);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lon");
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("lat");
     }
@@ -40,9 +41,9 @@ public class ReverseRequestFactoryTest {
         try {
             ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
             reverseRequest = reverseRequestFactory.create(mockRequest);
-            Assert.fail();
+            fail();
         } catch (BadRequestException e) {
-            Assert.assertEquals(expectedMessage, e.getMessage());
+            assertEquals(expectedMessage, e.getMessage());
         }
     }
 
@@ -133,7 +134,7 @@ public class ReverseRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("radius")).thenReturn("5.1");
         ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
-        Assert.assertEquals(reverseRequest.getRadius(), 5.1d, 0);
+        assertEquals(reverseRequest.getRadius(), 5.1d, 0);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("radius");
     }
 
@@ -159,7 +160,7 @@ public class ReverseRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("limit")).thenReturn("51");
         ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
-        Assert.assertEquals(reverseRequest.getLimit().longValue(), 50);
+        assertEquals(reverseRequest.getLimit().longValue(), 50);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("limit");
     }
     
@@ -170,6 +171,6 @@ public class ReverseRequestFactoryTest {
         ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("distance_sort", "true");
-        Assert.assertEquals(true, reverseRequest.getLocationDistanceSort());
+        assertEquals(true, reverseRequest.getLocationDistanceSort());
     }
 }

--- a/src/test/java/de/komoot/photon/searcher/StreetDupesRemoverTest.java
+++ b/src/test/java/de/komoot/photon/searcher/StreetDupesRemoverTest.java
@@ -2,11 +2,12 @@ package de.komoot.photon.searcher;
 
 import de.komoot.photon.Constants;
 import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StreetDupesRemoverTest {
 
@@ -18,7 +19,7 @@ public class StreetDupesRemoverTest {
         allResults.add(createDummyResult("99999", "Main Street", "highway", "Unclassified"));
 
         List<JSONObject> dedupedResults = streetDupesRemover.execute(allResults);
-        Assert.assertEquals(1, dedupedResults.size());
+        assertEquals(1, dedupedResults.size());
     }
 
     @Test
@@ -29,7 +30,7 @@ public class StreetDupesRemoverTest {
         allResults.add(createDummyResult("99999", "Main Street", "highway", "Unclassified"));
 
         List<JSONObject> dedupedResults = streetDupesRemover.execute(allResults);
-        Assert.assertEquals(2, dedupedResults.size());
+        assertEquals(2, dedupedResults.size());
     }
     
     private JSONObject createDummyResult(String postCode, String name, String osmKey,

--- a/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
+++ b/src/test/java/de/komoot/photon/utils/ConvertToJsonTest.java
@@ -8,9 +8,9 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/test/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/src/test/java/org/elasticsearch/bootstrap/JarHell.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.logging.Loggers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Simple check for duplicate class files across the classpath.
+ * <p>
+ * This class checks for incompatibilities in the following ways:
+ * <ul>
+ *   <li>Checks that class files are not duplicated across jars.</li>
+ *   <li>Checks any {@code X-Compile-Target-JDK} value in the jar
+ *       manifest is compatible with current JRE</li>
+ *   <li>Checks any {@code X-Compile-Elasticsearch-Version} value in
+ *       the jar manifest is compatible with the current ES</li>
+ * </ul>
+ */
+public class JarHell {
+
+    /** no instantiation */
+    private JarHell() {}
+
+    /** Simple driver class, can be used eg. from builds. Returns non-zero on jar-hell */
+    @SuppressForbidden(reason = "command line tool")
+    public static void main(String args[]) throws Exception {
+        System.out.println("checking for jar hell...");
+        checkJarHell();
+        System.out.println("no jar hell found");
+    }
+
+    /**
+     * Checks the current classpath for duplicate classes
+     * @throws IllegalStateException if jar hell was found
+     */
+    public static void checkJarHell() throws IOException, URISyntaxException {
+        ClassLoader loader = JarHell.class.getClassLoader();
+        Logger logger = Loggers.getLogger(JarHell.class);
+        if (logger.isDebugEnabled()) {
+            logger.debug("java.class.path: {}", System.getProperty("java.class.path"));
+            logger.debug("sun.boot.class.path: {}", System.getProperty("sun.boot.class.path"));
+            if (loader instanceof URLClassLoader ) {
+                logger.debug("classloader urls: {}", Arrays.toString(((URLClassLoader)loader).getURLs()));
+             }
+        }
+        checkJarHell(parseClassPath());
+    }
+
+    /**
+     * Parses the classpath into an array of URLs
+     * @return array of URLs
+     * @throws IllegalStateException if the classpath contains empty elements
+     */
+    public static Set<URL> parseClassPath()  {
+        return parseClassPath(System.getProperty("java.class.path"));
+    }
+
+    /**
+     * Parses the classpath into a set of URLs. For testing.
+     * @param classPath classpath to parse (typically the system property {@code java.class.path})
+     * @return array of URLs
+     * @throws IllegalStateException if the classpath contains empty elements
+     */
+    @SuppressForbidden(reason = "resolves against CWD because that is how classpaths work")
+    static Set<URL> parseClassPath(String classPath) {
+        String pathSeparator = System.getProperty("path.separator");
+        String fileSeparator = System.getProperty("file.separator");
+        String elements[] = classPath.split(pathSeparator);
+        Set<URL> urlElements = new LinkedHashSet<>(); // order is already lost, but some filesystems have it
+        for (String element : elements) {
+            // Technically empty classpath element behaves like CWD.
+            // So below is the "correct" code, however in practice with ES, this is usually just a misconfiguration,
+            // from old shell scripts left behind or something:
+            //   if (element.isEmpty()) {
+            //      element = System.getProperty("user.dir");
+            //   }
+            // Instead we just throw an exception, and keep it clean.
+            if (element.isEmpty()) {
+                throw new IllegalStateException("Classpath should not contain empty elements! (outdated shell script from a previous version?) classpath='" + classPath + "'");
+            }
+            // we should be able to just Paths.get() each element, but unfortunately this is not the
+            // whole story on how classpath parsing works: if you want to know, start at sun.misc.Launcher,
+            // be sure to stop before you tear out your eyes. we just handle the "alternative" filename
+            // specification which java seems to allow, explicitly, right here...
+            if (element.startsWith("/") && "\\".equals(fileSeparator)) {
+                // "correct" the entry to become a normal entry
+                // change to correct file separators
+                element = element.replace("/", "\\");
+                // if there is a drive letter, nuke the leading separator
+                if (element.length() >= 3 && element.charAt(2) == ':') {
+                    element = element.substring(1);
+                }
+            }
+            // now just parse as ordinary file
+            try {
+                URL url = PathUtils.get(element).toUri().toURL();
+                if (urlElements.add(url) == false) {
+                    throw new IllegalStateException("jar hell!" + System.lineSeparator() +
+                        "duplicate jar [" + element + "] on classpath: " + classPath);
+                }
+            } catch (MalformedURLException e) {
+                // should not happen, as we use the filesystem API
+                throw new RuntimeException(e);
+            }
+        }
+        return Collections.unmodifiableSet(urlElements);
+    }
+
+    /**
+     * Checks the set of URLs for duplicate classes
+     * @throws IllegalStateException if jar hell was found
+     */
+    @SuppressForbidden(reason = "needs JarFile for speed, just reading entries")
+    public static void checkJarHell(Set<URL> urls) throws URISyntaxException, IOException {
+        Logger logger = Loggers.getLogger(JarHell.class);
+        // we don't try to be sneaky and use deprecated/internal/not portable stuff
+        // like sun.boot.class.path, and with jigsaw we don't yet have a way to get
+        // a "list" at all. So just exclude any elements underneath the java home
+        String javaHome = System.getProperty("java.home");
+        logger.debug("java.home: {}", javaHome);
+        final Map<String,Path> clazzes = new HashMap<>(32768);
+        Set<Path> seenJars = new HashSet<>();
+        for (final URL url : urls) {
+            final Path path = PathUtils.get(url.toURI());
+            // exclude system resources
+            if (path.startsWith(javaHome)) {
+                logger.debug("excluding system resource: {}", path);
+                continue;
+            }
+            if (path.toString().endsWith(".jar")) {
+                if (!seenJars.add(path)) {
+                    throw new IllegalStateException("jar hell!" + System.lineSeparator() +
+                                                    "duplicate jar on classpath: " + path);
+                }
+                logger.debug("examining jar: {}", path);
+                try (JarFile file = new JarFile(path.toString())) {
+                    Manifest manifest = file.getManifest();
+                    if (manifest != null) {
+                        checkManifest(manifest, path);
+                    }
+                    // inspect entries
+                    Enumeration<JarEntry> elements = file.entries();
+                    while (elements.hasMoreElements()) {
+                        String entry = elements.nextElement().getName();
+                        if (entry.endsWith(".class")) {
+                            // for jar format, the separator is defined as /
+                            entry = entry.replace('/', '.').substring(0, entry.length() - 6);
+                            checkClass(clazzes, entry, path);
+                        }
+                    }
+                }
+            } else {
+                logger.debug("examining directory: {}", path);
+                // case for tests: where we have class files in the classpath
+                final Path root = PathUtils.get(url.toURI());
+                final String sep = root.getFileSystem().getSeparator();
+                Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        String entry = root.relativize(file).toString();
+                        if (entry.endsWith(".class")) {
+                            // normalize with the os separator, remove '.class'
+                            entry = entry.replace(sep, ".").substring(0,  entry.length() - ".class".length());
+                            checkClass(clazzes, entry, path);
+                        }
+                        return super.visitFile(file, attrs);
+                    }
+                });
+            }
+        }
+    }
+
+    /** inspect manifest for sure incompatibilities */
+    static void checkManifest(Manifest manifest, Path jar) {
+        // give a nice error if jar requires a newer java version
+        String targetVersion = manifest.getMainAttributes().getValue("X-Compile-Target-JDK");
+        if (targetVersion != null) {
+            checkVersionFormat(targetVersion);
+            checkJavaVersion(jar.toString(), targetVersion);
+        }
+
+        // give a nice error if jar is compiled against different es version
+        String systemESVersion = Version.CURRENT.toString();
+        String targetESVersion = manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Version");
+        if (targetESVersion != null && targetESVersion.equals(systemESVersion) == false) {
+            throw new IllegalStateException(jar + " requires Elasticsearch " + targetESVersion
+                    + ", your system: " + systemESVersion);
+        }
+    }
+
+    public static void checkVersionFormat(String targetVersion) {
+        if (!JavaVersion.isValid(targetVersion)) {
+            throw new IllegalStateException(
+                    String.format(
+                            Locale.ROOT,
+                            "version string must be a sequence of nonnegative decimal integers separated by \".\"'s and may have leading zeros but was %s",
+                            targetVersion
+                    )
+            );
+        }
+    }
+
+    /**
+     * Checks that the java specification version {@code targetVersion}
+     * required by {@code resource} is compatible with the current installation.
+     */
+    public static void checkJavaVersion(String resource, String targetVersion) {
+        JavaVersion version = JavaVersion.parse(targetVersion);
+        if (JavaVersion.current().compareTo(version) < 0) {
+            throw new IllegalStateException(
+                    String.format(
+                            Locale.ROOT,
+                            "%s requires Java %s:, your system: %s",
+                            resource,
+                            targetVersion,
+                            JavaVersion.current().toString()
+                    )
+            );
+        }
+    }
+
+    static void checkClass(Map<String,Path> clazzes, String clazz, Path jarpath) {
+        if (clazz.equals("module-info") || clazz.endsWith(".module-info") || clazz.startsWith("org.elasticsearch.bootstrap.JarHell")) {
+            return;
+        }
+        Path previous = clazzes.put(clazz, jarpath);
+        if (previous != null) {
+            if (previous.equals(jarpath)) {
+                if (clazz.startsWith("org.apache.xmlbeans")) {
+                    return; // https://issues.apache.org/jira/browse/XMLBEANS-499
+                }
+                // throw a better exception in this ridiculous case.
+                // unfortunately the zip file format allows this buggy possibility
+                // UweSays: It can, but should be considered as bug :-)
+                throw new IllegalStateException("jar hell!" + System.lineSeparator() +
+                        "class: " + clazz + System.lineSeparator() +
+                        "exists multiple times in jar: " + jarpath + " !!!!!!!!!");
+            } else {
+                throw new IllegalStateException("jar hell!" + System.lineSeparator() +
+                        "class: " + clazz + System.lineSeparator() +
+                        "jar1: " + previous + System.lineSeparator() +
+                        "jar2: " + jarpath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
JUnit 5 has a few gimmicks like parametrized tests that I'm looking forward to use. This PR just contains the necessary syntax changes to run our tests under JUnit5. With our rather basic use of the test framework, there are no bigger changes necessary on that side.

I did run into the problem again with ES' JarHell wrongly detecting the module-info as a duplicate. To work around that the tests now come with a patched version of the JarHell.java file that has a backport of the changes in https://github.com/elastic/elasticsearch/pull/33011 to ES 5.6. It ignores module-info and JarHell.java files (because, being a good duplicate detector, it detects itself correctly as a duplicate). It's a good-enough workaround for the tests but not really something I would want to use on the binary.

