### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
-            <artifactId>nv-i18n</artifactId>
-            <version>1.27</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
             <version>3.12.0</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
-            <version>1.9.13</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.22</version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.78</version>
+            <version>1.82</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.10</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.6</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.3</version>
         </dependency>
         <dependency>
             <groupId>net.postgis</groupId>
@@ -147,17 +147,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20190722</version>
+            <version>20211205</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -1,7 +1,6 @@
 package de.komoot.photon;
 
 import com.google.common.collect.ImmutableMap;
-import com.neovisionaries.i18n.CountryCode;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
@@ -31,7 +30,7 @@ public class PhotonDoc {
     private Envelope bbox = null;
     private long parentPlaceId = 0; // 0 if unset
     private double importance = 0;
-    private CountryCode countryCode = null;
+    private String countryCode = null;
     private long linkedPlaceId = 0; // 0 if unset
     private int rankAddress = 30;
 
@@ -92,7 +91,7 @@ public class PhotonDoc {
     }
 
     public PhotonDoc countryCode(String countryCode) {
-        this.countryCode = CountryCode.getByCode(countryCode, false);
+        this.countryCode = countryCode.toUpperCase();
         return this;
     }
 

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -3,7 +3,6 @@ package de.komoot.photon;
 import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import com.neovisionaries.i18n.CountryCode;
 import com.vividsolutions.jts.geom.Envelope;
 import de.komoot.photon.nominatim.model.AddressType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -57,9 +56,9 @@ public class Utils {
         for (Map.Entry<AddressType, Map<String, String>> entry : doc.getAddressParts().entrySet()) {
             writeIntlNames(builder, entry.getValue(), entry.getKey().getName(), languages);
         }
-        CountryCode countryCode = doc.getCountryCode();
+        String countryCode = doc.getCountryCode();
         if (countryCode != null)
-            builder.field(Constants.COUNTRYCODE, countryCode.getAlpha2());
+            builder.field(Constants.COUNTRYCODE, countryCode);
         writeContext(builder, doc.getContext(), languages);
         writeExtraTags(builder, doc.getExtratags(), extraTags);
         writeExtent(builder, doc.getBbox());

--- a/src/test/java/de/komoot/photon/PhotonDocTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocTest.java
@@ -38,7 +38,7 @@ public class PhotonDocTest {
         PhotonDoc doc = new PhotonDoc(1, "W", 2, "highway", "residential").countryCode("de");
 
         assertNotNull(doc.getCountryCode());
-        assertEquals("DE", doc.getCountryCode().getAlpha2());
+        assertEquals("DE", doc.getCountryCode());
     }
 
     private PhotonDoc simplePhotonDoc() {


### PR DESCRIPTION
Update dependencies where possible. (Still stuck with log4j and jts.)

Also removes the use of nv-i18n. It was only used for country codes. given that they are already sanitized by Nominatim, there is no need to go through a separate library for them.