### PR TITLE
OpenSearch version: fix collector name

### DIFF
--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -101,7 +101,7 @@ public class IndexMapping {
 
         mappings.properties("name.default", b -> b.text(p -> p
                 .index(false)
-                .copyTo("collector.default", "collector_base")));
+                .copyTo("collector.default", "collector.base")));
 
         // Collector for all name parts.
         mappings.properties("name.other", b -> b.text(pi -> pi.index(true).analyzer("index_raw")));


### PR DESCRIPTION
There was a typo in the index mapping preventing default names from entering the base collector.