### PR TITLE
Make sure to reopen the index when installation of synonym fails

### DIFF
--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -11,6 +11,7 @@ import org.codelibs.opensearch.runner.OpenSearchRunner;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.slf4j.Logger;
 
@@ -126,9 +127,16 @@ public class Server {
     }
 
     public void updateIndexSettings(String synonymFile) throws IOException {
+        // This ensures we are on the right version. Do not mess with the
+        // database if the version does not fit.
         var dbProperties = loadFromDatabase();
 
-        (new IndexSettingBuilder()).setSynonymFile(synonymFile).updateIndex(client, PhotonIndex.NAME);
+        try {
+            (new IndexSettingBuilder()).setSynonymFile(synonymFile).updateIndex(client, PhotonIndex.NAME);
+        } catch (OpenSearchException ex) {
+            client.shutdown();
+            throw new UsageException("Could not install synonyms: " + ex.getMessage());
+        }
 
         if (dbProperties.getLanguages() != null) {
             (new IndexMapping(dbProperties.getSupportStructuredQueries()))

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -40,10 +40,13 @@ public class IndexSettingBuilder {
         addDefaultSettings();
 
         client.indices().close(req -> req.index(indexName));
-        client.indices().putSettings(req -> req
-                .index(indexName)
-                .settings(s -> s.analysis(settings.build())));
-        client.indices().open(req -> req.index(indexName));
+        try {
+            client.indices().putSettings(req -> req
+                    .index(indexName)
+                    .settings(s -> s.analysis(settings.build())));
+        } finally {
+            client.indices().open(req -> req.index(indexName));
+        }
     }
 
     public IndexSettingBuilder setSynonymFile(String synonymFile) throws IOException {


### PR DESCRIPTION
When installing a synonym list, the index needs to be closed first and is reopened after the mapping changes are done. If there is an error during the synonym installation, the index was never reopened and consequently fail to start up the next time.

This ensures that the index is always reopened.