### PR TITLE
Replace uses of lombok with explicit constructs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
             <version>3.14.0</version>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
             <version>5.3.31</version>

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -8,7 +8,7 @@ import de.komoot.photon.nominatim.NominatimUpdater;
 import de.komoot.photon.searcher.ReverseHandler;
 import de.komoot.photon.searcher.SearchHandler;
 import de.komoot.photon.utils.CorsFilter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 import spark.Request;
 import spark.Response;
 
@@ -18,8 +18,8 @@ import java.io.IOException;
 import static spark.Spark.*;
 
 
-@Slf4j
 public class App {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(App.class);
 
     public static void main(String[] rawArgs) throws Exception {
         CommandLineArgs args = parseCommandLine(rawArgs);
@@ -37,9 +37,9 @@ public class App {
         boolean shutdownES = false;
         final Server esServer = new Server(args.getDataDirectory()).start(args.getCluster(), args.getTransportAddresses());
         try {
-            log.info("Make sure that the ES cluster is ready, this might take some time.");
+            LOGGER.info("Make sure that the ES cluster is ready, this might take some time.");
             esServer.waitForReady();
-            log.info("ES cluster is now ready.");
+            LOGGER.info("ES cluster is now ready.");
 
             if (args.isNominatimImport()) {
                 shutdownES = true;
@@ -78,7 +78,7 @@ public class App {
                 throw new ParameterException("Use only one cors configuration type");
             }
         } catch (ParameterException e) {
-            log.warn("could not start photon: " + e.getMessage());
+            LOGGER.warn("could not start photon: " + e.getMessage());
             jCommander.usage();
             System.exit(1);
         }
@@ -105,9 +105,9 @@ public class App {
             NominatimConnector nominatimConnector = new NominatimConnector(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword());
             nominatimConnector.setImporter(jsonDumper);
             nominatimConnector.readEntireDatabase(args.getCountryCodes());
-            log.info("json dump was created: " + filename);
+            LOGGER.info("json dump was created: " + filename);
         } catch (FileNotFoundException e) {
-            log.error("cannot create dump", e);
+            LOGGER.error("cannot create dump", e);
         }
     }
 
@@ -123,12 +123,12 @@ public class App {
             throw new RuntimeException("cannot setup index, elastic search config files not readable", e);
         }
 
-        log.info("starting import from nominatim to photon with languages: " + String.join(",", dbProperties.getLanguages()));
+        LOGGER.info("starting import from nominatim to photon with languages: " + String.join(",", dbProperties.getLanguages()));
         NominatimConnector nominatimConnector = new NominatimConnector(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword());
         nominatimConnector.setImporter(esServer.createImporter(dbProperties.getLanguages(), args.getExtraTags()));
         nominatimConnector.readEntireDatabase(args.getCountryCodes());
 
-        log.info("imported data from nominatim to photon with languages: " + String.join(",", dbProperties.getLanguages()));
+        LOGGER.info("imported data from nominatim to photon with languages: " + String.join(",", dbProperties.getLanguages()));
     }
 
     private static void startNominatimUpdateInit(CommandLineArgs args) {

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -6,12 +6,10 @@ package de.komoot.photon;
 
 import com.beust.jcommander.Parameter;
 import de.komoot.photon.utils.StringArrayConverter;
-import lombok.Data;
 
 import java.io.File;
 
 
-@Data
 public class CommandLineArgs {
 
     @Parameter(names = "-cluster", description = "name of elasticsearch cluster to put the server into (default is 'photon')")
@@ -96,6 +94,98 @@ public class CommandLineArgs {
 
     public String[] getLanguages() {
         return getLanguages(true);
+    }
+
+    public String getCluster() {
+        return this.cluster;
+    }
+
+    public String[] getTransportAddresses() {
+        return this.transportAddresses;
+    }
+
+    public boolean isNominatimImport() {
+        return this.nominatimImport;
+    }
+
+    public String getNominatimUpdateInit() {
+        return this.nominatimUpdateInit;
+    }
+
+    public boolean isNominatimUpdate() {
+        return this.nominatimUpdate;
+    }
+
+    public String getDefaultLanguage() {
+        return this.defaultLanguage;
+    }
+
+    public String[] getCountryCodes() {
+        return this.countryCodes;
+    }
+
+    public String[] getExtraTags() {
+        return this.extraTags;
+    }
+
+    public String getSynonymFile() {
+        return this.synonymFile;
+    }
+
+    public int getQueryTimeout() {
+        return this.queryTimeout;
+    }
+
+    public String getJsonDump() {
+        return this.jsonDump;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public Integer getPort() {
+        return this.port;
+    }
+
+    public String getDatabase() {
+        return this.database;
+    }
+
+    public String getUser() {
+        return this.user;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public String getDataDirectory() {
+        return this.dataDirectory;
+    }
+
+    public int getListenPort() {
+        return this.listenPort;
+    }
+
+    public String getListenIp() {
+        return this.listenIp;
+    }
+
+    public boolean isCorsAnyOrigin() {
+        return this.corsAnyOrigin;
+    }
+
+    public String getCorsOrigin() {
+        return this.corsOrigin;
+    }
+
+    public boolean isEnableUpdateApi() {
+        return this.enableUpdateApi;
+    }
+
+    public boolean isUsage() {
+        return this.usage;
     }
 }
 

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -1,6 +1,5 @@
 package de.komoot.photon;
 
-import lombok.extern.slf4j.Slf4j;
 import java.util.*;
 
 /**
@@ -8,10 +7,7 @@ import java.util.*;
  *
  * The server is responsible for making the data persistent throught the Photon database.
  */
-@Slf4j
 public class DatabaseProperties {
-
-
     private String[] languages = null;
 
     /**

--- a/src/main/java/de/komoot/photon/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/JsonDumper.java
@@ -1,6 +1,6 @@
 package de.komoot.photon;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -8,11 +8,10 @@ import java.io.PrintWriter;
 
 /**
  * useful to create json files that can be used for fast re imports
- *
- * @author christoph
  */
-@Slf4j
 public class JsonDumper implements Importer {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(JsonDumper.class);
+
     private PrintWriter writer;
     private final String[] languages;
     private final String[] extraTags;
@@ -29,7 +28,7 @@ public class JsonDumper implements Importer {
             writer.println("{\"index\": {}}");
             writer.println(Utils.convert(doc, languages, extraTags).string());
         } catch (IOException e) {
-            log.error("error writing json file", e);
+            LOGGER.error("error writing json file", e);
         }
     }
 

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -4,19 +4,16 @@ import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
 import de.komoot.photon.nominatim.model.AddressType;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.util.*;
 
 /**
  * denormalized doc with all information needed be dumped to elasticsearch
- *
- * @author christoph
  */
-@Getter
-@Slf4j
 public class PhotonDoc {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(PhotonDoc.class);
+
     private final long placeId;
     private final String osmType;
     private final long osmId;
@@ -108,8 +105,8 @@ public class PhotonDoc {
 
             String addressPostCode = address.get("postcode");
             if (addressPostCode != null && !addressPostCode.equals(postcode)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Replacing postcode " + postcode + " with " + addressPostCode + " for osmId #" + osmId);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Replacing postcode " + postcode + " with " + addressPostCode + " for osmId #" + osmId);
                 }
                 postcode = addressPostCode;
             }
@@ -223,8 +220,8 @@ public class PhotonDoc {
 
             String existingName = map.get("name");
             if (!field.equals(existingName)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Replacing " + addressFieldName + " name '" + existingName + "' with '" + field + "' for osmId #" + osmId);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Replacing " + addressFieldName + " name '" + existingName + "' with '" + field + "' for osmId #" + osmId);
                 }
                 // we keep the former name in the context as it might be helpful when looking up typos
                 if (!Objects.isNull(existingName)) {
@@ -248,4 +245,71 @@ public class PhotonDoc {
         addressParts.put(AddressType.COUNTRY, names);
     }
 
+    public long getPlaceId() {
+        return this.placeId;
+    }
+
+    public String getOsmType() {
+        return this.osmType;
+    }
+
+    public long getOsmId() {
+        return this.osmId;
+    }
+
+    public String getTagKey() {
+        return this.tagKey;
+    }
+
+    public String getTagValue() {
+        return this.tagValue;
+    }
+
+    public Map<String, String> getName() {
+        return this.name;
+    }
+
+    public String getPostcode() {
+        return this.postcode;
+    }
+
+    public Map<String, String> getExtratags() {
+        return this.extratags;
+    }
+
+    public Envelope getBbox() {
+        return this.bbox;
+    }
+
+    public long getParentPlaceId() {
+        return this.parentPlaceId;
+    }
+
+    public double getImportance() {
+        return this.importance;
+    }
+
+    public String getCountryCode() {
+        return this.countryCode;
+    }
+
+    public int getRankAddress() {
+        return this.rankAddress;
+    }
+
+    public Map<AddressType, Map<String, String>> getAddressParts() {
+        return this.addressParts;
+    }
+
+    public Set<Map<String, String>> getContext() {
+        return this.context;
+    }
+
+    public String getHouseNumber() {
+        return this.houseNumber;
+    }
+
+    public Point getCentroid() {
+        return this.centroid;
+    }
 }

--- a/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
@@ -2,14 +2,15 @@ package de.komoot.photon.elasticsearch;
 
 import de.komoot.photon.Constants;
 import de.komoot.photon.searcher.PhotonResult;
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.search.SearchHit;
+import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
 public class ElasticResult implements PhotonResult {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ElasticResult.class);
+
     private static final String[] NAME_PRECEDENCE = {"default", "housename", "int", "loc", "reg", "alt", "old"};
 
     private final SearchHit result;
@@ -52,7 +53,7 @@ public class ElasticResult implements PhotonResult {
     public double[] getCoordinates() {
         final Map<String, Double> coordinate = (Map<String, Double>) result.getSource().get("coordinate");
         if (coordinate == null) {
-            log.error(String.format("invalid data [id=%s, type=%s], coordinate is missing!",
+            LOGGER.error(String.format("invalid data [id=%s, type=%s], coordinate is missing!",
                     result.getSource().get(Constants.OSM_ID),
                     result.getSource().get(Constants.OSM_VALUE)));
             return INVALID_COORDINATES;

--- a/src/main/java/de/komoot/photon/elasticsearch/Importer.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Importer.java
@@ -2,18 +2,19 @@ package de.komoot.photon.elasticsearch;
 
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.Utils;
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 
 /**
  * Elasticsearch importer
  */
-@Slf4j
 public class Importer implements de.komoot.photon.Importer {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Importer.class);
+
     private int documentCount = 0;
 
     private final Client esClient;
@@ -35,7 +36,7 @@ public class Importer implements de.komoot.photon.Importer {
             this.bulkRequest.add(this.esClient.prepareIndex(PhotonIndex.NAME, PhotonIndex.TYPE).
                     setSource(Utils.convert(doc, languages, extraTags)).setId(uid));
         } catch (IOException e) {
-            log.error("could not bulk add document " + uid, e);
+            LOGGER.error("could not bulk add document " + uid, e);
             return;
         }
         this.documentCount += 1;
@@ -49,7 +50,7 @@ public class Importer implements de.komoot.photon.Importer {
 
         BulkResponse bulkResponse = bulkRequest.execute().actionGet();
         if (bulkResponse.hasFailures()) {
-            log.error("error while bulk import:" + bulkResponse.buildFailureMessage());
+            LOGGER.error("error while bulk import:" + bulkResponse.buildFailureMessage());
         }
         this.bulkRequest = this.esClient.prepareBulk();
     }

--- a/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/IndexMapping.java
@@ -1,19 +1,20 @@
 package de.komoot.photon.elasticsearch;
 
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.slf4j.Logger;
 
 import java.io.InputStream;
 
 /**
  * Encapsulates the ES index mapping for the photon index.
  */
-@Slf4j
 public class IndexMapping {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(IndexMapping.class);
+
     private final JSONObject mappings;
 
     /**
@@ -46,7 +47,7 @@ public class IndexMapping {
         JSONObject propertiesObject = placeObject == null ? null : placeObject.optJSONObject("properties");
 
         if (propertiesObject == null) {
-            log.error("cannot add languages to mapping.json, please double-check the mappings.json or the language values supplied");
+            LOGGER.error("cannot add languages to mapping.json, please double-check the mappings.json or the language values supplied");
             return this;
         }
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Server.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Server.java
@@ -5,7 +5,6 @@ import de.komoot.photon.Importer;
 import de.komoot.photon.Updater;
 import de.komoot.photon.searcher.ReverseHandler;
 import de.komoot.photon.searcher.SearchHandler;
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
@@ -20,22 +19,25 @@ import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.slf4j.Logger;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * Helper class to start/stop elasticsearch node and get elasticsearch clients
- *
- * @author felix
  */
-@Slf4j
 public class Server {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Server.class);
+
     /**
      * Database version created by new imports with the current code.
      *
@@ -93,7 +95,7 @@ public class Server {
 
             esClient = trClient;
 
-            log.info("Started elastic search client connected to " + String.join(", ", transportAddresses));
+            LOGGER.info("Started elastic search client connected to " + String.join(", ", transportAddresses));
 
         } else {
 
@@ -105,7 +107,7 @@ public class Server {
                 esNode = new MyNode(settings, lList);
                 esNode.start();
 
-                log.info("started elastic search node");
+                LOGGER.info("started elastic search node");
 
                 esClient = esNode.client();
 
@@ -252,7 +254,7 @@ public class Server {
 
         String version = properties.getOrDefault(FIELD_VERSION, "");
         if (!DATABASE_VERSION.equals(version)) {
-            log.error("Database has incompatible version '" + version + "'. Expected: " + DATABASE_VERSION);
+            LOGGER.error("Database has incompatible version '" + version + "'. Expected: " + DATABASE_VERSION);
             throw new RuntimeException("Incompatible database.");
         }
 

--- a/src/main/java/de/komoot/photon/elasticsearch/Updater.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/Updater.java
@@ -2,20 +2,19 @@ package de.komoot.photon.elasticsearch;
 
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.Utils;
-import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 
 /**
  * Updater for elasticsearch
- *
- * @author felix
  */
-@Slf4j
 public class Updater implements de.komoot.photon.Updater {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Updater.class);
+
     private final Client esClient;
     private BulkRequestBuilder bulkRequest;
     private final String[] languages;
@@ -38,7 +37,7 @@ public class Updater implements de.komoot.photon.Updater {
         try {
             bulkRequest.add(esClient.prepareIndex(PhotonIndex.NAME, PhotonIndex.TYPE).setSource(Utils.convert(doc, languages, extraTags)).setId(uid));
         } catch (IOException e) {
-            log.error(String.format("creation of new doc [%s] failed", uid), e);
+            LOGGER.error(String.format("creation of new doc [%s] failed", uid), e);
         }
     }
 
@@ -59,12 +58,12 @@ public class Updater implements de.komoot.photon.Updater {
 
     private void updateDocuments() {
         if (this.bulkRequest.numberOfActions() == 0) {
-            log.warn("Update empty");
+            LOGGER.warn("Update empty");
             return;
         }
         BulkResponse bulkResponse = bulkRequest.execute().actionGet();
         if (bulkResponse.hasFailures()) {
-            log.error("error while bulk update: " + bulkResponse.buildFailureMessage());
+            LOGGER.error("error while bulk update: " + bulkResponse.buildFailureMessage());
         }
         this.bulkRequest = this.esClient.prepareBulk();
     }

--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -2,15 +2,15 @@ package de.komoot.photon.nominatim;
 
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Slf4j
 class ImportThread {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ImportThread.class);
+
     private static final int PROGRESS_INTERVAL = 50000;
     private static final NominatimResult FINAL_DOCUMENT = new NominatimResult(new PhotonDoc(0, null, 0, null, null));
     private final BlockingQueue<NominatimResult> documents = new LinkedBlockingDeque<>(20);
@@ -38,7 +38,7 @@ class ImportThread {
                 documents.put(docs);
                 break;
             } catch (InterruptedException e) {
-                log.warn("Thread interrupted while placing document in queue.");
+                LOGGER.warn("Thread interrupted while placing document in queue.");
                 // Restore interrupted state.
                 Thread.currentThread().interrupt();
             }
@@ -46,7 +46,7 @@ class ImportThread {
 
         if (counter.incrementAndGet() % PROGRESS_INTERVAL == 0) {
             final double documentsPerSecond = 1000d * counter.longValue() / (System.currentTimeMillis() - startMillis);
-            log.info(String.format("imported %d documents [%.1f/second]", counter.longValue(), documentsPerSecond));
+            LOGGER.info(String.format("imported %d documents [%.1f/second]", counter.longValue(), documentsPerSecond));
         }
     }
 
@@ -62,12 +62,12 @@ class ImportThread {
                 thread.join();
                 break;
             } catch (InterruptedException e) {
-                log.warn("Thread interrupted while placing document in queue.");
+                LOGGER.warn("Thread interrupted while placing document in queue.");
                 // Restore interrupted state.
                 Thread.currentThread().interrupt();
             }
         }
-        log.info(String.format("finished import of %d photon documents.", counter.longValue()));
+        LOGGER.info(String.format("finished import of %d photon documents.", counter.longValue()));
     }
 
     private class ImportRunnable implements Runnable {
@@ -85,7 +85,7 @@ class ImportThread {
                         importer.add(doc, object_id++);
                     }
                 } catch (InterruptedException e) {
-                    log.info("interrupted exception ", e);
+                    LOGGER.info("interrupted exception ", e);
                     // Restore interrupted state.
                     Thread.currentThread().interrupt();
                 }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -5,23 +5,27 @@ import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressRow;
 import de.komoot.photon.nominatim.model.AddressType;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.postgis.jts.JtsWrapper;
+import org.slf4j.Logger;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Export nominatim data
  *
  * @author felix, christoph
  */
-@Slf4j
 public class NominatimConnector {
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(NominatimConnector.class);
+
     private static final String SELECT_COLS_PLACEX = "SELECT place_id, osm_type, osm_id, class, type, name, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_address, rank_search, importance, country_code, centroid";
     private static final String SELECT_COLS_ADDRESS = "SELECT p.name, p.class, p.type, p.rank_address";
 
@@ -263,7 +267,7 @@ public class NominatimConnector {
             andCountryCodeStr = "AND country_code in (" + countryCodeStr + ")";
         }
 
-        log.info("start importing documents from nominatim (" + (countryCodeStr.isEmpty() ? "global" : countryCodeStr) + ")");
+        LOGGER.info("start importing documents from nominatim (" + (countryCodeStr.isEmpty() ? "global" : countryCodeStr) + ")");
 
         ImportThread importThread = new ImportThread(importer);
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -5,7 +5,6 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.linearref.LengthIndexedLine;
 import de.komoot.photon.PhotonDoc;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 import java.util.regex.Pattern;
@@ -14,7 +13,6 @@ import java.util.regex.Pattern;
  * A Nominatim result consisting of the basic PhotonDoc for the object
  * and a map of attached house numbers together with their respective positions.
  */
-@Slf4j
 class NominatimResult {
     private PhotonDoc doc;
     private Map<String, Point> housenumbers;

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -1,20 +1,22 @@
 package de.komoot.photon.nominatim.model;
 
-import lombok.Data;
-
 import java.util.Map;
 
 /**
  * representation of an address as returned by nominatim's get_addressdata PL/pgSQL function
- *
- * @author christoph
  */
-@Data
 public class AddressRow {
     private final Map<String, String> name;
     private final String osmKey;
     private final String osmValue;
     private final int rankAddress;
+
+    public AddressRow(Map<String, String> name, String osmKey, String osmValue, int rankAddress) {
+        this.name = name;
+        this.osmKey = osmKey;
+        this.osmValue = osmValue;
+        this.rankAddress = rankAddress;
+    }
 
     public AddressType getAddressType() {
         return AddressType.fromRank(rankAddress);
@@ -30,5 +32,9 @@ public class AddressRow {
 
     public boolean isUsefulForContext() {
         return !name.isEmpty() && !isPostcode();
+    }
+
+    public Map<String, String> getName() {
+        return this.name;
     }
 }

--- a/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
+++ b/src/main/java/de/komoot/photon/query/RequestLanguageResolver.java
@@ -1,6 +1,5 @@
 package de.komoot.photon.query;
 
-import lombok.AllArgsConstructor;
 import spark.Request;
 import spark.utils.StringUtils;
 
@@ -10,12 +9,16 @@ import java.util.Locale;
 /**
  * Resolver for the response language for a web request.
  */
-@AllArgsConstructor
 public class RequestLanguageResolver {
     static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
 
     private final List<String> supportedLanguages;
     private final String defaultLanguage;
+
+    public RequestLanguageResolver(List<String> supportedLanguages, String defaultLanguage) {
+        this.supportedLanguages = supportedLanguages;
+        this.defaultLanguage = defaultLanguage;
+    }
 
     /**
      * Get the language to use for the response to the given request.

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -6,7 +6,6 @@ import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.PrecisionModel;
 import de.komoot.photon.elasticsearch.ElasticTestServer;
 import de.komoot.photon.searcher.PhotonResult;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -16,10 +15,7 @@ import java.util.Collections;
 
 /**
  * Start an ES server with some test data that then can be queried in tests that extend this class
- *
- * @author Peter Karich
  */
-@Slf4j
 public class ESBaseTester {
     @TempDir
     protected Path dataDirectory;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -9,7 +9,6 @@ import de.komoot.photon.nominatim.testdb.CollectingImporter;
 import de.komoot.photon.nominatim.testdb.H2DataAdapter;
 import de.komoot.photon.nominatim.testdb.OsmlineTestRow;
 import de.komoot.photon.nominatim.testdb.PlacexTestRow;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,7 +17,6 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
-@Slf4j
 public class NominatimConnectorDBTest {
     private EmbeddedDatabase db;
     private NominatimConnector connector;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -3,7 +3,6 @@ package de.komoot.photon.nominatim.testdb;
 import com.vividsolutions.jts.io.ParseException;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +10,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Slf4j
 public class CollectingImporter implements Importer {
     private List<Map.Entry<Integer, PhotonDoc>> docs = new ArrayList<>();
     private int finishCalled = 0;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingUpdater.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingUpdater.java
@@ -2,7 +2,6 @@ package de.komoot.photon.nominatim.testdb;
 
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.Updater;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Slf4j
 public class CollectingUpdater implements Updater {
     private List<Map.Entry<Integer, PhotonDoc>> created = new ArrayList<>();
     private List<Map.Entry<Integer, Long>> deleted = new ArrayList<>();

--- a/src/test/java/de/komoot/photon/nominatim/testdb/OsmlineTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/OsmlineTestRow.java
@@ -1,9 +1,7 @@
 package de.komoot.photon.nominatim.testdb;
 
-import lombok.Getter;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@Getter
 public class OsmlineTestRow {
     private static long place_id_sequence = 100000;
 
@@ -45,5 +43,9 @@ public class OsmlineTestRow {
                 placeId, parentPlaceId, osmId, startnumber, endnumber, step, lineGeo, countryCode);
 
         return this;
+    }
+
+    public Long getPlaceId() {
+        return this.placeId;
     }
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -3,7 +3,6 @@ package de.komoot.photon.nominatim.testdb;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
-import lombok.Getter;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -11,7 +10,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
 public class PlacexTestRow {
     private static final WKTReader wkt = new WKTReader();
     private static long place_id_sequence = 10000;
@@ -138,5 +136,25 @@ public class PlacexTestRow {
         Assertions.assertEquals(rankAddress, (Integer) doc.getRankAddress());
         Assertions.assertEquals(new WKTReader().read(centroid), doc.getCentroid());
         Assertions.assertEquals(names, doc.getName());
+    }
+
+    public Long getPlaceId() {
+        return this.placeId;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public Map<String, String> getNames() {
+        return this.names;
+    }
+
+    public Integer getRankAddress() {
+        return this.rankAddress;
     }
 }

--- a/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
@@ -2,7 +2,6 @@ package de.komoot.photon.query;
 
 import de.komoot.photon.*;
 import de.komoot.photon.searcher.PhotonResult;
-import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +16,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Slf4j
 public class QueryByClassificationTest extends ESBaseTester {
     @TempDir
     static Path sharedTempDir;

--- a/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
@@ -5,7 +5,6 @@ import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.Importer;
 import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.searcher.PhotonResult;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -20,7 +19,6 @@ import java.util.*;
 /**
  * Tests for queries in different languages.
  */
-@Slf4j
 public class QueryByLanguageTest extends ESBaseTester {
     private int testDocId = 10001;
     private String[] languageList;


### PR DESCRIPTION
Photon makes very little use of lombok and where it does, it doesn't really save much lines of code. So explicit is preferred over implicit here.