### PR TITLE
Update jts and slf dependencies to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,27 +44,26 @@ sourceSets {
 
 dependencies {
     implementation('org.elasticsearch:elasticsearch:5.6.16') {
-exclude(module: 'log4j-api')
+        exclude(module: 'log4j-api')
     }
     implementation 'org.elasticsearch.plugin:transport-netty4-client:5.6.16'
-    implementation 'org.apache.logging.log4j:log4j-core:2.22.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.22.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.23.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.23.1'
     implementation('org.elasticsearch.client:transport:5.6.16') {
-exclude(module: 'commons-logging')
+        exclude(module: 'commons-logging')
     }
     implementation 'org.postgresql:postgresql:42.7.2'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.22.0'
+    implementation 'org.slf4j:slf4j-api:2.0.13'
+    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1'
     implementation 'com.beust:jcommander:1.82'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'org.springframework:spring-jdbc:5.3.32'
     implementation('org.apache.commons:commons-dbcp2:2.12.0') {
 exclude(module: 'commons-logging')
     }
-    implementation 'com.vividsolutions:jts:1.13'
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
     implementation 'com.sparkjava:spark-core:2.9.4'
-    implementation 'net.postgis:postgis-jdbc:2.5.0'
-    implementation 'net.postgis:postgis-jdbc-jtsparser:2.2.2'
+    implementation 'net.postgis:postgis-jdbc:2023.1.0'
     implementation 'org.json:json:20240303'
 
     testImplementation(platform("org.junit:junit-bom:5.10.2"))

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -1,8 +1,8 @@
 package de.komoot.photon;
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.nominatim.model.AddressType;
 import org.slf4j.Logger;
 

--- a/src/main/java/de/komoot/photon/Utils.java
+++ b/src/main/java/de/komoot/photon/Utils.java
@@ -1,6 +1,6 @@
 package de.komoot.photon;
 
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Envelope;
 import de.komoot.photon.nominatim.model.AddressType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;

--- a/src/main/java/de/komoot/photon/elasticsearch/ElasticsearchReverseHandler.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/ElasticsearchReverseHandler.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.elasticsearch;
 
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.query.ReverseRequest;
 import de.komoot.photon.searcher.PhotonResult;
 import de.komoot.photon.searcher.ReverseHandler;

--- a/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
@@ -1,8 +1,8 @@
 package de.komoot.photon.elasticsearch;
 
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.searcher.TagFilter;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery.ScoreMode;

--- a/src/main/java/de/komoot/photon/elasticsearch/ReverseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/elasticsearch/ReverseQueryBuilder.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.elasticsearch;
 
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.searcher.TagFilter;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.query.BoolQueryBuilder;

--- a/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/DBDataAdapter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.sql.ResultSet;

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -1,12 +1,11 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressRow;
 import de.komoot.photon.nominatim.model.AddressType;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.postgis.jts.JtsWrapper;
 import org.slf4j.Logger;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -152,12 +151,11 @@ public class NominatimConnector {
     static BasicDataSource buildDataSource(String host, int port, String database, String username, String password, boolean autocommit) {
         BasicDataSource dataSource = new BasicDataSource();
 
-        dataSource.setUrl(String.format("jdbc:postgres_jts://%s:%d/%s", host, port, database));
+        dataSource.setUrl(String.format("jdbc:postgresql://%s:%d/%s", host, port, database));
         dataSource.setUsername(username);
         if (password != null) {
             dataSource.setPassword(password);
         }
-        dataSource.setDriverClassName(JtsWrapper.class.getCanonicalName());
         dataSource.setDefaultAutoCommit(autocommit);
         return dataSource;
     }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimResult.java
@@ -1,9 +1,9 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.linearref.LengthIndexedLine;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.linearref.LengthIndexedLine;
 import de.komoot.photon.PhotonDoc;
 
 import java.util.*;

--- a/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
+++ b/src/main/java/de/komoot/photon/nominatim/PostgisDataAdapter.java
@@ -1,7 +1,9 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.geom.Geometry;
-import org.postgis.jts.JtsGeometry;
+import net.postgis.jdbc.PGgeometry;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -27,11 +29,18 @@ public class PostgisDataAdapter implements DBDataAdapter {
 
     @Override
     public Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException {
-        JtsGeometry geom = (JtsGeometry) rs.getObject(columnName);
-        if (geom == null) {
-            return null;
+        PGgeometry wkt = (PGgeometry) rs.getObject(columnName);
+        if (wkt != null) {
+            try {
+                StringBuffer sb = new StringBuffer();
+                wkt.getGeometry().outerWKT(sb);
+                return new WKTReader().read(sb.toString());
+            } catch (ParseException e) {
+                // ignore
+            }
         }
-        return geom.getGeometry();
+
+        return null;
     }
 
     @Override

--- a/src/main/java/de/komoot/photon/query/BoundingBoxParamConverter.java
+++ b/src/main/java/de/komoot/photon/query/BoundingBoxParamConverter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Envelope;
 
 import spark.Request;
 

--- a/src/main/java/de/komoot/photon/query/LocationParamConverter.java
+++ b/src/main/java/de/komoot/photon/query/LocationParamConverter.java
@@ -1,9 +1,9 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 import spark.Request;
 

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.searcher.TagFilter;
 
 import java.util.*;

--- a/src/main/java/de/komoot/photon/query/ReverseRequest.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 
 import de.komoot.photon.searcher.TagFilter;
 

--- a/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/ReverseRequestFactory.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.searcher.TagFilter;
 import spark.QueryParamsMap;
 import spark.Request;

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,9 +1,9 @@
 package de.komoot.photon;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import de.komoot.photon.elasticsearch.ElasticTestServer;
 import de.komoot.photon.searcher.PhotonResult;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/de/komoot/photon/api/ApiLanguagesTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiLanguagesTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.api;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 
 import de.komoot.photon.App;
 import de.komoot.photon.ESBaseTester;

--- a/src/test/java/de/komoot/photon/elasticsearch/ElasticResultTest.java
+++ b/src/test/java/de/komoot/photon/elasticsearch/ElasticResultTest.java
@@ -1,8 +1,7 @@
 package de.komoot.photon.elasticsearch;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 import de.komoot.photon.AssertUtil;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.ReflectionTestUtil;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimResultTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim;
 
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim.testdb;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -1,8 +1,6 @@
 package de.komoot.photon.nominatim.testdb;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.geom.Geometry;
 import de.komoot.photon.nominatim.DBDataAdapter;
 import org.json.JSONObject;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -30,16 +28,7 @@ public class H2DataAdapter implements DBDataAdapter {
 
     @Override
     public Geometry extractGeometry(ResultSet rs, String columnName) throws SQLException {
-        String wkt = (String) rs.getObject(columnName);
-        if (wkt != null) {
-            try {
-                return new WKTReader().read(wkt);
-            } catch (ParseException e) {
-                // ignore
-            }
-        }
-
-        return null;
+        return (Geometry) rs.getObject(columnName);
     }
 
     @Override

--- a/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.nominatim.testdb;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 import org.springframework.lang.Nullable;
 
 import java.sql.ResultSet;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim.testdb;
 
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/PhotonRequestFactoryTest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Envelope;
 import de.komoot.photon.searcher.TagFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -1,6 +1,6 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;

--- a/src/test/java/de/komoot/photon/query/QueryReverseFilterLayerTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryReverseFilterLayerTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;

--- a/src/test/java/de/komoot/photon/query/QueryReverseFilterTagValueTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryReverseFilterTagValueTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
-import  static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;

--- a/src/test/java/de/komoot/photon/query/QueryReverseTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryReverseTest.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.query;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.searcher.PhotonResult;


### PR DESCRIPTION
Gradle's dependency management makes it a bit simpler to work with the very old ElasticSearch version.

JTS is a bit tricky because it has been moved around quite a bit from 'com.vividsolutions.jts.jts' to  ´com.vividsolutions.jts.jts-core'  to 'org.locationtech.jts.jts-core'. ES still depends on the version from vividsolutions. This in itself is not an issue, we could simply include both version s of the library. The actual blocker turns out to be 'org.locationtech.spatial4j ´. It is used in the ES library, where it is expected to return vividsolution geometries. And it is used in the postgis-jdbc-jtsparser, where after the update a locationtech geometry is expected. The solution is to get rid of postgis-jdbc-jtsparser and implement our own parsing of PostGIS geometries. 