### PR TITLE
Get rid of Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,11 +139,6 @@
            </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20211205</version>

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -1,6 +1,5 @@
 package de.komoot.photon;
 
-import com.google.common.collect.ImmutableMap;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
@@ -202,7 +201,7 @@ public class PhotonDoc {
                 }
                 // we keep the former name in the context as it might be helpful when looking up typos
                 if (!Objects.isNull(existingName)) {
-                    context.add(ImmutableMap.of("formerName", existingName));
+                    context.add(Collections.singletonMap("formerName", existingName));
                 }
                 map.put("name", field);
             }

--- a/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
@@ -1,7 +1,6 @@
 package de.komoot.photon.elasticsearch;
 
 
-import com.google.common.collect.ImmutableSet;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
@@ -14,8 +13,6 @@ import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.index.query.functionscore.WeightBuilder;
 
 import java.util.*;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 
 /**
@@ -166,7 +163,7 @@ public class PhotonQueryBuilder {
             scale = 0.0000001;
         }
 
-        Map<String, Object> params = newHashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("lon", point.getX());
         params.put("lat", point.getY());
 
@@ -300,30 +297,10 @@ public class PhotonQueryBuilder {
     }
 
 
-    public PhotonQueryBuilder withKeys(String... keys) {
-        return this.withKeys(ImmutableSet.<String>builder().add(keys).build());
-    }
-
-
-    public PhotonQueryBuilder withValues(String... values) {
-        return this.withValues(ImmutableSet.<String>builder().add(values).build());
-    }
-
-
-    public PhotonQueryBuilder withoutKeys(String... keysToExclude) {
-        return this.withoutKeys(ImmutableSet.<String>builder().add(keysToExclude).build());
-    }
-
-
-    public PhotonQueryBuilder withoutValues(String... valuesToExclude) {
-        return this.withoutValues(ImmutableSet.<String>builder().add(valuesToExclude).build());
-    }
-
-
     /**
-     * When this method is called, all filters are placed inside their {@link OrQueryBuilder OR} or {@link AndQueryBuilder AND} containers and the top level filter
-     * builder is built. Subsequent invocations of this method have no additional effect. Note that after this method is called, calling other methods on this class also
-     * have no effect.
+     * When this method is called, all filters are placed inside their containers and the top level filter
+     * builder is built. Subsequent invocations of this method have no additional effect. Note that after this method
+     * is called, calling other methods on this class also have no effect.
      */
     public QueryBuilder buildQuery() {
         if (state.equals(State.FINISHED)) return finalQueryBuilder;

--- a/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
@@ -3,7 +3,6 @@ package de.komoot.photon.nominatim;
 import com.vividsolutions.jts.geom.Geometry;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
@@ -20,7 +19,6 @@ public interface DBDataAdapter {
     /**
      * Create a JTS geometry from the given column data.
      */
-    @Nullable
     Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException;
 
     /**

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -1,16 +1,12 @@
 package de.komoot.photon.nominatim;
 
-import com.google.common.collect.ImmutableList;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.linearref.LengthIndexedLine;
 import de.komoot.photon.PhotonDoc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -39,7 +35,7 @@ class NominatimResult {
 
     List<PhotonDoc> getDocsWithHousenumber() {
         if (housenumbers == null || housenumbers.isEmpty()) {
-            return ImmutableList.of(doc);
+            return Collections.singletonList(doc);
         }
 
         List<PhotonDoc> results = new ArrayList<>(housenumbers.size());

--- a/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
@@ -1,14 +1,13 @@
 package de.komoot.photon.nominatim;
 
-import com.google.common.collect.Maps;
 import com.vividsolutions.jts.geom.Geometry;
 import org.postgis.jts.JtsGeometry;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
-import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -22,13 +21,12 @@ public class PostgisDataAdapter implements DBDataAdapter {
     public Map<String, String> getMap(ResultSet rs, String columnName) throws SQLException {
         Map<String, String> map = (Map<String, String>) rs.getObject(columnName);
         if (map == null) {
-            return Maps.newHashMap();
+            return new HashMap<>();
         }
 
         return map;
     }
 
-    @Nullable
     @Override
     public Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException {
         JtsGeometry geom = (JtsGeometry) rs.getObject(columnName);

--- a/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
+++ b/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
@@ -1,6 +1,5 @@
 package de.komoot.photon.query;
 
-import com.google.common.base.Joiner;
 import lombok.AllArgsConstructor;
 import spark.Request;
 import spark.utils.StringUtils;
@@ -70,7 +69,7 @@ public class RequestLanguageResolver {
      */
     private void checkLanguageSupported(String lang) throws BadRequestException {
         if (!("default".equals(lang) || supportedLanguages.contains((lang)))) {
-            throw new BadRequestException(400, "language " + lang + " is not supported, supported languages are: default, " + Joiner.on(", ").join(supportedLanguages));
+            throw new BadRequestException(400, "language " + lang + " is not supported, supported languages are: default, " + String.join(", ", supportedLanguages));
         }
     }
 }

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,6 +1,5 @@
 package de.komoot.photon;
 
-import com.google.common.collect.ImmutableMap;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Start an ES server with some test data that then can be queried in tests that extend this class
@@ -26,9 +26,8 @@ public class ESBaseTester {
     private Server server;
 
     protected PhotonDoc createDoc(double lon, double lat, int id, int osmId, String key, String value) {
-        ImmutableMap<String, String> nameMap = ImmutableMap.of("name", "berlin");
         Point location = FACTORY.createPoint(new Coordinate(lon, lat));
-        return new PhotonDoc(id, "W", osmId, key, value).names(nameMap).centroid(location);
+        return new PhotonDoc(id, "W", osmId, key, value).names(Collections.singletonMap("name", "berlin")).centroid(location);
     }
 
     protected GetResponse getById(int id) {

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -7,7 +7,6 @@ import de.komoot.photon.nominatim.DBDataAdapter;
 import org.json.JSONObject;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ public class H2DataAdapter implements DBDataAdapter {
         return out;
     }
 
-    @Nullable
     @Override
     public Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException {
         String wkt = (String) rs.getObject(columnName);

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -1,8 +1,5 @@
 package de.komoot.photon.query;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.vividsolutions.jts.geom.Envelope;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,6 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import spark.QueryParamsMap;
 import spark.Request;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by Sachin Dole on 2/12/2015.
@@ -27,7 +28,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("limit")).thenReturn("5");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         photonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", photonRequest.getQuery());
         assertEquals(-87, photonRequest.getLocationForBias().getX(), 0);
@@ -44,7 +45,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
         Mockito.when(mockRequest.queryParams("lon")).thenReturn(null);
         Mockito.when(mockRequest.queryParams("lat")).thenReturn(null);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
@@ -65,7 +66,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
             fail();
         } catch (BadRequestException e) {
@@ -82,7 +83,7 @@ public class PhotonRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         Mockito.when(mockRequest.queryParams("q")).thenReturn("berlin");
         Mockito.when(mockRequest.queryParams("limit")).thenReturn(null);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         QueryParamsMap mockQueryParamsMap = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         photonRequest = photonRequestFactory.create(mockRequest);
@@ -97,7 +98,7 @@ public class PhotonRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         Mockito.when(mockRequest.queryParams("q")).thenReturn(null);
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
             photonRequest = photonRequestFactory.create(mockRequest);
             fail();
         } catch (BadRequestException e) {
@@ -113,14 +114,17 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"aTag"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.keys());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aTag");
+        assertEquals(expectedValue, filteredPhotonRequest.keys());
     }
 
     @Test
@@ -130,13 +134,16 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"aTag:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.tags());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aValue");
+        assertEquals(Collections.singletonMap("aTag", expectedValue), filteredPhotonRequest.tags());
     }
 
     @Test
