### PR TITLE
Add a status call for the update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ export NOMINATIM_DIR=/srv/nominatim/...
 ./continuously_update_from_nominatim.sh
 ```
 
-If you have Nominatim < 3.7, please read the comments in the script carefully.
+where `NOMINATIM_DIR` is the project directory of your Nominatim installation.
 
 ### Search API
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Discover more of photon's feature with its usage `java -jar photon-*.jar -h`. Th
 If you need search data in other languages or restricted to a country you will need to create your search data by your own.
 Once you have your [Nominatim](https://nominatim.org) database ready, you can import the data to photon.
 
-If you haven't already set a password for your nominatim database user, do it now (change user name and password as you like, below):
+If you haven't already set a password for your Nominatim database user, do it now (change user name and password as you like, below):
 
 ```bash
 su postgres
@@ -138,7 +138,7 @@ Import the data to photon:
 java -jar photon-*.jar -nominatim-import -host localhost -port 5432 -database nominatim -user nominatim -password mysecretpassword -languages es,fr
 ```
 
-The import of worldwide data set will take some hours/days, SSD/NVME disks are recommended to accelerate nominatim queries.
+The import of worldwide data set will take some hours/days, SSD/NVME disks are recommended to accelerate Nominatim queries.
 
 #### Updating from OSM via Nominatim
 
@@ -177,16 +177,22 @@ Then you can trigger updates like this:
 curl http://localhost:2322/nominatim-update
 ```
 
+This will only start the updates. To check if the updates have finished,
+use the status API:
+
+```bash
+curl http://localhost:2322/nominatim-update/status
+```
+
+It returns a single JSON string `"BUSY"` when updates are in progress or
+`"OK"` when another update round can be started.
+
 For your convenience, this repository contains a script to continuously update
-both Nominatim and Photon. To run it, first customize some environment
-variables according to your installation:
+both Nominatim and Photon using Photon's update API. Make sure you have
+Photon started with `-enable-update-api` and then run:
 
 ```bash
 export NOMINATIM_DIR=/srv/nominatim/...
-export PHOTON_JAR=photon.jar
-export PHOTON_DB_NAME=nominatim
-export PHOTON_DB_USER=nominatim
-export PHOTON_DB_PASSWORD=...
 ./continuously_update_from_nominatim.sh
 ```
 

--- a/continuously_update_from_nominatim.sh
+++ b/continuously_update_from_nominatim.sh
@@ -12,8 +12,6 @@ do
     # The important part here is to leave out the indexing step. This
     # will be handled by Photon.
 
-    # For Nominatim versions < 3.7 use the following:
-    # ./utils/update.php --import-osmosis
     nominatim replication --project-dir $NOMINATIM_DIR  --once
 
     # Now tell Photon to finish the updates and copy the new data into its

--- a/continuously_update_from_nominatim.sh
+++ b/continuously_update_from_nominatim.sh
@@ -3,15 +3,6 @@
 # For Nominatim < 3.7 set this to the Nominatim build directory.
 # For newer versions, this must be the project directory of your import.
 : ${NOMINATIM_DIR:=.}
-# Path to Photon Jar file
-: ${PHOTON_JAR:=photon.jar}
-# Name of Nominatim database.
-: ${PHOTON_DB_NAME:=nominatim}
-# PostgreSQL user name to use for update in Photon
-: ${PHOTON_DB_USER:=nominatim}
-# Password for PostgreSQL user
-: ${PHOTON_DB_PASSWORD:=}
-
 
 while true
 do
@@ -27,7 +18,7 @@ do
 
     # Now tell Photon to finish the updates and copy the new data into its
     # own database.
-    java -jar $PHOTON_JAR -database $PHOTON_DB_NAME -user $PHOTON_DB_USER -password $PHOTON_DB_PASSWORD -nominatim-update
+    curl http://localhost:2322/nominatim-update
 
     # Sleep a bit if updates take less than a minute.
     # If you consume hourly or daily diffs adapt the period accordingly.
