### PR TITLE
Take postcodes from postcode relations into account

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -104,11 +104,7 @@ public class PhotonDoc {
             extractAddress(address, AddressType.COUNTY, "county");
             extractAddress(address, AddressType.STATE, "state");
 
-            String addressPostCode = address.get("postcode");
-            if (addressPostCode != null && !addressPostCode.equals(postcode)) {
-                LOGGER.debug("Replacing postcode {} with {} for osmId #{}", postcode, addressPostCode, osmId);
-                postcode = addressPostCode;
-            }
+            postcode = address.getOrDefault("postcode", postcode);
         }
         return this;
     }
@@ -211,9 +207,6 @@ public class PhotonDoc {
      *
      * @param addressType The type of address field to fill.
      * @param addressFieldName The name of the address tag to use (without the 'addr:' prefix).
-     *
-     * @return 'existingField' potentially with the name field replaced. If existingField was null and
-     *         the address field could be found, then a new map with the address as single entry is returned.
      */
     private void extractAddress(Map<String, String> address, AddressType addressType, String addressFieldName) {
         String field = address.get(addressFieldName);
@@ -258,13 +251,17 @@ public class PhotonDoc {
     public void completePlace(List<AddressRow> addresses) {
         final AddressType doctype = getAddressType();
         for (AddressRow address : addresses) {
-            final AddressType atype = address.getAddressType();
+            if (address.isPostcode()) {
+                this.postcode = address.getName().getOrDefault("ref", this.postcode);
+            } else {
+                final AddressType atype = address.getAddressType();
 
-            if (atype != null
-                    && (atype == doctype || !setAddressPartIfNew(atype, address.getName()))
-                    && address.isUsefulForContext()) {
-                // no specifically handled item, check if useful for context
-                getContext().add(address.getName());
+                if (atype != null
+                        && (atype == doctype || !setAddressPartIfNew(atype, address.getName()))
+                        && address.isUsefulForContext()) {
+                    // no specifically handled item, check if useful for context
+                    getContext().add(address.getName());
+                }
             }
         }
     }

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -22,7 +22,7 @@ public class AddressRow {
         return AddressType.fromRank(rankAddress);
     }
 
-    private boolean isPostcode() {
+    public boolean isPostcode() {
         if ("place".equals(osmKey) && "postcode".equals(osmValue)) {
             return true;
         }

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -361,6 +361,60 @@ class NominatimConnectorDBTest {
     }
 
     @Test
+    void testUsePostcodeFromPlacex() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes")
+                .addr("housenumber", "34")
+                .postcode("AA 44XH")
+                .parent(parent).add(jdbc);
+
+        readEntireDatabase();
+
+        PhotonDoc result = importer.get(place);
+
+        assertEquals("AA 44XH", result.getPostcode());
+    }
+
+    @Test
+    void testPreferPostcodeFromPostcodeRelations() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes")
+                .addr("housenumber", "34")
+                .postcode("XXX")
+                .parent(parent).add(jdbc);
+        PlacexTestRow postcode = new PlacexTestRow("boundary", "postal_code")
+                .name("ref", "1234XZ").ranks(11).add(jdbc);
+
+        parent.addAddresslines(jdbc, postcode);
+
+        readEntireDatabase();
+
+        PhotonDoc result = importer.get(place);
+
+        assertEquals("1234XZ", result.getPostcode());
+    }
+
+    @Test
+    void testPreferPostcodeFromAddress() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes")
+                .addr("housenumber", "34")
+                .addr("postcode", "45-234")
+                .postcode("XXX")
+                .parent(parent).add(jdbc);
+        PlacexTestRow postcode = new PlacexTestRow("boundary", "postal_code")
+                .name("ref", "1234XZ").ranks(11).add(jdbc);
+
+        parent.addAddresslines(jdbc, postcode);
+
+        readEntireDatabase();
+
+        PhotonDoc result = importer.get(place);
+
+        assertEquals("45-234", result.getPostcode());
+    }
+
+    @Test
     void testGetImportDate() {
         Date importDate = connector.getLastImportDate();
         assertNull(importDate);

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -23,6 +23,7 @@ public class PlacexTestRow {
     private Integer rankAddress = 30;
     private Integer rankSearch = 30;
     private String centroid;
+    private String postcode;
     private String countryCode = "us";
     private Double importance = null;
 
@@ -115,12 +116,17 @@ public class PlacexTestRow {
         return this;
     }
 
+    public PlacexTestRow postcode(String postcode) {
+        this.postcode = postcode;
+        return this;
+    }
+
     public PlacexTestRow add(JdbcTemplate jdbc) {
         jdbc.update("INSERT INTO placex (place_id, parent_place_id, osm_type, osm_id, class, type, rank_search, rank_address,"
-                        + " centroid, name, country_code, importance, address, indexed_status)"
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ?, ?, ? FORMAT JSON, 0)",
+                        + " centroid, name, country_code, importance, address, postcode, indexed_status)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ?, ?, ? FORMAT JSON, ?, 0)",
                 placeId, parentPlaceId, osmType, osmId, key, value, rankSearch, rankAddress, centroid,
-                asJson(names), countryCode, importance, asJson(address));
+                asJson(names), countryCode, importance, asJson(address), postcode);
 
         return this;
     }


### PR DESCRIPTION
Use postcodes from `boundary=postal_code` relations which appear in an object's address list. Postcode boundaries need to take precedence over the postcode field from the object because that one may be just an educated guess. `addr:postcode` tags still have precedence and thus can overwrite the postcode from the relation they are inside.

Fixes #835.