@@ -147,13 +154,16 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{":aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.values());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aValue");
+        assertEquals(expectedValue, filteredPhotonRequest.values());
     }
 
     @Test
@@ -163,14 +173,17 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!aTag"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableSet.of("aTag"), filteredPhotonRequest.notKeys());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aTag");
+        assertEquals(expectedValue, filteredPhotonRequest.notKeys());
     }
 
     @Test
@@ -180,13 +193,16 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!aTag:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableMap.of("aTag", ImmutableSet.of("aValue")), filteredPhotonRequest.notTags());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aValue");
+        assertEquals(Collections.singletonMap("aTag", expectedValue), filteredPhotonRequest.notTags());
     }
 
     @Test
@@ -196,14 +212,17 @@ public class PhotonRequestFactoryTest {
         QueryParamsMap mockOsmTagQueryParm = Mockito.mock(QueryParamsMap.class);
         Mockito.when(mockOsmTagQueryParm.values()).thenReturn(new String[]{"!:aValue"});
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockOsmTagQueryParm);
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         Mockito.when(mockOsmTagQueryParm.hasValue()).thenReturn(true);
         PhotonRequest filteredPhotonRequest = photonRequestFactory.create(mockRequest);
         assertEquals("berlin", filteredPhotonRequest.getQuery());
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("q");
         Mockito.verify(mockRequest, Mockito.times(1)).queryMap("osm_tag");
         Mockito.verify(mockOsmTagQueryParm, Mockito.times(2)).values();
