### PR TITLE
Decouple database versions for ES and OS implementation

### DIFF
--- a/app/es_embedded/src/main/java/de/komoot/photon/Server.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/Server.java
@@ -37,6 +37,17 @@ import java.util.Map;
  * Helper class to start/stop ElasticSearch node and get ElasticSearch clients.
  */
 public class Server {
+    /**
+     * Database version created by new imports with the current code.
+     *
+     * Format must be: major.minor.patch-dev
+     *
+     * Increase to next to be released version when the database layout
+     * changes in an incompatible way. If it is already at the next released
+     * version, increase the dev version.
+     */
+    public static final String DATABASE_VERSION = "0.3.6-1";
+
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Server.class);
 
     public static final String PROPERTY_DOCUMENT_ID = "DATABASE_PROPERTIES";
@@ -228,7 +239,7 @@ public class Server {
      */
     public void saveToDatabase(DatabaseProperties dbProperties) throws IOException  {
         final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(BASE_FIELD)
-                        .field(FIELD_VERSION, DatabaseProperties.DATABASE_VERSION)
+                        .field(FIELD_VERSION, DATABASE_VERSION)
                         .field(FIELD_LANGUAGES, String.join(",", dbProperties.getLanguages()))
                         .field(FIELD_IMPORT_DATE, dbProperties.getImportDate() instanceof Date ? dbProperties.getImportDate().toInstant() : null)
                         .endObject().endObject();
@@ -261,8 +272,9 @@ public class Server {
         }
 
         String version = properties.getOrDefault(FIELD_VERSION, "");
-        if (!DatabaseProperties.DATABASE_VERSION.equals(version)) {
-            LOGGER.error("Database has incompatible version '{}'. Expected: {}", version, DatabaseProperties.DATABASE_VERSION);
+        if (!DATABASE_VERSION.equals(version)) {
+            LOGGER.error("Database has incompatible version '{}'. Expected: {}",
+                         version, DATABASE_VERSION);
             throw new UsageException("Incompatible database.");
         }
 

--- a/app/es_embedded/src/main/java/de/komoot/photon/Server.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/Server.java
@@ -184,9 +184,7 @@ public class Server {
 
         createAndPutIndexMapping(languages, supportStructuredQueries);
 
-        DatabaseProperties dbProperties = new DatabaseProperties()
-            .setLanguages(languages)
-            .setImportDate(importDate);
+        DatabaseProperties dbProperties = new DatabaseProperties(languages, importDate, false);
         saveToDatabase(dbProperties);
 
         return dbProperties;
@@ -257,7 +255,6 @@ public class Server {
      * database version will then fail.
      */
     public DatabaseProperties loadFromDatabase() {
-        DatabaseProperties dbProperties = new DatabaseProperties();
         GetResponse response = esClient.prepareGet(PhotonIndex.NAME, PhotonIndex.TYPE, PROPERTY_DOCUMENT_ID).execute().actionGet();
 
         // We are currently at the database version where versioning was introduced.
@@ -279,12 +276,11 @@ public class Server {
         }
 
         String langString = properties.get(FIELD_LANGUAGES);
-        dbProperties.setLanguages(langString == null ? null : langString.split(","));
-
         String importDateString = properties.get(FIELD_IMPORT_DATE);
-        dbProperties.setImportDate(importDateString == null ? null : Date.from(Instant.parse(importDateString)));
 
-        return dbProperties;
+        return new DatabaseProperties(langString == null ? null : langString.split(","),
+                                      importDateString == null ? null : Date.from(Instant.parse(importDateString)),
+                                      false);
     }
 
     public Importer createImporter(String[] languages, String[] extraTags) {

--- a/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ServerTest.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ServerTest.java
@@ -15,10 +15,8 @@ class ServerTest extends ESBaseTester {
     void testSaveAndLoadFromDatabase() throws IOException {
         setUpES();
 
-        DatabaseProperties prop = new DatabaseProperties();
-        prop.setLanguages(new String[]{"en", "de", "fr"});
         Date now = new Date();
-        prop.setImportDate(now);
+        DatabaseProperties prop = new DatabaseProperties(new String[]{"en", "de", "fr"}, now, false);
         getServer().saveToDatabase(prop);
 
         prop = getServer().loadFromDatabase();

--- a/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ServerTest.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ServerTest.java
@@ -21,8 +21,7 @@ class ServerTest extends ESBaseTester {
         prop.setImportDate(now);
         getServer().saveToDatabase(prop);
 
-        prop = new DatabaseProperties();
-        getServer().loadFromDatabase(prop);
+        prop = getServer().loadFromDatabase();
 
         assertArrayEquals(new String[]{"en", "de", "fr"}, prop.getLanguages());
         assertEquals(now, prop.getImportDate());

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -119,10 +119,7 @@ public class Server {
 
         (new IndexMapping(supportStructuredQueries)).addLanguages(languages).putMapping(client, PhotonIndex.NAME);
 
-        var dbProperties = new DatabaseProperties()
-                .setLanguages(languages)
-                .setSupportStructuredQueries(supportStructuredQueries)
-                .setImportDate(importDate);
+        var dbProperties = new DatabaseProperties(languages, importDate, supportStructuredQueries);
         saveToDatabase(dbProperties);
 
         return dbProperties;
@@ -149,7 +146,6 @@ public class Server {
     }
 
     public DatabaseProperties loadFromDatabase() throws IOException {
-        DatabaseProperties dbProperties = new DatabaseProperties();
         var dbEntry = client.get(r -> r
                 .index(PhotonIndex.NAME)
                 .id(PhotonIndex.PROPERTY_DOCUMENT_ID),
@@ -165,11 +161,9 @@ public class Server {
             throw new UsageException("Incompatible database.");
         }
 
-        dbProperties.setLanguages(dbEntry.source().languages);
-        dbProperties.setImportDate(dbEntry.source().importDate);
-        dbProperties.setSupportStructuredQueries(dbEntry.source().supportStructuredQueries);
-
-        return dbProperties;
+        return new DatabaseProperties(dbEntry.source().languages,
+                                      dbEntry.source().importDate,
+                                      dbEntry.source().supportStructuredQueries);
     }
 
     public Importer createImporter(String[] languages, String[] extraTags) {

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -19,6 +19,17 @@ import java.io.IOException;
 import java.util.Date;
 
 public class Server {
+    /**
+     * Database version created by new imports with the current code.
+     *
+     * Format must be: major.minor.patch-dev
+     *
+     * Increase to next to be released version when the database layout
+     * changes in an incompatible way. If it is already at the next released
+     * version, increase the dev version.
+     */
+    public static final String DATABASE_VERSION = "0.3.6-1";
+
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Server.class);
 
     protected OpenSearchClient client;
@@ -134,7 +145,7 @@ public class Server {
         client.index(r -> r
                         .index(PhotonIndex.NAME)
                         .id(PhotonIndex.PROPERTY_DOCUMENT_ID)
-                        .document(new DBPropertyEntry(dbProperties))
+                        .document(new DBPropertyEntry(dbProperties, DATABASE_VERSION))
                         );
     }
 
@@ -148,9 +159,9 @@ public class Server {
             throw new UsageException("Cannot access property record. Database too old?");
         }
 
-        if (!DatabaseProperties.DATABASE_VERSION.equals(dbEntry.source().databaseVersion)) {
+        if (!DATABASE_VERSION.equals(dbEntry.source().databaseVersion)) {
             LOGGER.error("Database has incompatible version '{}'. Expected: {}",
-                         dbEntry.source().databaseVersion, DatabaseProperties.DATABASE_VERSION);
+                         dbEntry.source().databaseVersion, DATABASE_VERSION);
             throw new UsageException("Incompatible database.");
         }
 

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -129,8 +129,7 @@ public class Server {
     }
 
     public void updateIndexSettings(String synonymFile) throws IOException {
-        var dbProperties = new DatabaseProperties();
-        loadFromDatabase(dbProperties);
+        var dbProperties = loadFromDatabase();
 
         (new IndexSettingBuilder()).setSynonymFile(synonymFile).updateIndex(client, PhotonIndex.NAME);
 
@@ -149,7 +148,8 @@ public class Server {
                         );
     }
 
-    public void loadFromDatabase(DatabaseProperties dbProperties) throws IOException {
+    public DatabaseProperties loadFromDatabase() throws IOException {
+        DatabaseProperties dbProperties = new DatabaseProperties();
         var dbEntry = client.get(r -> r
                 .index(PhotonIndex.NAME)
                 .id(PhotonIndex.PROPERTY_DOCUMENT_ID),
@@ -168,6 +168,8 @@ public class Server {
         dbProperties.setLanguages(dbEntry.source().languages);
         dbProperties.setImportDate(dbEntry.source().importDate);
         dbProperties.setSupportStructuredQueries(dbEntry.source().supportStructuredQueries);
+
+        return dbProperties;
     }
 
     public Importer createImporter(String[] languages, String[] extraTags) {

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/DBPropertyEntry.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/DBPropertyEntry.java
@@ -12,8 +12,8 @@ public class DBPropertyEntry {
 
     public DBPropertyEntry() {}
 
-    public DBPropertyEntry(DatabaseProperties props) {
-        databaseVersion = DatabaseProperties.DATABASE_VERSION;
+    public DBPropertyEntry(DatabaseProperties props, String databaseVersion) {
+        this.databaseVersion = databaseVersion;
         importDate = props.getImportDate();
         languages = props.getLanguages();
         supportStructuredQueries = props.getSupportStructuredQueries();

--- a/app/opensearch/src/test/java/de/komoot/photon/ServerTest.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/ServerTest.java
@@ -13,10 +13,10 @@ class ServerTest extends ESBaseTester {
     void testSaveAndLoadFromDatabase() throws IOException {
         setUpES();
 
-        DatabaseProperties prop = new DatabaseProperties();
-        prop.setLanguages(new String[]{"en", "de", "fr"});
         Date now = new Date();
-        prop.setImportDate(now);
+        DatabaseProperties prop = new DatabaseProperties(new String[]{"en", "de", "fr"},
+                                                         now,
+                                   false);
         getServer().saveToDatabase(prop);
 
         prop = getServer().loadFromDatabase();

--- a/app/opensearch/src/test/java/de/komoot/photon/ServerTest.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/ServerTest.java
@@ -19,8 +19,7 @@ class ServerTest extends ESBaseTester {
         prop.setImportDate(now);
         getServer().saveToDatabase(prop);
 
-        prop = new DatabaseProperties();
-        getServer().loadFromDatabase(prop);
+        prop = getServer().loadFromDatabase();
 
         assertArrayEquals(new String[]{"en", "de", "fr"}, prop.getLanguages());
         assertEquals(now, prop.getImportDate());

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -145,9 +145,8 @@ public class App {
     private static void startNominatimUpdate(NominatimUpdater nominatimUpdater, Server esServer)  {
         nominatimUpdater.update();
 
-        DatabaseProperties dbProperties = new DatabaseProperties();
         try {
-            esServer.loadFromDatabase(dbProperties);
+            DatabaseProperties dbProperties = esServer.loadFromDatabase();
             Date importDate = nominatimUpdater.getLastImportDate();
             dbProperties.setImportDate(importDate);
             esServer.saveToDatabase(dbProperties);
@@ -162,8 +161,7 @@ public class App {
      */
     private static NominatimUpdater setupNominatimUpdater(CommandLineArgs args, Server server)throws IOException {
         // Get database properties and ensure that the version is compatible.
-        DatabaseProperties dbProperties = new DatabaseProperties();
-        server.loadFromDatabase(dbProperties);
+        DatabaseProperties dbProperties = server.loadFromDatabase();
 
         NominatimUpdater nominatimUpdater = new NominatimUpdater(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword());
         nominatimUpdater.setUpdater(server.createUpdater(dbProperties.getLanguages(), args.getExtraTags()));
@@ -175,8 +173,7 @@ public class App {
      */
     private static void startApi(CommandLineArgs args, Server server) throws IOException {
         // Get database properties and ensure that the version is compatible.
-        DatabaseProperties dbProperties = new DatabaseProperties();
-        server.loadFromDatabase(dbProperties);
+        DatabaseProperties dbProperties = server.loadFromDatabase();
         if (args.getLanguages(false).length > 0) {
             dbProperties.restrictLanguages(args.getLanguages());
         }

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -8,18 +8,21 @@ import java.util.*;
  * The server is responsible for making the data persistent in the Photon database.
  */
 public class DatabaseProperties {
-    private String[] languages = null;
-
-    /**
-     * The OSM data date
-     */
+    private String[] languages;
     private Date importDate;
+    private final boolean supportStructuredQueries;
 
-    private boolean supportStructuredQueries;
+    public DatabaseProperties(String[] languages, Date importDate, boolean supportStructuredQueries) {
+        this.languages = languages;
+        this.importDate = importDate;
+        this.supportStructuredQueries = supportStructuredQueries;
+    }
 
     /**
      * Return the list of languages for which the database is configured.
-     * @return
+     * If no list was set, then the default is returned.
+     *
+     * @return List of supported languages.
      */
     public String[] getLanguages() {
         if (languages == null) {
@@ -27,18 +30,6 @@ public class DatabaseProperties {
         }
 
         return languages;
-    }
-
-    /**
-     * Replace the language list with the given list.
-     *
-     * @param languages Array of two-letter language codes.
-     *
-     * @return This object for function chaining.
-     */
-    public DatabaseProperties setLanguages(String[] languages) {
-        this.languages = languages;
-        return this;
     }
 
     /**
@@ -72,21 +63,16 @@ public class DatabaseProperties {
         }
     }
 
+     public void setImportDate(Date importDate) {
+        this.importDate = importDate;
+    }
+
+
     public Date getImportDate() {
         return this.importDate;
     }
 
-    public DatabaseProperties setImportDate(Date importDate) {
-        this.importDate = importDate;
-        return this;
-    }
-
     public boolean getSupportStructuredQueries() {
         return supportStructuredQueries;
-    }
-
-    public DatabaseProperties setSupportStructuredQueries(boolean supportStructuredQueries) {
-        this.supportStructuredQueries = supportStructuredQueries;
-        return this;
     }
 }

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -8,17 +8,6 @@ import java.util.*;
  * The server is responsible for making the data persistent in the Photon database.
  */
 public class DatabaseProperties {
-    /**
-     * Database version created by new imports with the current code.
-     *
-     * Format must be: major.minor.patch-dev
-     *
-     * Increase to next to be released version when the database layout
-     * changes in an incompatible way. If it is already at the next released
-     * version, increase the dev version.
-     */
-    public static final String DATABASE_VERSION = "0.3.6-1";
-
     private String[] languages = null;
 
     /**

--- a/src/main/java/de/komoot/photon/StatusRequestHandler.java
+++ b/src/main/java/de/komoot/photon/StatusRequestHandler.java
@@ -19,8 +19,7 @@ public class StatusRequestHandler extends RouteImpl {
 
     @Override
     public String handle(Request request, Response response) throws IOException {
-        DatabaseProperties dbProperties = new DatabaseProperties();
-        server.loadFromDatabase(dbProperties);
+        DatabaseProperties dbProperties = server.loadFromDatabase();
         String importDateStr = null;
         if (dbProperties.getImportDate() instanceof Date) {
             importDateStr = dbProperties.getImportDate().toInstant().toString();

--- a/src/test/java/de/komoot/photon/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/ApiIntegrationTest.java
@@ -139,8 +139,7 @@ class ApiIntegrationTest extends ESBaseTester {
     void testApiStatus() throws Exception {
         App.main(new String[]{"-cluster", TEST_CLUSTER_NAME, "-listen-port", Integer.toString(LISTEN_PORT), "-transport-addresses", "127.0.0.1"});
         awaitInitialization();
-        DatabaseProperties prop = new DatabaseProperties();
-        getServer().loadFromDatabase(prop);
+        DatabaseProperties prop = getServer().loadFromDatabase();
         HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:" + port() + "/status").openConnection();
         JSONObject json = new JSONObject(
                 new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n")));

--- a/src/test/java/de/komoot/photon/DatabasePropertiesTest.java
+++ b/src/test/java/de/komoot/photon/DatabasePropertiesTest.java
@@ -16,16 +16,11 @@ class DatabasePropertiesTest extends ESBaseTester {
      */
     @Test
     void testSetLanguages() {
-        DatabaseProperties prop = new DatabaseProperties();
+        var now = new Date();
+        DatabaseProperties prop = new DatabaseProperties(new String[]{"en", "bg", "de"}, now, false);
 
-        prop.setLanguages(new String[]{"en", "bg", "de"});
-        Date now = new Date();
-        prop.setImportDate(now);
         assertArrayEquals(new String[]{"en", "bg", "de"}, prop.getLanguages());
         assertEquals(now, prop.getImportDate());
-
-        prop.setLanguages(new String[]{"ru"});
-        assertArrayEquals(new String[]{"ru"}, prop.getLanguages());
     }
 
     /**
@@ -33,7 +28,7 @@ class DatabasePropertiesTest extends ESBaseTester {
      */
     @Test
     void testRestrictLanguagesUnsetLanguages() {
-        DatabaseProperties prop = new DatabaseProperties();
+        DatabaseProperties prop = new DatabaseProperties(null, null, false);
         prop.restrictLanguages(new String[]{"en", "bg", "de"});
 
         assertArrayEquals(new String[]{"en", "bg", "de"}, prop.getLanguages());
@@ -45,8 +40,7 @@ class DatabasePropertiesTest extends ESBaseTester {
      */
     @Test
     void testRestrictLanguagesAlreadySet() {
-        DatabaseProperties prop = new DatabaseProperties();
-        prop.setLanguages(new String[]{"en", "de", "fr"});
+        DatabaseProperties prop = new DatabaseProperties(new String[]{"en", "de", "fr"}, null, false);
 
         prop.restrictLanguages(new String[]{"cn", "de", "en", "es"});
 


### PR DESCRIPTION
Database versions can now be set independently for the two flavours, so the OS version can move forward while the ES version remains stable.

Also simplifies the code around the `DatabaseProperties` class somewhat. See commit messages for details.