### PR TITLE
add support for structured queries (opensearch only)

### DIFF
--- a/app/es_embedded/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -55,7 +55,7 @@ public class ESBaseTester {
     public void setUpES(Path test_directory, String... languages) throws IOException {
         server = new ElasticTestServer(test_directory.toString());
         server.start(TEST_CLUSTER_NAME, new String[]{});
-        server.recreateIndex(languages, new Date());
+        server.recreateIndex(languages, new Date(), false);
         refresh();
     }
 

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
@@ -1,0 +1,275 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.Constants;
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.*;
+import org.opensearch.common.unit.Fuzziness;
+
+import java.util.Objects;
+
+public class AddressQueryBuilder {
+    private static final float STATE_BOOST = 0.1f; // state is unreliable - some locations have e.g. "NY", some "New York".
+    private static final float COUNTY_BOOST = 4.0f;
+    private static final float CITY_BOOST = 3.0f;
+    private static final float POSTAL_CODE_BOOST = 7.0f;
+    private static final float DISTRICT_BOOST = 2.0f;
+    private static final float STREET_BOOST = 5.0f; // we filter streets in the wrong city / district / ... so we can use a high boost value
+    private static final float HOUSE_NUMBER_BOOST = 10.0f;
+    private static final float HOUSE_NUMBER_UNMATCHED_BOOST = 5f;
+    private static final float FACTOR_FOR_WRONG_LANGUAGE = 0.1f;
+    private final String[] languages;
+    private final String language;
+
+    private BoolQuery.Builder query = QueryBuilders.bool();
+
+    private BoolQuery.Builder cityFilter;
+
+    private boolean lenient;
+
+    public AddressQueryBuilder(boolean lenient, String language, String[] languages) {
+        this.lenient = lenient;
+        this.language = language;
+        this.languages = languages;
+    }
+
+    public Query getQuery() {
+        return query.build().toQuery();
+    }
+
+    public AddressQueryBuilder addCountryCode(String countryCode) {
+        if (countryCode == null) return this;
+
+        query.filter(QueryBuilders.term().field(Constants.COUNTRYCODE).value(FieldValue.of(countryCode.toUpperCase())).build().toQuery());
+        return this;
+    }
+
+    public AddressQueryBuilder addState(String state, boolean hasMoreDetails) {
+        if (state == null) return this;
+
+        var stateQuery = GetNameOrFieldQuery(Constants.STATE, state, STATE_BOOST, "state", hasMoreDetails);
+        query.should(stateQuery);
+        return this;
+    }
+
+    public AddressQueryBuilder addCounty(String county, boolean hasMoreDetails) {
+        if (county == null) return this;
+
+        AddNameOrFieldQuery(Constants.COUNTY, county, COUNTY_BOOST, "county", hasMoreDetails);
+        return this;
+    }
+
+    public AddressQueryBuilder addCity(String city, boolean hasDistrict, boolean hasStreet, boolean hasPostCode) {
+        if (city == null) return this;
+
+        Query combinedQuery;
+        Query nameQuery = GetFuzzyNameQueryBuilder(city, "city").boost(CITY_BOOST)
+                .build()
+                .toQuery();
+        Query fieldQuery = GetFuzzyQueryBuilder(Constants.CITY, city).boost(CITY_BOOST).build().toQuery();
+
+        if (!hasDistrict) {
+            var districtNameQuery = GetFuzzyNameQueryBuilder(city, "district").boost(0.95f * CITY_BOOST)
+                    .build()
+                    .toQuery();
+            nameQuery = QueryBuilders.bool()
+                    .should(nameQuery)
+                    .should(districtNameQuery)
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery();
+
+            var districtFieldQuery = GetFuzzyQueryBuilder(Constants.DISTRICT, city).boost(0.95f * CITY_BOOST).build().toQuery();
+            fieldQuery = QueryBuilders.bool()
+                    .should(fieldQuery)
+                    .should(districtFieldQuery)
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery();
+        }
+
+        if (!hasStreet && !hasDistrict) {
+            // match only name
+            if (hasPostCode) {
+                // post code can implicitly specify a district that has the city in the address field (instead of the name)
+                combinedQuery = QueryBuilders.bool()
+                        .should(nameQuery)
+                        .should(fieldQuery)
+                        .build()
+                        .toQuery();
+            }
+            else {
+                combinedQuery = nameQuery;
+            }
+        } else {
+            // match only address field
+            combinedQuery = fieldQuery;
+        }
+
+        addToCityFilter(combinedQuery);
+        query.must(combinedQuery);
+
+        return this;
+    }
+
+    private void addToCityFilter(Query query) {
+        if (cityFilter == null) {
+            cityFilter = QueryBuilders.bool();
+        }
+
+        cityFilter.should(query);
+    }
+
+    public AddressQueryBuilder addPostalCode(String postalCode) {
+        if (postalCode == null) return this;
+
+        Fuzziness fuzziness = lenient ? Fuzziness.AUTO : Fuzziness.ZERO;
+
+        Query query;
+        if (StringUtils.containsWhitespace(postalCode)) {
+            query = QueryBuilders.match()
+                    .field(Constants.POSTCODE)
+                    .query(FieldValue.of(postalCode))
+                    .fuzziness(fuzziness.asString())
+                    .boost(POSTAL_CODE_BOOST)
+                    .build()
+                    .toQuery();
+        } else {
+            query = QueryBuilders.fuzzy()
+                    .field(Constants.POSTCODE)
+                    .value(FieldValue.of(postalCode))
+                    .fuzziness(fuzziness.asString())
+                    .boost(POSTAL_CODE_BOOST)
+                    .build()
+                    .toQuery();
+        }
+
+        addToCityFilter(query);
+        this.query.must(query);
+
+        return this;
+    }
+
+    public AddressQueryBuilder addDistrict(String district, boolean hasMoreDetails) {
+        if (district == null) return this;
+
+        AddNameOrFieldQuery(Constants.DISTRICT, district, DISTRICT_BOOST, "district", hasMoreDetails);
+        return this;
+    }
+
+    public AddressQueryBuilder addStreetAndHouseNumber(String street, String houseNumber) {
+        if (street == null) {
+            if (houseNumber != null) {
+                // some hamlets have no street name and only number the buildings
+                var houseNumberQuery = QueryBuilders.bool()
+                        .mustNot(QueryBuilders.exists().field(Constants.STREET).build().toQuery())
+                        .must(QueryBuilders.matchPhrase()
+                                .field(Constants.HOUSENUMBER)
+                                .query(houseNumber)
+                                .build()
+                                .toQuery());
+
+                query.must(houseNumberQuery.build().toQuery());
+            }
+
+            return this;
+        }
+
+        Query streetQuery;
+
+        if (lenient) {
+            var nameFieldQuery = GetFuzzyNameQueryBuilder(street, "street");
+            if (houseNumber == null) {
+                streetQuery = nameFieldQuery.boost(STREET_BOOST).build().toQuery();
+            } else {
+                streetQuery = QueryBuilders.bool()
+                        .should(GetFuzzyQuery(Constants.STREET, street))
+                        .should(nameFieldQuery.build().toQuery())
+                        .minimumShouldMatch("1")
+                        .boost(STREET_BOOST).build().toQuery();
+            }
+        } else {
+            streetQuery = GetFuzzyQueryBuilder(Constants.STREET, street).boost(STREET_BOOST).build().toQuery();
+        }
+
+        if (houseNumber != null) {
+            var houseNumberMatchQuery = QueryBuilders.bool().must(QueryBuilders.matchPhrase()
+                    .field(Constants.HOUSENUMBER)
+                    .query(houseNumber)
+                    .build()
+                    .toQuery());
+
+            houseNumberMatchQuery.filter(GetFuzzyQuery(Constants.STREET, street));
+            if (cityFilter != null) {
+                houseNumberMatchQuery.filter(cityFilter.build().toQuery());
+            }
+
+            BoolQuery.Builder houseNumberQuery = QueryBuilders.bool()
+                    .should(houseNumberMatchQuery.build().toQuery())
+                    .should(QueryBuilders.bool().mustNot(QueryBuilders.exists().field(Constants.HOUSENUMBER).build().toQuery()).build().toQuery())
+                    .boost(HOUSE_NUMBER_BOOST);
+
+            query.must(houseNumberQuery.build().toQuery());
+        }
+
+        query.must(streetQuery);
+
+        return this;
+    }
+
+    private Query GetFuzzyQuery(String name, String value) {
+        return GetFuzzyQueryBuilder(name, value).build().toQuery();
+    }
+
+    private MatchPhraseQuery.Builder GetFuzzyQueryBuilder(String name, String value) {
+        return QueryBuilders.matchPhrase()
+                .field(name + "_collector")
+                .query(value);
+    }
+
+    private BoolQuery.Builder GetFuzzyNameQueryBuilder(String value, String objectType) {
+        var or = QueryBuilders.bool();
+        for (String lang : languages) {
+            float boost = lang.equals(language) ? 1.0f : FACTOR_FOR_WRONG_LANGUAGE;
+            var fieldName = Constants.NAME + '.' + lang + ".raw";
+
+            or.should(QueryBuilders.matchPhrase()
+                    .field(fieldName)
+                    .query(value)
+                    .boost(boost)
+                    .build()
+                    .toQuery());
+        }
+
+        return or.minimumShouldMatch("1")
+                .filter(QueryBuilders.term()
+                        .field(Constants.OBJECT_TYPE)
+                        .value(FieldValue.of(objectType))
+                        .build()
+                        .toQuery());
+    }
+
+    private static boolean isCityRelatedField(String name) {
+        return Objects.equals(name, Constants.POSTCODE) || Objects.equals(name, Constants.CITY) || Objects.equals(name, Constants.DISTRICT);
+    }
+
+    private void AddNameOrFieldQuery(String field, String value, float boost, String objectType, boolean hasMoreDetails) {
+        var query = GetNameOrFieldQuery(field, value, boost, objectType, hasMoreDetails);
+        if (isCityRelatedField(field)) {
+            addToCityFilter(query);
+        }
+
+        this.query.must(query);
+    }
+
+    private Query GetNameOrFieldQuery(String field, String value, float boost, String objectType, boolean hasMoreDetails) {
+        if (hasMoreDetails) {
+            return GetFuzzyQuery(field, value);
+        }
+
+        return GetFuzzyNameQueryBuilder(value, objectType)
+                .boost(boost)
+                .build()
+                .toQuery();
+    }
+}

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/DBPropertyEntry.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/DBPropertyEntry.java
@@ -8,6 +8,7 @@ public class DBPropertyEntry {
     public String databaseVersion;
     public Date importDate;
     public String[] languages;
+    public boolean supportStructuredQueries;
 
     public DBPropertyEntry() {}
 
@@ -15,5 +16,6 @@ public class DBPropertyEntry {
         databaseVersion = DatabaseProperties.DATABASE_VERSION;
         importDate = props.getImportDate();
         languages = props.getLanguages();
+        supportStructuredQueries = props.getSupportStructuredQueries();
     }
 }

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -43,7 +43,9 @@ public class IndexMapping {
                 }
 
                 mappings.properties(propertyName,
-                        b -> b.text(p -> p.copyTo(collectors)));
+                        b -> b.text(p -> p
+                                .index(false)
+                                .copyTo(collectors)));
             }
 
             mappings.properties("name." + lang,
@@ -115,7 +117,7 @@ public class IndexMapping {
             }
 
             mappings.properties(field + ".default", b -> b.text(p -> p
-                    .index(shouldIndexAddressField(field))
+                    .index(false)
                     .copyTo(collectors)));
         }
         mappings.properties("postcode", b -> b.text(p -> p

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -1,0 +1,85 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.*;
+import de.komoot.photon.searcher.StructuredSearchHandler;
+import de.komoot.photon.searcher.PhotonResult;
+import de.komoot.photon.query.StructuredPhotonRequest;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.SearchType;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.explain.ExplanationDetail;
+import org.opensearch.common.util.iterable.Iterables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.io.IOException;
+
+/**
+ * Execute a structured forward lookup on an Elasticsearch database.
+ */
+public class OpenSearchStructuredSearchHandler implements StructuredSearchHandler {
+    private final OpenSearchClient client;
+    private final String[] supportedLanguages;
+    private final String queryTimeout;
+
+    public OpenSearchStructuredSearchHandler(OpenSearchClient client, String[] languages, int queryTimeoutSec) {
+        this.client = client;
+        this.supportedLanguages = languages;
+        queryTimeout = queryTimeoutSec + "s";
+    }
+
+    @Override
+    public List<PhotonResult> search(StructuredPhotonRequest photonRequest) {
+        var queryBuilder = buildQuery(photonRequest, false);
+
+        // for the case of deduplication we need a bit more results, #300
+        int limit = photonRequest.getLimit();
+        int extLimit = limit > 1 ? (int) Math.round(photonRequest.getLimit() * 1.5) : 1;
+
+        var results = sendQuery(queryBuilder.buildQuery(), extLimit);
+
+        if (results.hits().total().value() == 0) {
+            results = sendQuery(buildQuery(photonRequest, true).buildQuery(), extLimit);
+
+            if (results.hits().total().value() == 0 && photonRequest.hasStreet()) {
+                var street = photonRequest.getStreet();
+                var houseNumber = photonRequest.getHouseNumber();
+                photonRequest.setStreet(null);
+                photonRequest.setHouseNumber(null);
+                results = sendQuery(buildQuery(photonRequest, true).buildQuery(), extLimit);
+                photonRequest.setStreet(street);
+                photonRequest.setHouseNumber(houseNumber);
+            }
+        }
+
+        List<PhotonResult> ret = new ArrayList<>();
+        for (var hit : results.hits().hits()) {
+            ret.add(hit.source().setScore(hit.score()));
+        }
+
+        return ret;
+    }
+
+    public SearchQueryBuilder buildQuery(StructuredPhotonRequest photonRequest, boolean lenient) {
+        return new SearchQueryBuilder(photonRequest, photonRequest.getLanguage(), supportedLanguages, lenient).
+                withOsmTagFilters(photonRequest.getOsmTagFilters()).
+                withLayerFilters(photonRequest.getLayerFilters()).
+                withLocationBias(photonRequest.getLocationForBias(), photonRequest.getScaleForBias(), photonRequest.getZoomForBias()).
+                withBoundingBox(photonRequest.getBbox());
+    }
+
+    private SearchResponse<OpenSearchResult> sendQuery(Query query, Integer limit) {
+        try {
+            return client.search(s -> s
+                    .index(PhotonIndex.NAME)
+                    .searchType(SearchType.QueryThenFetch)
+                    .query(query)
+                    .size(limit)
+                    .timeout(queryTimeout), OpenSearchResult.class);
+        } catch (IOException e) {
+            throw new RuntimeException("IO error during search", e);
+        }
+    }
+}

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -147,9 +147,10 @@ public class SearchQueryBuilder {
 
     public SearchQueryBuilder(StructuredPhotonRequest request, String language, String[] languages, boolean lenient)
     {
+        var hasSubStateField = request.hasCounty() || request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet();
         var query4QueryBuilder = new AddressQueryBuilder(lenient, language, languages)
-                .addCountryCode(request.getCountryCode())
-                .addState(request.getState(), request.hasCounty() || request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())
+                .addCountryCode(request.getCountryCode(), request.hasState() || hasSubStateField)
+                .addState(request.getState(), hasSubStateField)
                 .addCounty(request.getCounty(), request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())
                 .addCity(request.getCity(), request.hasDistrict(), request.hasStreet(), request.hasPostCode())
                 .addPostalCode(request.getPostCode())
@@ -170,7 +171,8 @@ public class SearchQueryBuilder {
 
         if (!request.hasHouseNumber())
         {
-            queryBuilderForTopLevelFilter = QueryBuilders.bool().mustNot(QueryBuilders.exists().field(Constants.HOUSENUMBER).build().toQuery());
+            queryBuilderForTopLevelFilter = QueryBuilders.bool().mustNot(QueryBuilders.exists().field(Constants.HOUSENUMBER).build().toQuery())
+                    .mustNot(QueryBuilders.term().field(Constants.OBJECT_TYPE).value(FieldValue.of("house")).build().toQuery());
         }
 
         osmTagFilter = new OsmTagFilter();

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -1,6 +1,9 @@
 package de.komoot.photon.opensearch;
 
 import de.komoot.photon.searcher.TagFilter;
+import de.komoot.photon.StructuredSearchRequestHandler;
+import de.komoot.photon.query.StructuredPhotonRequest;
+import de.komoot.photon.Constants;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Point;
 import org.opensearch.client.json.JsonData;
@@ -44,10 +47,10 @@ public class SearchQueryBuilder {
         query4QueryBuilder.should(shd -> shd.functionScore(fs -> fs
                 .query(q -> q.multiMatch(mm -> {
                     mm.query(query).type(TextQueryType.BestFields).analyzer("search");
-                    mm.fields(String.format("%s^%f", "collector.default", 1.0f));
+                    mm.fields(String.format(Locale.ROOT, "%s^%f", "collector.default", 1.0f));
 
                     for (String lang : languages) {
-                        mm.fields(String.format("collector.%s^%f", lang, lang.equals(language) ? 1.0f : 0.6f));
+                        mm.fields(String.format(Locale.ROOT, "collector.%s^%f", lang, lang.equals(language) ? 1.0f : 0.6f));
                     }
 
                     return mm.boost(0.3f);
@@ -71,7 +74,7 @@ public class SearchQueryBuilder {
             }
 
             for (String lang : languages) {
-                q.fields(String.format("name.%s.ngrams^%f", lang, lang.equals(defLang) ? 1.0f : 0.4f));
+                q.fields(String.format(Locale.ROOT, "name.%s.ngrams^%f", lang, lang.equals(defLang) ? 1.0f : 0.4f));
             }
 
             q.fields("name.other^0.4");
@@ -142,6 +145,37 @@ public class SearchQueryBuilder {
                         .field(String.format("name.%s.raw", language))));
     }
 
+    public SearchQueryBuilder(StructuredPhotonRequest request, String language, String[] languages, boolean lenient)
+    {
+        var query4QueryBuilder = new AddressQueryBuilder(lenient, language, languages)
+                .addCountryCode(request.getCountryCode())
+                .addState(request.getState(), request.hasCounty() || request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())
+                .addCounty(request.getCounty(), request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())
+                .addCity(request.getCity(), request.hasDistrict(), request.hasStreet(), request.hasPostCode())
+                .addPostalCode(request.getPostCode())
+                .addDistrict(request.getDistrict(), request.hasStreet())
+                .addStreetAndHouseNumber(request.getStreet(), request.getHouseNumber())
+                .getQuery();
+
+        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
+                .query(query4QueryBuilder)
+                .functions(fn1 -> fn1
+                        .linear(df1 -> df1
+                                .field("importance")
+                                .placement(p1 -> p1
+                                        .origin(JsonData.of(1.0))
+                                        .scale(JsonData.of(1.0))
+                                        .decay(0.5))))
+                .scoreMode(FunctionScoreMode.Sum));
+
+        if (!request.hasHouseNumber())
+        {
+            queryBuilderForTopLevelFilter = QueryBuilders.bool().mustNot(QueryBuilders.exists().field(Constants.HOUSENUMBER).build().toQuery());
+        }
+
+        osmTagFilter = new OsmTagFilter();
+    }
+
     public SearchQueryBuilder withLocationBias(Point point, double scale, int zoom) {
         if (point == null || zoom < 4) return this;
 
@@ -205,7 +239,10 @@ public class SearchQueryBuilder {
         if (finalQuery == null) {
             finalQuery = BoolQuery.of(q -> {
                 q.must(finalQueryWithoutTagFilterBuilder.build());
-                q.filter(queryBuilderForTopLevelFilter.build().toQuery());
+                if (queryBuilderForTopLevelFilter != null) {
+                    q.filter(queryBuilderForTopLevelFilter.build().toQuery());
+                }
+
                 q.filter(f -> f.bool(fb -> fb
                         .mustNot(n -> n.ids(i -> i.values(PhotonIndex.PROPERTY_DOCUMENT_ID)))
                 ));

--- a/app/opensearch/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -49,7 +49,7 @@ public class ESBaseTester {
     public void setUpES(Path test_directory, String... languages) throws IOException {
         server = new OpenSearchTestServer(test_directory.toString());
         server.startTestServer(TEST_CLUSTER_NAME);
-        server.recreateIndex(languages, new Date());
+        server.recreateIndex(languages, new Date(), true);
         server.refreshIndexes();
     }
 

--- a/app/opensearch/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
@@ -1,0 +1,237 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.query.StructuredPhotonRequest;
+import de.komoot.photon.Constants;
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.Importer;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
+import de.komoot.photon.searcher.PhotonResult;
+import de.komoot.photon.searcher.StructuredSearchHandler;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class StructuredQueryTest extends ESBaseTester {
+
+    private static final String CountryCode = "DE";
+    private static final String Language = "en";
+    private static final String District = "MajorSuburb";
+    private static final String HouseNumber = "42";
+    private static final String City = "Some City";
+    private static final String Hamlet = "Hamlet";
+    private static final String Street = "Some street";
+    public static final String DistrictPostCode = "12346";
+
+    @TempDir
+    private static Path instanceTestDirectory;
+
+    private static int getRank(AddressType type)
+    {
+        for(int i = 0; i < 50; ++i)
+        {
+            if (type.coversRank(i)){
+                return i;
+            }
+        }
+
+        return 99;
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpES(instanceTestDirectory, Language, "de", "fr");
+        Importer instance = makeImporter();
+
+        var country = new PhotonDoc(0, "R", 0, "place", "country")
+                .names(Collections.singletonMap("name", "Germany"))
+                .countryCode(CountryCode)
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.COUNTRY));
+
+        var city = new PhotonDoc(1, "R", 1, "place", "city")
+                .names(Collections.singletonMap("name", City))
+                .countryCode(CountryCode)
+                .postcode("12345")
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.CITY));
+
+        Map<String, String> address = new HashMap<>();
+        address.put("city", City);
+        var suburb = new PhotonDoc(2, "N", 2, "place", "suburb")
+                .names(Collections.singletonMap("name", District))
+                .countryCode(CountryCode)
+                .postcode(DistrictPostCode)
+                .address(address)
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.DISTRICT));
+
+        var street = new PhotonDoc(3, "W", 3, "place", "street")
+                .names(Collections.singletonMap("name", Street))
+                .countryCode(CountryCode)
+                .postcode("12345")
+                .address(address)
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.STREET));
+
+        address.put("street", Street);
+        var house = new PhotonDoc(4, "R", 4, "place", "house")
+                .countryCode(CountryCode)
+                .postcode("12345")
+                .address(address)
+                .houseNumber(HouseNumber)
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.HOUSE));
+
+        instance.add(country, 0);
+        instance.add(city, 1);
+        instance.add(suburb, 2);
+        instance.add(street, 3);
+        instance.add(house, 4);
+        addHamletHouse(instance, 5, "1");
+        addHamletHouse(instance, 6, "2");
+        addHamletHouse(instance, 7, "3");
+        instance.finish();
+        refresh();
+    }
+
+    @Test
+    void doesFindDistrictByPostcode()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+        request.setPostCode(DistrictPostCode);
+
+        var result = search(request);
+        Assertions.assertEquals(request.getPostCode(), result.get(Constants.POSTCODE));
+    }
+
+    @Test
+    void doesFindHouseNumberInHamletWithoutStreetName() {
+        var request = new StructuredPhotonRequest(Language);
+        request.setDistrict(Hamlet);
+        request.setHouseNumber("2");
+
+        StructuredSearchHandler queryHandler = getServer().createStructuredSearchHandler(new String[]{Language}, 1);
+        var results = queryHandler.search(request);
+        assertEquals(1, results.size());
+        var result = results.get(0);
+        assertEquals(request.getHouseNumber(), result.get(Constants.HOUSENUMBER));
+    }
+
+    @Test
+    void doesNotReturnHousesForCityRequest()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+
+        StructuredSearchHandler queryHandler = getServer().createStructuredSearchHandler(new String[]{Language}, 1);
+        var results = queryHandler.search(request);
+
+        for(var result : results)
+        {
+            assertNull(result.getLocalised(Constants.STREET, Language));
+            assertNull(result.get(Constants.HOUSENUMBER));
+        }
+    }
+
+    @Test
+    void testWrongStreet()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+        request.setStreet("totally wrong");
+        request.setHouseNumber(HouseNumber);
+
+        var result = search(request);
+        assertNull(result.getLocalised(Constants.STREET, Language));
+        Assertions.assertEquals(request.getCity(), result.getLocalised(Constants.NAME, Language));
+    }
+
+    @Test
+    void testDistrictAsCity()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(District);
+        var result = search(request);
+        Assertions.assertEquals(City, result.getLocalised(Constants.CITY, Language));
+        Assertions.assertEquals(request.getCity(), result.getLocalised(Constants.NAME, Language));
+    }
+
+    @Test
+    void testWrongHouseNumber()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+        request.setStreet(Street);
+        request.setHouseNumber("1");
+        var result = search(request);
+        assertNull(result.getLocalised(Constants.HOUSENUMBER, Language));
+        Assertions.assertEquals(request.getStreet(), result.getLocalised(Constants.NAME, Language));
+        Assertions.assertEquals(request.getCity(), result.getLocalised(Constants.CITY, Language));
+    }
+
+    @Test
+    void testWrongHouseNumberAndWrongStreet()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+        request.setStreet("does not exist");
+        request.setHouseNumber("1");
+        var result = search(request);
+        assertNull(result.getLocalised(Constants.HOUSENUMBER, Language));
+        assertNull(result.getLocalised(Constants.STREET, Language));
+        Assertions.assertEquals(request.getCity(), result.getLocalised(Constants.NAME, Language));
+    }
+
+    @Test
+    void testHouse()
+    {
+        var request = new StructuredPhotonRequest(Language);
+        request.setCountryCode(CountryCode);
+        request.setCity(City);
+        request.setStreet(Street);
+        request.setHouseNumber(HouseNumber);
+
+        var result = search(request);
+        Assertions.assertEquals(request.getCity(), result.getLocalised(Constants.CITY, Language));
+        Assertions.assertEquals(request.getStreet(), result.getLocalised(Constants.STREET, Language));
+        Assertions.assertEquals(request.getHouseNumber(), result.get(Constants.HOUSENUMBER));
+    }
+
+    private PhotonResult search(StructuredPhotonRequest request) {
+        StructuredSearchHandler queryHandler = getServer().createStructuredSearchHandler(new String[]{Language}, 1);
+        var results = queryHandler.search(request);
+
+        return results.get(0);
+    }
+
+    private void addHamletHouse(Importer instance, int id, String houseNumber) {
+        var hamletAddress = new HashMap<String, String>();
+        hamletAddress.put("city", City);
+        hamletAddress.put("suburb", Hamlet);
+
+        var doc = new PhotonDoc(id, "R", id, "place", "house")
+                .countryCode(CountryCode)
+                .address(hamletAddress)
+                .houseNumber(houseNumber)
+                .importance(1.0)
+                .rankAddress(getRank(AddressType.HOUSE));
+
+        instance.add(doc, id);
+    }
+}

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -10,6 +10,9 @@ import java.io.File;
  */
 public class CommandLineArgs {
 
+    @Parameter(names = "-structured", description = "Enable support for structured queries")
+    private boolean supportStructuredQueries = false;
+
     @Parameter(names = "-cluster", description = "Name of ElasticSearch cluster to put the server into")
     private String cluster = "photon";
 
@@ -191,6 +194,8 @@ public class CommandLineArgs {
     public boolean isUsage() {
         return this.usage;
     }
+    
+    public boolean getSupportStructuredQueries() { return supportStructuredQueries; }
 
     public int getMaxReverseResults() {
         return maxReverseResults;

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -26,6 +26,8 @@ public class DatabaseProperties {
      */
     private Date importDate;
 
+    private boolean supportStructuredQueries;
+
     /**
      * Return the list of languages for which the database is configured.
      * @return
@@ -87,6 +89,15 @@ public class DatabaseProperties {
 
     public DatabaseProperties setImportDate(Date importDate) {
         this.importDate = importDate;
+        return this;
+    }
+
+    public boolean getSupportStructuredQueries() {
+        return supportStructuredQueries;
+    }
+
+    public DatabaseProperties setSupportStructuredQueries(boolean supportStructuredQueries) {
+        this.supportStructuredQueries = supportStructuredQueries;
         return this;
     }
 }

--- a/src/main/java/de/komoot/photon/StructuredSearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/StructuredSearchRequestHandler.java
@@ -1,0 +1,56 @@
+package de.komoot.photon;
+
+import de.komoot.photon.query.BadRequestException;
+import de.komoot.photon.query.PhotonRequestFactory;
+import de.komoot.photon.query.StructuredPhotonRequest;
+import de.komoot.photon.searcher.*;
+import org.json.JSONObject;
+import spark.Request;
+import spark.Response;
+import spark.RouteImpl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static spark.Spark.halt;
+
+public class StructuredSearchRequestHandler extends RouteImpl {
+    private final PhotonRequestFactory photonRequestFactory;
+    private final StructuredSearchHandler requestHandler;
+
+    StructuredSearchRequestHandler(String path, StructuredSearchHandler dbHandler, String[] languages, String defaultLanguage, int maxResults) {
+        super(path);
+        List<String> supportedLanguages = Arrays.asList(languages);
+        this.photonRequestFactory = new PhotonRequestFactory(supportedLanguages, defaultLanguage, maxResults);
+        this.requestHandler = dbHandler;
+    }
+
+    @Override
+    public String handle(Request request, Response response) {
+        StructuredPhotonRequest photonRequest = null;
+        try {
+            photonRequest = photonRequestFactory.createStructured(request);
+        } catch (BadRequestException e) {
+            JSONObject json = new JSONObject();
+            json.put("message", e.getMessage());
+            throw halt(e.getHttpStatus(), json.toString());
+        }
+
+        List<PhotonResult> results = requestHandler.search(photonRequest);
+
+        // Further filtering
+        results = new StreetDupesRemover(photonRequest.getLanguage()).execute(results);
+
+        // Restrict to the requested limit.
+        if (results.size() > photonRequest.getLimit()) {
+            results = results.subList(0, photonRequest.getLimit());
+        }
+
+        String debugInfo = null;
+     /*   if (photonRequest.getDebug()) {
+            debugInfo = requestHandler.dumpQuery(photonRequest);
+        }
+ */
+        return new GeocodeJsonFormatter(photonRequest.getDebug(), photonRequest.getLanguage()).convert(results, debugInfo);
+    }
+}

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -1,116 +1,17 @@
 package de.komoot.photon.query;
 
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Point;
-import de.komoot.photon.searcher.TagFilter;
-
-import java.util.*;
-
 /**
  * Collection of query parameters for a search request.
  */
-public class PhotonRequest {
+public class PhotonRequest extends PhotonRequestBase {
     private final String query;
-    private final String language;
-    private int limit = 15;
-    private Point locationForBias = null;
-    private double scale = 0.2;
-    private int zoom = 14;
-    private Envelope bbox = null;
-    private boolean debug = false;
-
-    private final List<TagFilter> osmTagFilters = new ArrayList<>(1);
-    private Set<String> layerFilters = new HashSet<>(1);
-
 
     public PhotonRequest(String query, String language) {
+        super(language);
         this.query = query;
-        this.language = language;
     }
 
     public String getQuery() {
         return query;
-    }
-
-    public int getLimit() {
-        return limit;
-    }
-    
-    public Envelope getBbox() {
-        return bbox;
-    }
-
-    public Point getLocationForBias() {
-        return locationForBias;
-    }
-
-    public double getScaleForBias() {
-        return scale;
-    }
-
-    public int getZoomForBias() {
-        return zoom;
-    }
-
-    public String getLanguage() {
-        return language;
-    }
-
-    public boolean getDebug() { return debug; }
-
-    public List<TagFilter> getOsmTagFilters() {
-        return osmTagFilters;
-    }
-
-    public Set<String> getLayerFilters() {
-        return layerFilters;
-    }
-
-    PhotonRequest addOsmTagFilter(TagFilter filter) {
-        osmTagFilters.add(filter);
-        return this;
-    }
-
-    PhotonRequest setLayerFilter(Set<String> filters) {
-        layerFilters = filters;
-        return this;
-    }
-
-    PhotonRequest setLimit(Integer limit) {
-        this.limit = limit;
-        return this;
-    }
-
-    PhotonRequest setLocationForBias(Point locationForBias) {
-        if (locationForBias != null) {
-            this.locationForBias = locationForBias;
-        }
-        return this;
-    }
-
-    PhotonRequest setScale(Double scale) {
-        if (scale != null) {
-            this.scale = Double.max(Double.min(scale, 1.0), 0.0);
-        }
-        return this;
-    }
-
-    PhotonRequest setZoom(Integer zoom) {
-        if (zoom != null) {
-            this.zoom = Integer.max(Integer.min(zoom, 18), 0);
-        }
-        return this;
-    }
-
-    PhotonRequest setBbox(Envelope bbox) {
-        if (bbox != null) {
-            this.bbox = bbox;
-        }
-        return this;
-    }
-
-    PhotonRequest enableDebug() {
-        this.debug = true;
-        return this;
     }
 }

--- a/src/main/java/de/komoot/photon/query/PhotonRequestBase.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestBase.java
@@ -1,0 +1,103 @@
+package de.komoot.photon.query;
+
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Point;
+import de.komoot.photon.searcher.TagFilter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PhotonRequestBase
+{
+    private final String language;
+    private int limit = 15;
+    private Point locationForBias = null;
+    private double scale = 0.2;
+    private int zoom = 14;
+    private Envelope bbox = null;
+    private boolean debug = false;
+
+    private final List<TagFilter> osmTagFilters = new ArrayList<>(1);
+    private Set<String> layerFilters = new HashSet<>(1);
+
+    protected PhotonRequestBase(String language)
+    {
+        this.language = language;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public Envelope getBbox() {
+        return bbox;
+    }
+
+    public Point getLocationForBias() {
+        return locationForBias;
+    }
+
+    public double getScaleForBias() {
+        return scale;
+    }
+
+    public int getZoomForBias() {
+        return zoom;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public boolean getDebug() { return debug; }
+
+    public List<TagFilter> getOsmTagFilters() {
+        return osmTagFilters;
+    }
+
+    public Set<String> getLayerFilters() {
+        return layerFilters;
+    }
+
+    void addOsmTagFilter(TagFilter filter) {
+        osmTagFilters.add(filter);
+    }
+
+    void setLayerFilter(Set<String> filters) {
+        layerFilters = filters;
+    }
+
+    void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    void setLocationForBias(Point locationForBias) {
+        if (locationForBias != null) {
+            this.locationForBias = locationForBias;
+        }
+    }
+
+    void setScale(Double scale) {
+        if (scale != null) {
+            this.scale = Double.max(Double.min(scale, 1.0), 0.0);
+        }
+    }
+
+    void setZoom(Integer zoom) {
+        if (zoom != null) {
+            this.zoom = Integer.max(Integer.min(zoom, 18), 0);
+        }
+    }
+
+    void setBbox(Envelope bbox) {
+        if (bbox != null) {
+            this.bbox = bbox;
+        }
+    }
+
+    void enableDebug() {
+        this.debug = true;
+    }
+}

--- a/src/main/java/de/komoot/photon/query/StructuredPhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/StructuredPhotonRequest.java
@@ -84,6 +84,8 @@ public class StructuredPhotonRequest extends PhotonRequestBase {
         this.state = state;
     }
 
+    public boolean hasState() { return !StringUtils.isEmpty(this.state); }
+
     public boolean hasDistrict() { return !StringUtils.isEmpty(this.district); }
 
     public boolean hasPostCode() { return !StringUtils.isEmpty(this.postCode); }

--- a/src/main/java/de/komoot/photon/query/StructuredPhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/StructuredPhotonRequest.java
@@ -1,0 +1,98 @@
+package de.komoot.photon.query;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class StructuredPhotonRequest extends PhotonRequestBase {
+    private String countryCode;
+    private String state;
+    private String county;
+    private String city;
+    private String postCode;
+    private String district;
+    private String street;
+    private String houseNumber;
+
+    public StructuredPhotonRequest(String language) {
+        super(language);
+    }
+
+    public boolean getDebug() {
+        return false;
+    }
+
+    public String getCounty() {
+        return county;
+    }
+
+    public void setCounty(String county) {
+        this.county = county;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getPostCode() {
+        return postCode;
+    }
+
+    public void setPostCode(String postCode) {
+        this.postCode = postCode;
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public void setDistrict(String district) {
+        this.district = district;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getHouseNumber() {
+        return houseNumber;
+    }
+
+    public void setHouseNumber(String houseNumber) {
+        this.houseNumber = houseNumber;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public boolean hasDistrict() { return !StringUtils.isEmpty(this.district); }
+
+    public boolean hasPostCode() { return !StringUtils.isEmpty(this.postCode); }
+
+    public boolean hasCityOrPostCode() { return !StringUtils.isEmpty(this.city) || hasPostCode(); }
+
+    public boolean hasCounty() { return !StringUtils.isEmpty(this.county); }
+
+    public boolean hasStreet() { return !StringUtils.isEmpty(this.street) || hasHouseNumber(); }
+
+    public boolean hasHouseNumber() { return !StringUtils.isEmpty(this.houseNumber); }
+}

--- a/src/main/java/de/komoot/photon/searcher/StructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/StructuredSearchHandler.java
@@ -1,0 +1,9 @@
+package de.komoot.photon.searcher;
+
+import de.komoot.photon.query.StructuredPhotonRequest;
+
+import java.util.List;
+
+public interface StructuredSearchHandler {
+    List<PhotonResult> search(StructuredPhotonRequest photonRequest);
+}

--- a/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
@@ -55,7 +55,8 @@ class QueryFilterLayerTest extends ESBaseTester {
     }
 
     private List<PhotonResult> searchWithLayers(String... layers) {
-        PhotonRequest request = new PhotonRequest("berlin", "en").setLimit(50);
+        PhotonRequest request = new PhotonRequest("berlin", "en");
+        request.setLimit(50);
         request.setLayerFilter(Arrays.stream(layers).collect(Collectors.toSet()));
 
         return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);

--- a/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
@@ -63,7 +63,8 @@ class QueryFilterTagValueTest extends ESBaseTester {
     }
 
     private List<PhotonResult> searchWithTags(String[] params) {
-        PhotonRequest request = new PhotonRequest("berlin", "en").setLimit(50);
+        PhotonRequest request = new PhotonRequest("berlin", "en");
+        request.setLimit(50);
         for (String param : params) {
             request.addOsmTagFilter(TagFilter.buildOsmTagFilter(param));
         }

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -99,8 +99,7 @@ class QueryRelevanceTest extends ESBaseTester {
         instance.finish();
         refresh();
 
-        List<PhotonResult> results = search(new PhotonRequest("ham", "en")
-                .setLocationForBias(FACTORY.createPoint(new Coordinate(-9.9, -10))));
+        List<PhotonResult> results = search(createBiasedRequest());
 
         assertEquals(2, results.size());
         assertEquals(1001, results.get(0).get("osm_id"));
@@ -118,10 +117,16 @@ class QueryRelevanceTest extends ESBaseTester {
         instance.finish();
         refresh();
 
-        List<PhotonResult> results = search(new PhotonRequest("ham", "en")
-                .setLocationForBias(FACTORY.createPoint(new Coordinate(-9.9, -10))));
+        List<PhotonResult> results = search(createBiasedRequest());
 
         assertEquals(2, results.size());
         assertEquals(1000, results.get(0).get("osm_id"));
+    }
+
+    private PhotonRequest createBiasedRequest()
+    {
+        PhotonRequest result = new PhotonRequest("ham", "en");
+        result.setLocationForBias(FACTORY.createPoint(new Coordinate(-9.9, -10)));
+        return result;
     }
 }


### PR DESCRIPTION
this adds a new function 
```
http://localhost:2322/structured?city=berlin
```

Supported parameters are
```
"lang", "limit",  "lon", "lat", "osm_tag", "location_bias_scale", "bbox", "debug", "zoom", "layer", "countrycode", "state", "county", "city", "postcode", "district", "housenumber", "street"
```

Result format is equal to /api.

For those parameters that are also available for /api the meaning is the same. 
CountryCode has to be the ISO2 code (e.g. DE instead of "Germany"). The country code must match exactly. Fuzzy matching does not make sense for 2 letter codes. In my experience the case that address is fine except for the country code is rare compared to nonsense hits in other countries.

In order to use structured queries, the new option "-structured" has to be used when importing from Nominatim. Expect 10-20% higher file size. If you run photon on an existing index folder, photon detects automatically if the data was imported with structured query support.
For data imported without "-structured" /structured?city=berlin returns a technical error as the route is not mapped.
Structured queries are only supported for OpenSearch based photon.

### Known issues

* state information is used with low priority. This can cause issues with cities that exist in several states (e.g. "Springfield" in the US). Reason is that states are not normalized - some documents have abbreviations like "NY", other spell "New York" out. To fix this either an alias list is needed or this is normalized on import (maybe even for nominatim). 
* no fine tuning of the scores yet - would require a large test set with reliable expected results and some automated way for guessing "good" scores.
* /structured?city=some_hamlet_or_isolated_dwelling does not always work