### PR TITLE
Do not allow skipping words on two word queries

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
@@ -63,12 +63,12 @@ public class PhotonQueryBuilder {
                             .fuzziness(Fuzziness.ONE)
                             .prefixLength(2)
                             .analyzer("search_ngram")
-                            .minimumShouldMatch("-1"))
+                            .minimumShouldMatch("-34%"))
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
                             .fuzziness(Fuzziness.ONE)
                             .prefixLength(2)
                             .analyzer("search_ngram")
-                            .minimumShouldMatch("-1"))
+                            .minimumShouldMatch("-34%"))
                     .minimumShouldMatch("1");
         } else {
             MultiMatchQueryBuilder builder =

--- a/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
@@ -61,6 +61,21 @@ public class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
+    public void testSearchNameSkipTerms() {
+        Importer instance = makeImporter();
+        instance.add(createDoc("name", "Hunted House Hotel"));
+        instance.finish();
+        refresh();
+
+        assertAll("default name",
+                () -> assertEquals(1, search("hunted").size()),
+                () -> assertEquals(1, search("hunted hotel").size()),
+                () -> assertEquals(1, search("hunted house hotel").size()),
+                () -> assertEquals(1, search("hunted house hotel 7").size()),
+                () -> assertEquals(1, search("hunted hotel 7").size())
+        );
+    }
+    @Test
     public void testSearchByAlternativeNames() {
         Importer instance = makeImporter();
         instance.add(createDoc("name", "original", "alt_name", "alt", "old_name", "older", "int_name", "int",


### PR DESCRIPTION
In two-word queries with a typo, ES tends to prefer skipping the word with the typo over a fuzzy match. For example, https://photon.komoot.io/api/?q=eifelturm%20paris&lang=de rather returns Paris (skipping 'Eifelturm') instead of the obvious fuzzy match of 'Eiffelturm, Paris'.

This disables the word skipping for two-word queries. We can't really do it for three-word queries as we might want to skip over the house number in a query like 'Hauptstr 34, Berlin'.