### PR TITLE
Ensure ImportThread is always terminated.

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -264,31 +264,34 @@ public class NominatimConnector {
 
         ImportThread importThread = new ImportThread(importer);
 
-        template.query(SELECT_COLS_PLACEX + " FROM placex " +
-                " WHERE linked_place_id IS NULL AND centroid IS NOT NULL " + andCountryCodeStr +
-                " ORDER BY geometry_sector, parent_place_id; ", rs -> {
-                    // turns a placex row into a photon document that gathers all de-normalised information
-                    NominatimResult docs = placeRowMapper.mapRow(rs, 0);
-                    assert(docs != null);
+        try {
+            template.query(SELECT_COLS_PLACEX + " FROM placex " +
+                    " WHERE linked_place_id IS NULL AND centroid IS NOT NULL " + andCountryCodeStr +
+                    " ORDER BY geometry_sector, parent_place_id; ", rs -> {
+                // turns a placex row into a photon document that gathers all de-normalised information
+                NominatimResult docs = placeRowMapper.mapRow(rs, 0);
+                assert (docs != null);
 
-                    if (docs.isUsefulForIndex()) {
-                        importThread.addDocument(docs);
-                    }
-                });
+                if (docs.isUsefulForIndex()) {
+                    importThread.addDocument(docs);
+                }
+            });
 
-        template.query(selectOsmlineSql + " FROM location_property_osmline " +
-                "WHERE startnumber is not null " +
-                andCountryCodeStr +
-                " ORDER BY geometry_sector, parent_place_id; ", rs -> {
-                    NominatimResult docs = osmlineRowMapper.mapRow(rs, 0);
-                    assert(docs != null);
+            template.query(selectOsmlineSql + " FROM location_property_osmline " +
+                    "WHERE startnumber is not null " +
+                    andCountryCodeStr +
+                    " ORDER BY geometry_sector, parent_place_id; ", rs -> {
+                NominatimResult docs = osmlineRowMapper.mapRow(rs, 0);
+                assert (docs != null);
 
-                    if (docs.isUsefulForIndex()) {
-                        importThread.addDocument(docs);
-                    }
-                });
+                if (docs.isUsefulForIndex()) {
+                    importThread.addDocument(docs);
+                }
+            });
 
-        importThread.finish();
+        } finally {
+            importThread.finish();
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request solves the problem I observe with v0.3.5: if `-nominatim-import` is executed when the database is not reachable, the process never ever exits. This is due to `ImportThead.finish()` never being called, and thus `ImportThread` never terminating. 

Note: this issue is no longer observable with latest code. After https://github.com/komoot/photon/commit/45b3ec75356bf795ddb63b91a734e1eb49f74801 commit `NominatimConstructor` reaches to the database (and fails) before `ImportThread` is created, effectively masking the problem. 

However it can still fail, should any of the queries in `readEntireDatabase()` raise any exception.