-        assertEquals(ImmutableSet.of("aValue"), filteredPhotonRequest.notValues());
+
+        Set<String> expectedValue = new HashSet<>();
+        expectedValue.add("aValue");
+        assertEquals(expectedValue, filteredPhotonRequest.notValues());
     }
     
     @Test
@@ -214,7 +233,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryMap("osm_tag")).thenReturn(mockQueryParamsMap);
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn("9.6,52.3,9.8,52.4");
         
-        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+        PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
         PhotonRequest photonRequest = photonRequestFactory.create(mockRequest); 
         
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("bbox");
@@ -230,7 +249,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn("9.6,52.3,9.8");
 
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
             photonRequestFactory.create(mockRequest);
             fail();
         } catch (BadRequestException e) {
@@ -268,7 +287,7 @@ public class PhotonRequestFactoryTest {
         Mockito.when(mockRequest.queryParams("bbox")).thenReturn(minLon + "," + minLat + "," + maxLon + "," + maxLat);
 
         try {
-            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(ImmutableList.of("en"), "en");
+            PhotonRequestFactory photonRequestFactory = new PhotonRequestFactory(Collections.singletonList("en"), "en");
             photonRequestFactory.create(mockRequest);
             fail();
         } catch (BadRequestException e) {

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -5,10 +5,11 @@
  */
 package de.komoot.photon.query;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import spark.Request;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,7 +30,7 @@ public class ReverseRequestFactoryTest {
     public void testWithLocation() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(Collections.singletonList("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         assertEquals(-87, reverseRequest.getLocation().getX(), 0);
         assertEquals(41, reverseRequest.getLocation().getY(), 0);
@@ -39,7 +40,7 @@ public class ReverseRequestFactoryTest {
 
     public void assertBadRequest(Request mockRequest, String expectedMessage) {
         try {
-            ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
+            ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(Collections.singletonList("en"), "en");
             reverseRequest = reverseRequestFactory.create(mockRequest);
             fail();
         } catch (BadRequestException e) {
@@ -132,7 +133,7 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
         Mockito.when(mockRequest.queryParams("radius")).thenReturn("5.1");
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(Collections.singletonList("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         assertEquals(reverseRequest.getRadius(), 5.1d, 0);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("radius");
@@ -158,7 +159,7 @@ public class ReverseRequestFactoryTest {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
         Mockito.when(mockRequest.queryParams("limit")).thenReturn("51");
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(Collections.singletonList("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         assertEquals(reverseRequest.getLimit().longValue(), 50);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParams("limit");
@@ -168,7 +169,7 @@ public class ReverseRequestFactoryTest {
     public void testDistanceSortDefault() throws Exception {
         Request mockRequest = Mockito.mock(Request.class);
         requestWithLongitudeLatitude(mockRequest, -87d, 41d);
-        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(ImmutableList.of("en"), "en");
+        ReverseRequestFactory reverseRequestFactory = new ReverseRequestFactory(Collections.singletonList("en"), "en");
         reverseRequest = reverseRequestFactory.create(mockRequest);
         Mockito.verify(mockRequest, Mockito.times(1)).queryParamOrDefault("distance_sort", "true");
         assertEquals(true, reverseRequest.getLocationDistanceSort());


### PR DESCRIPTION
Most of the constructs that Photon uses from guava have a equivalent built-ins in  Java 8+. So no need to keep this dependency around.

The handling of sets in the tests for PhotonRequestFactory becomes a bit awkward. That's better fixed with improving the interface of PhotonRequest, though.