### PR TITLE
OpenSearch: do not install or load unused plugins

### DIFF
--- a/app/opensearch/build.gradle
+++ b/app/opensearch/build.gradle
@@ -18,15 +18,30 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.opensearch.client:opensearch-java:2.16.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+    implementation 'org.opensearch.client:opensearch-java:2.18.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
 
-    implementation 'org.codelibs.opensearch:opensearch-runner:2.17.1.0'
+    implementation('org.codelibs.opensearch:opensearch-runner:2.18.0.0') {
+        exclude(module: 'repository-url')
+        exclude(module: 'reindex-client')
+        exclude(module: 'rank-eval-client')
+        exclude(module: 'percolator-client')
+        exclude(module: 'parent-join-client')
+        exclude(module: 'mapper-extras-client')
+        exclude(module: 'opensearch-scripting-painless-spi')
+        exclude(module: 'lang-painless')
+        exclude(module: 'lang-mustache-client')
+        exclude(module: 'lang-expression')
+        exclude(module: 'ingest-user-agent')
+        exclude(module: 'ingest-common')
+        exclude(module: 'aggs-matrix-stats-client')
+        exclude(module: 'lucene-grouping')
+    }
 
     // updates for indirect dependencies
-    implementation 'io.netty:netty-codec:4.1.114.Final'
-    implementation 'io.netty:netty-codec-http:4.1.114.Final'
+    implementation 'io.netty:netty-codec:4.1.115.Final'
+    implementation 'io.netty:netty-codec-http:4.1.115.Final'
 }
 
 tasks.named('jar') {

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -33,6 +33,10 @@ public class Server {
 
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Server.class);
 
+    public static final String OPENSEARCH_MODULES =
+            "org.opensearch.transport.Netty4Plugin,"
+            + "org.opensearch.analysis.common.CommonAnalysisPlugin";
+
     protected OpenSearchClient client;
     private OpenSearchRunner runner = null;
     protected final String dataDirectory;
@@ -78,7 +82,12 @@ public class Server {
             settingsBuilder.put("discovery.type", "single-node");
             settingsBuilder.putList("discovery.seed_hosts", "127.0.0.1:9201");
             settingsBuilder.put("indices.query.bool.max_clause_count", "30000");
-        }).build(OpenSearchRunner.newConfigs().basePath(dataDirectory).clusterName(clusterName).numOfNode(1));
+        }).build(OpenSearchRunner.newConfigs()
+                .basePath(dataDirectory)
+                .clusterName(clusterName)
+                .numOfNode(1)
+                .moduleTypes(OPENSEARCH_MODULES)
+        );
 
         runner.ensureYellow();
 

--- a/app/opensearch/src/test/java/de/komoot/photon/opensearch/OpenSearchTestServer.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/opensearch/OpenSearchTestServer.java
@@ -34,7 +34,12 @@ public class OpenSearchTestServer extends Server {
                 settingsBuilder.put("cluster.search.request.slowlog.threshold.trace", "0ms");
 
             }
-            }).build(OpenSearchRunner.newConfigs().basePath(instanceDir).clusterName(clusterName).numOfNode(1).baseHttpPort(9200));
+            }).build(OpenSearchRunner.newConfigs()
+                .basePath(instanceDir)
+                .clusterName(clusterName)
+                .numOfNode(1)
+                .baseHttpPort(9200)
+                .moduleTypes(OPENSEARCH_MODULES));
 
         // wait for yellow status
         runner.ensureYellow();


### PR DESCRIPTION
Exclude most OpenSearch plugins from being installed and loaded. Photon currently doesn't use them right now and they can be reenabled when needed.

Saves around 4MB on the final jar.