### PR TITLE
opensearch: dump raw result data on debug

### DIFF
--- a/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
@@ -4,6 +4,7 @@ import de.komoot.photon.Constants;
 import de.komoot.photon.searcher.PhotonResult;
 import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
+import org.json.JSONObject;
 
 import java.util.List;
 import java.util.Map;
@@ -82,5 +83,10 @@ public class ElasticResult implements PhotonResult {
     @Override
     public double getScore() {
         return result.getScore();
+    }
+
+    @Override
+    public JSONObject getRawData() {
+        return new JSONObject();
     }
 }

--- a/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ElasticGetIdResult.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ElasticGetIdResult.java
@@ -3,6 +3,7 @@ package de.komoot.photon.elasticsearch;
 import de.komoot.photon.searcher.PhotonResult;
 import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.action.get.GetResponse;
+import org.json.JSONObject;
 
 import java.util.Map;
 
@@ -40,6 +41,11 @@ public class ElasticGetIdResult implements PhotonResult {
 
     @Override
     public double getScore() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public JSONObject getRawData() {
         throw new NotImplementedException();
     }
 }

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -1,6 +1,8 @@
 package de.komoot.photon.opensearch;
 
 import de.komoot.photon.searcher.PhotonResult;
+import jakarta.json.JsonArray;
+import org.json.JSONObject;
 
 import java.util.Map;
 
@@ -68,5 +70,13 @@ public class OpenSearchResult implements PhotonResult {
     @Override
     public double getScore() {
         return score;
+    }
+
+    @Override
+    public JSONObject getRawData() {
+        return new JSONObject()
+                .put("infos", new JSONObject(infos))
+                .put("localeTags", new JSONObject(localeTags))
+                .put("score", score);
     }
 }

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -44,7 +44,7 @@ public class OpenSearchSearchHandler implements SearchHandler {
 
     @Override
     public String dumpQuery(PhotonRequest photonRequest) {
-        return "{}";
+        return null;
     }
 
     private SearchQueryBuilder buildQuery(PhotonRequest request, boolean lenient) {

--- a/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
@@ -40,11 +40,16 @@ public class GeocodeJsonFormatter implements ResultFormatter {
         out.put("type", "FeatureCollection")
            .put("features", features);
 
-        if (debugInfo != null) {
-            out.put("properties", new JSONObject().put("debug", new JSONObject(debugInfo)));
-        }
-
         if (addDebugInfo) {
+            final JSONObject extraProps = new JSONObject();
+            if (debugInfo != null) {
+                extraProps.put("debug", new JSONObject(debugInfo));
+            }
+            final JSONArray rawResults = new JSONArray();
+            results.forEach(res -> rawResults.put(res.getRawData()));
+            extraProps.put("raw_data", rawResults);
+            out.put("properties", extraProps);
+
             return out.toString(4);
         }
 
@@ -53,10 +58,6 @@ public class GeocodeJsonFormatter implements ResultFormatter {
 
     private JSONObject getResultProperties(PhotonResult result) {
         JSONObject props = new JSONObject();
-        if (addDebugInfo) {
-            props.put("score", result.getScore());
-            put(props,"importance", result.get("importance"));
-        }
 
         for (String key : KEYS_LANG_UNSPEC) {
             put(props, key, result.get(key));

--- a/src/main/java/de/komoot/photon/searcher/PhotonResult.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonResult.java
@@ -1,5 +1,7 @@
 package de.komoot.photon.searcher;
 
+import org.json.JSONObject;
+
 import java.util.Map;
 
 /**
@@ -26,4 +28,5 @@ public interface PhotonResult {
 
     double getScore();
 
+    JSONObject getRawData();
 }

--- a/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
+++ b/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
@@ -1,5 +1,7 @@
 package de.komoot.photon.searcher;
 
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,5 +50,10 @@ public class MockPhotonResult implements PhotonResult {
     public MockPhotonResult putLocalized(String key, String lang, String value) {
         localized.put(key + "||" + lang, value);
         return this;
+    }
+
+    @Override
+    public JSONObject getRawData() {
+        return new JSONObject();
     }
 }


### PR DESCRIPTION
Wenn `debug=1` is given, dump all available information about each result. This should help exploring the raw contents of the database.

Also moves score and importance into this new `raw_data` field instead of having it pollute the original result data.