### PR TITLE
Fix geojson geometry type in GeocodeJsonFormatter

### DIFF
--- a/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
@@ -30,10 +30,10 @@ public class GeocodeJsonFormatter implements ResultFormatter {
             final double[] coordinates = result.getCoordinates();
 
             features.put(new JSONObject()
-                        .put("type", "feature")
+                        .put("type", "Feature")
                         .put("properties", getResultProperties(result))
                         .put("geometry", new JSONObject()
-                                .put("type", "feature")
+                                .put("type", "Point")
                                 .put("coordinates", coordinates)));
         }
 

--- a/src/test/java/de/komoot/photon/searcher/GeocodeJsonFormatterTest.java
+++ b/src/test/java/de/komoot/photon/searcher/GeocodeJsonFormatterTest.java
@@ -1,0 +1,45 @@
+package de.komoot.photon.searcher;
+
+import de.komoot.photon.Constants;
+import org.json.JSONObject;
+import org.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GeocodeJsonFormatterTest {
+
+    @Test
+    public void testConvertToGeojson() {
+        GeocodeJsonFormatter formatter = new GeocodeJsonFormatter(false, "en");
+        List<PhotonResult> allResults = new ArrayList<>();
+        allResults.add(createDummyResult("99999", "Park Foo", "leisure", "park"));
+        allResults.add(createDummyResult("88888", "Bar Park", "leisure", "park"));
+
+        String geojsonString = formatter.convert(allResults, null);
+        JSONObject jsonObj = new JSONObject(geojsonString);
+        assertEquals("FeatureCollection", jsonObj.getString("type"));
+        JSONArray features = jsonObj.getJSONArray("features");
+        assertEquals(2, features.length());
+        for (int i = 0; i < features.length(); i++) {
+            JSONObject feature = features.getJSONObject(i);
+            assertEquals("Feature", feature.getString("type"));
+            assertEquals("Point", feature.getJSONObject("geometry").getString("type"));
+            assertEquals("leisure", feature.getJSONObject("properties").getString(Constants.OSM_KEY));
+            assertEquals("park", feature.getJSONObject("properties").getString(Constants.OSM_VALUE));
+        }
+    }
+    
+    private PhotonResult createDummyResult(String postCode, String name, String osmKey,
+                    String osmValue) {
+        return new MockPhotonResult()
+                .put(Constants.POSTCODE, postCode)
+                .putLocalized(Constants.NAME, "en", name)
+                .put(Constants.OSM_KEY, osmKey)
+                .put(Constants.OSM_VALUE, osmValue);
+    }
+
+}


### PR DESCRIPTION
Fixes #656

Also use the constants instead of hard-coded strings in the
GeocodeJsonFormatter class and add unit tests for the geojson formatter.