### PR TITLE
Add counties to collectors

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
@@ -59,6 +59,7 @@ public class IndexMapping {
             // add language specific tags to the collector
             addToCollector("city", propertiesObject, copyToCollectorObject, lang);
             addToCollector("context", propertiesObject, copyToCollectorObject, lang);
+            addToCollector("county", propertiesObject, copyToCollectorObject, lang);
             addToCollector("country", propertiesObject, copyToCollectorObject, lang);
             addToCollector("state", propertiesObject, copyToCollectorObject, lang);
             addToCollector("street", propertiesObject, copyToCollectorObject, lang);


### PR DESCRIPTION
#468 forgot to add the mappings that ensure that county names are copied into the collectors. So searching by county never worked. They were just displayed. This PR fixes that.

Also adds tests for searching for address parts.