### PR TITLE
Refactor Osm Tag filters

### DIFF
--- a/src/main/java/de/komoot/photon/elasticsearch/OsmTagFilter.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/OsmTagFilter.java
@@ -1,0 +1,74 @@
+package de.komoot.photon.elasticsearch;
+
+import java.util.List;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import de.komoot.photon.searcher.TagFilter;
+import de.komoot.photon.searcher.TagFilterKind;
+
+public class OsmTagFilter {
+    private BoolQueryBuilder orQueryBuilderForIncludeTagFiltering = null;
+    private BoolQueryBuilder andQueryBuilderForExcludeTagFiltering = null;
+    
+    public OsmTagFilter withOsmTagFilters(List<TagFilter> filters) {
+        for (TagFilter filter : filters) {
+            addOsmTagFilter(filter);
+        }
+        return this;
+    }
+
+    public BoolQueryBuilder getTagFiltersQuery() {
+        if (orQueryBuilderForIncludeTagFiltering != null || andQueryBuilderForExcludeTagFiltering != null) {
+            BoolQueryBuilder tagFilters = QueryBuilders.boolQuery();
+            if (orQueryBuilderForIncludeTagFiltering != null)
+                tagFilters.must(orQueryBuilderForIncludeTagFiltering);
+            if (andQueryBuilderForExcludeTagFiltering != null)
+                tagFilters.mustNot(andQueryBuilderForExcludeTagFiltering);
+            return tagFilters;
+        }
+        return null;
+    }
+
+    private OsmTagFilter addOsmTagFilter(TagFilter filter) {
+        if (filter.getKind() == TagFilterKind.EXCLUDE_VALUE) {
+            appendIncludeTermQuery(QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("osm_key", filter.getKey()))
+                    .mustNot(QueryBuilders.termQuery("osm_value", filter.getValue())));
+        } else {
+            QueryBuilder builder;
+            if (filter.isKeyOnly()) {
+                builder = QueryBuilders.termQuery("osm_key", filter.getKey());
+            } else if (filter.isValueOnly()) {
+                builder = QueryBuilders.termQuery("osm_value", filter.getValue());
+            } else {
+                builder = QueryBuilders.boolQuery()
+                        .must(QueryBuilders.termQuery("osm_key", filter.getKey()))
+                        .must(QueryBuilders.termQuery("osm_value", filter.getValue()));
+            }
+            if (filter.getKind() == TagFilterKind.INCLUDE) {
+                appendIncludeTermQuery(builder);
+            } else {
+                appendExcludeTermQuery(builder);
+            }
+        }
+        return this;
+    }
+
+    private void appendIncludeTermQuery(QueryBuilder termQuery) {
+        if (orQueryBuilderForIncludeTagFiltering == null)
+            orQueryBuilderForIncludeTagFiltering = QueryBuilders.boolQuery();
+
+        orQueryBuilderForIncludeTagFiltering.should(termQuery);
+    }
+
+
+    private void appendExcludeTermQuery(QueryBuilder termQuery) {
+        if (andQueryBuilderForExcludeTagFiltering == null)
+            andQueryBuilderForExcludeTagFiltering = QueryBuilders.boolQuery();
+
+        andQueryBuilderForExcludeTagFiltering.should(termQuery);
+    }
+}

--- a/src/main/java/de/komoot/photon/elasticsearch/ReverseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/ReverseQueryBuilder.java
@@ -2,7 +2,6 @@ package de.komoot.photon.elasticsearch;
 
 import com.vividsolutions.jts.geom.Point;
 import de.komoot.photon.searcher.TagFilter;
