### PR TITLE
Introduce 'other' rank for address rank 0 objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ List of available layers:
 - county
 - state
 - country
+- other (e.g. natural features)
 
 ```
 http://localhost:2322/api?q=berlin&layer=city&layer=locality

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
@@ -18,7 +18,8 @@ public enum AddressType {
     CITY("city", 13, 16),
     COUNTY("county", 10, 12),
     STATE("state", 5, 9),
-    COUNTRY("country", 4, 4);
+    COUNTRY("country", 4, 4),
+    OTHER("other", 0, 0);
 
     private final String name;
     private final int minRank;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -100,6 +100,25 @@ class NominatimConnectorDBTest {
     }
 
     @Test
+    void testPlaceAddressAddressRank0() throws ParseException {
+        PlacexTestRow place = new PlacexTestRow("natural", "water").name("Lake Tee").rankAddress(0).rankSearch(20).add(jdbc);
+
+        place.addAddresslines(jdbc,
+                new PlacexTestRow("place", "county").name("Lost County").rankAddress(12).add(jdbc),
+                new PlacexTestRow("place", "state").name("Le Havre").rankAddress(8).add(jdbc));
+
+        connector.readEntireDatabase();
+
+        assertEquals(3, importer.size());
+        importer.assertContains(place);
+
+        PhotonDoc doc = importer.get(place);
+
+        AssertUtil.assertAddressName("Lost County", doc, AddressType.COUNTY);
+        AssertUtil.assertAddressName("Le Havre", doc, AddressType.STATE);
+    }
+
+    @Test
     void testPoiAddress() throws ParseException {
         PlacexTestRow parent = PlacexTestRow.make_street("Burg").add(jdbc);
 

--- a/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
+++ b/src/test/java/de/komoot/photon/query/ReverseRequestFactoryTest.java
@@ -218,7 +218,7 @@ class ReverseRequestFactoryTest {
         Request mockRequest = createRequestWithLongitudeLatitude(-87d, 41d);
         requestWithLayers(mockRequest, "city", "bad");
 
-        assertBadRequest(mockRequest, "Invalid layer 'bad'. Allowed layers are: house,street,locality,district,city,county,state,country");
+        assertBadRequest(mockRequest, "Invalid layer 'bad'. Allowed layers are: house,street,locality,district,city,county,state,country,other");
     }
 
     @Test


### PR DESCRIPTION
This fixes the issue that non-addressable features wouldn't be assigned any address items.

In order to get an address, a feature needs to have a named rank. Mixing rank 0 objects with other address ranks seems wrong, so give it its own named rank instead. This slightly changes the output of these features. They now get `type=other` instead of `type=locality`.