### PR TITLE
Allow multiple CORS origins to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Discover more of photon's features with its usage `java -jar photon-*.jar -h`. T
 
 -cors-any             Enable cross-site resource sharing for any origin (default CORS not supported)
 
--cors-origin          Enable cross-site resource sharing for the specified origin (default CORS not supported)
+-cors-origin          Enable cross-site resource sharing for the specified origins, comma separated (default CORS not supported)
 
 -enable-update-api    Enable the additional endpoint /nominatim-update, which allows to trigger updates
                       from a nominatim database

--- a/app/opensearch/build.gradle
+++ b/app/opensearch/build.gradle
@@ -50,4 +50,3 @@ shadowJar {
     // when you cannot upgrade as per https://logging.apache.org/log4j/2.x/security.html
     exclude 'org/apache/logging/log4j/core/lookup/JndiLookup.class'
 }
-

--- a/buildSrc/shared.gradle
+++ b/buildSrc/shared.gradle
@@ -73,3 +73,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+test {
+    systemProperty "sun.net.http.allowRestrictedHeaders", "true"
+}

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -76,7 +76,7 @@ public class App {
             jCommander.parse(rawArgs);
 
             // Cors arguments are mutually exclusive.
-            if (args.isCorsAnyOrigin() && args.getCorsOrigin() != null) {
+            if (args.isCorsAnyOrigin() && args.getCorsOrigin().length > 0) {
                 throw new ParameterException("Use only one cors configuration type");
             }
         } catch (ParameterException e) {
@@ -179,8 +179,8 @@ public class App {
         port(args.getListenPort());
         ipAddress(args.getListenIp());
 
-        String allowedOrigin = args.isCorsAnyOrigin() ? "*" : args.getCorsOrigin();
-        if (allowedOrigin != null) {
+        String[] allowedOrigin = args.isCorsAnyOrigin() ? new String[]{ "*" } : args.getCorsOrigin();
+        if (allowedOrigin.length > 0) {
             CorsFilter.enableCORS(allowedOrigin, "get", "*");
         } else {
             // Set Json content type. In the other case already set by enableCors.

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -76,8 +76,8 @@ public class CommandLineArgs {
     @Parameter(names = "-cors-any", description = "Enable cross-site resource sharing for any origin")
     private boolean corsAnyOrigin = false;
     
-    @Parameter(names = "-cors-origin", description = "Enable cross-site resource sharing for the specified origin")
-    private String corsOrigin = null;
+    @Parameter(names = "-cors-origin", description = "Enable cross-site resource sharing for the specified origins, comma separated", converter = StringArrayConverter.class)
+    private String[] corsOrigin = new String[]{};
 
     @Parameter(names = "-enable-update-api", description = "Enable the additional endpoint /nominatim-update, which allows to trigger updates from a nominatim database")
     private boolean enableUpdateApi = false;
@@ -183,7 +183,7 @@ public class CommandLineArgs {
         return this.corsAnyOrigin;
     }
 
-    public String getCorsOrigin() {
+    public String[] getCorsOrigin() {
         return this.corsOrigin;
     }
 

--- a/src/main/java/de/komoot/photon/utils/CorsFilter.java
+++ b/src/main/java/de/komoot/photon/utils/CorsFilter.java
@@ -1,5 +1,7 @@
 package de.komoot.photon.utils;
 
+import java.util.Arrays;
+
 import static spark.Spark.before;
 import static spark.Spark.options;
 
@@ -15,7 +17,7 @@ public class CorsFilter {
      * @param methods permitted methods comma separated
      * @param headers permitted headers comma separated
      */
-    public static void enableCORS(final String origin, final String methods, final String headers) {
+    public static void enableCORS(final String[] origin, final String methods, final String headers) {
 
         options("/*", (request, response) -> {
 
@@ -32,11 +34,24 @@ public class CorsFilter {
             return "OK";
         });
 
-        before((request, response) -> {
-            response.header("Access-Control-Allow-Origin", origin);
-            response.header("Access-Control-Request-Method", methods);
-            response.header("Access-Control-Allow-Headers", headers);
-            response.type("application/json; charset=UTF-8");
-        });
+        if (origin.length == 1) {
+            before((request, response) -> {
+                response.header("Access-Control-Allow-Origin", origin[0]);
+                response.header("Access-Control-Request-Method", methods);
+                response.header("Access-Control-Allow-Headers", headers);
+                response.type("application/json; charset=UTF-8");
+            });
+        } else {
+            before((request, response) -> {
+                String requestOrigin = request.headers("Origin");
+                String matchingOrigin = Arrays.stream(origin).filter(s -> s.equalsIgnoreCase(requestOrigin)).findFirst().orElse(origin[0]);
+
+                response.header("Access-Control-Allow-Origin", matchingOrigin);
+                response.header("Access-Control-Request-Method", methods);
+                response.header("Access-Control-Allow-Headers", headers);
+                response.header("Vary", "Origin");
+                response.type("application/json; charset=UTF-8");
+            });
+        }
     }
 }


### PR DESCRIPTION
We'd find it useful if we could specify multiple, comma separated origins when using the `--cors-origin` flag