-import de.komoot.photon.searcher.TagFilterKind;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -21,14 +20,14 @@ public class ReverseQueryBuilder {
     private String queryStringFilter;
     private Set<String> layerFilter;
 
-    private BoolQueryBuilder orQueryBuilderForIncludeTagFiltering = null;
-    private BoolQueryBuilder andQueryBuilderForExcludeTagFiltering = null;
+    private OsmTagFilter osmTagFilter;
 
     private ReverseQueryBuilder(Point location, Double radius, String queryStringFilter, Set<String> layerFilter) {
         this.location = location;
         this.radius = radius;
         this.queryStringFilter = queryStringFilter;
         this.layerFilter = layerFilter;
+        this.osmTagFilter = new OsmTagFilter();
     }
 
     public static ReverseQueryBuilder builder(Point location, Double radius, String queryStringFilter, Set<String> layerFilter) {
@@ -48,12 +47,8 @@ public class ReverseQueryBuilder {
             finalQuery.must(new TermsQueryBuilder("type", layerFilter));
         }
 
-        if (orQueryBuilderForIncludeTagFiltering != null || andQueryBuilderForExcludeTagFiltering != null) {
-            BoolQueryBuilder tagFilters = QueryBuilders.boolQuery();
-            if (orQueryBuilderForIncludeTagFiltering != null)
-                tagFilters.must(orQueryBuilderForIncludeTagFiltering);
-            if (andQueryBuilderForExcludeTagFiltering != null)
-                tagFilters.mustNot(andQueryBuilderForExcludeTagFiltering);
+        BoolQueryBuilder tagFilters = osmTagFilter.getTagFiltersQuery();
+        if (tagFilters != null) {
             finalQuery.filter(tagFilters);
         }
 
@@ -65,51 +60,7 @@ public class ReverseQueryBuilder {
     }
 
     public ReverseQueryBuilder withOsmTagFilters(List<TagFilter> filters) {
-        for (TagFilter filter : filters) {
-            addOsmTagFilter(filter);
-        }
+        osmTagFilter.withOsmTagFilters(filters);
         return this;
-    }
-
-    public ReverseQueryBuilder addOsmTagFilter(TagFilter filter) {
-        if (filter.getKind() == TagFilterKind.EXCLUDE_VALUE) {
-            appendIncludeTermQuery(QueryBuilders.boolQuery()
-                    .must(QueryBuilders.termQuery("osm_key", filter.getKey()))
-                    .mustNot(QueryBuilders.termQuery("osm_value", filter.getValue())));
-        } else {
-            QueryBuilder builder;
-            if (filter.isKeyOnly()) {
-                builder = QueryBuilders.termQuery("osm_key", filter.getKey());
-            } else if (filter.isValueOnly()) {
-                builder = QueryBuilders.termQuery("osm_value", filter.getValue());
-            } else {
-                builder = QueryBuilders.boolQuery()
-                        .must(QueryBuilders.termQuery("osm_key", filter.getKey()))
-                        .must(QueryBuilders.termQuery("osm_value", filter.getValue()));
-            }
-            if (filter.getKind() == TagFilterKind.INCLUDE) {
-                appendIncludeTermQuery(builder);
-            } else {
-                appendExcludeTermQuery(builder);
-            }
-        }
-        return this;
-    }
-
-    private void appendIncludeTermQuery(QueryBuilder termQuery) {
-
-        if (orQueryBuilderForIncludeTagFiltering == null)
-            orQueryBuilderForIncludeTagFiltering = QueryBuilders.boolQuery();
-
-        orQueryBuilderForIncludeTagFiltering.should(termQuery);
-    }
-
-
-    private void appendExcludeTermQuery(QueryBuilder termQuery) {
-
-        if (andQueryBuilderForExcludeTagFiltering == null)
-            andQueryBuilderForExcludeTagFiltering = QueryBuilders.boolQuery();
-
-        andQueryBuilderForExcludeTagFiltering.should(termQuery);
     }
 }


### PR DESCRIPTION
Refactor osm tag filters to use same code for reverse and simple geocoding as suggested here [https://github.com/komoot/photon/pull/742#issuecomment-1653713950](https://github.com/komoot/photon/pull/742#issuecomment-1653713950) by @lonvia 

Any idea when osm_tag feature for reverse geocoding will be available on photon.komoot.io API ?