### PR TITLE
opensearch: fix translation of numbers during deserialization

### DIFF
--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResultDeserializer.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResultDeserializer.java
@@ -38,8 +38,10 @@ public class OpenSearchResultDeserializer extends StdDeserializer<OpenSearchResu
                 tags.put(key, value.asText());
             } else if (value.isInt()) {
                 tags.put(entry.getKey(), value.asInt());
-            } else if (value.isBigInteger()) {
+            } else if (value.isLong()) {
                 tags.put(entry.getKey(), value.asLong());
+            } else if (value.isFloatingPointNumber()) {
+                tags.put(entry.getKey(), value.asDouble());
             } else if (value.isObject()) {
                 Map<String, String> vtags = new HashMap<>();
                 var subfields = value.fields();


### PR DESCRIPTION
Osm IDs over 32bit and importance values were missing in the result.