### PR TITLE
README: point people to forum and discussions instead of mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _photon_ was started by [komoot](http://www.komoot.de) and provides search-as-yo
 
 All code contributions and bug reports are welcome!
 
-For questions please send an email to our [mailing list](https://lists.openstreetmap.org/listinfo/photon).
+For questions please either use [Github discussions](https://github.com/komoot/photon/discussions) or join the [OpenStreetMap forum](https://community.openstreetmap.org/).
 
 Feel free to test and participate!
 


### PR DESCRIPTION
Point people to Github's discussion feature and the OpenStreetMap community forum for discussion.

The Photon mailinglist has seen very little activity in the last years, just like most other mailing lists. So the OSM administrators are considering to shut down the mailing list service. Lets help them and move on.