@@ -39,4 +30,11 @@ do
         echo "Sleeping for ${sleepy}s..."
         sleep $sleepy
     fi
+
+    # Now check if the updates have finished
+    while [ `curl -s http://localhost:2322/nominatim-update/status` != '"OK"' ];
+    do
+        echo "Sleeping 15 more seconds."
+        sleep 15
+    done
 done

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -204,6 +204,9 @@ public class App {
         if (args.isEnableUpdateApi()) {
             // setup update API
             final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, server);
+            if (!nominatimUpdater.isSetUpForUpdates()) {
+                throw new RuntimeException("Update API enabled, but Nominatim database is not prepared. Run -nominiatim-update-init-for first.");
+            }
             get("/nominatim-update/status", (Request request, Response response) -> {
                if (nominatimUpdater.isBusy()) {
                    return "\"BUSY\"";

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -57,7 +57,7 @@ public class App {
 
             if (args.isNominatimUpdate()) {
                 shutdownES = true;
-                startNominatimUpdate(args, esServer);
+                startNominatimUpdate(setupNominatimUpdater(args, esServer), esServer);
                 return;
             }
 
@@ -137,14 +137,12 @@ public class App {
         nominatimUpdater.initUpdates(args.getNominatimUpdateInit());
     }
 
-    private static void startNominatimUpdate(CommandLineArgs args, Server esServer) {
-        final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, esServer);
+    private static void startNominatimUpdate(NominatimUpdater nominatimUpdater, Server esServer) {
         nominatimUpdater.update();
 
         DatabaseProperties dbProperties = new DatabaseProperties();
         esServer.loadFromDatabase(dbProperties);
-        NominatimConnector nominatimConnector = new NominatimConnector(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword());
-        Date importDate = nominatimConnector.getLastImportDate();
+        Date importDate = nominatimUpdater.getLastImportDate();
         dbProperties.setImportDate(importDate);
         try {
             esServer.saveToDatabase(dbProperties);
@@ -206,9 +204,16 @@ public class App {
         if (args.isEnableUpdateApi()) {
             // setup update API
             final NominatimUpdater nominatimUpdater = setupNominatimUpdater(args, server);
+            get("/nominatim-update/status", (Request request, Response response) -> {
+               if (nominatimUpdater.isBusy()) {
+                   return "\"BUSY\"";
+               }
+
+               return "\"OK\"";
+            });
             get("/nominatim-update", (Request request, Response response) -> {
-                new Thread(()-> App.startNominatimUpdate(args, server)).start();
-                return "nominatim update started (more information in console output) ...";
+                new Thread(()-> App.startNominatimUpdate(nominatimUpdater, server)).start();
+                return "\"nominatim update started (more information in console output) ...\"";
             });
         }
     }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -63,6 +63,11 @@ public class NominatimUpdater {
         return updateLock.isLocked();
     }
 
+    public boolean isSetUpForUpdates() {
+        int result = template.queryForObject("SELECT count(*) FROM pg_tables WHERE tablename = 'photon_updates'", Integer.class);
+        return result > 0;
+    }
+
     public void setUpdater(Updater updater) {
         this.updater = updater;
     }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -53,6 +54,14 @@ public class NominatimUpdater {
      * Lock to prevent thread from updating concurrently.
      */
     private ReentrantLock updateLock = new ReentrantLock();
+
+    public Date getLastImportDate() {
+        return exporter.getLastImportDate();
+    }
+
+    public boolean isBusy() {
+        return updateLock.isLocked();
+    }
 
     public void setUpdater(Updater updater) {
         this.updater = updater;


### PR DESCRIPTION
This adds a new API endpoint `/nominatim-update/status`.  It returns `"OK"` if the `/nominatim-update` endpoint is usable and `"BUSY"` if an update is ongoing. It can be used to poll the server during an update cycle.

Using this endpoint, the continuous update script can be switched back to triggering updates via the API.

Also adds a check that the necessary data tables for updates are there when starting up the server. If they are missing, the update endpoints are disabled and you get a 404.