### PR TITLE
Replace usage of json library with jackson where possible

### DIFF
--- a/app/es_embedded/build.gradle
+++ b/app/es_embedded/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation('org.elasticsearch.client:transport:5.6.16') {
         exclude(module: 'commons-logging')
     }
+    implementation 'org.json:json:20240303'
 
     runtimePlugins 'org.codelibs.elasticsearch.module:lang-painless:5.6.16'
     runtimePlugins 'org.ow2.asm:asm-debug-all:5.1'

--- a/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
@@ -1,5 +1,7 @@
 package de.komoot.photon.elasticsearch;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.komoot.photon.Constants;
 import de.komoot.photon.searcher.PhotonResult;
 import org.elasticsearch.search.SearchHit;
@@ -68,7 +70,17 @@ public class ElasticResult implements PhotonResult {
 
     @Override
     public String getGeometry() {
-        return (String) result.getSource().get("geometry");
+        final var source = result.getSource();
+
+        if (!source.containsKey("geometry")) {
+            return null;
+        }
+
+        try {
+            return new ObjectMapper().writeValueAsString(source.get("geometry"));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/ElasticResult.java
@@ -91,7 +91,7 @@ public class ElasticResult implements PhotonResult {
     }
 
     @Override
-    public JSONObject getRawData() {
-        return new JSONObject();
+    public Map<String, Object> getRawData() {
+        return Map.of();
     }
 }

--- a/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ElasticGetIdResult.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/elasticsearch/ElasticGetIdResult.java
@@ -3,7 +3,6 @@ package de.komoot.photon.elasticsearch;
 import de.komoot.photon.searcher.PhotonResult;
 import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.action.get.GetResponse;
-import org.json.JSONObject;
 
 import java.util.Map;
 
@@ -49,7 +48,7 @@ public class ElasticGetIdResult implements PhotonResult {
     }
 
     @Override
-    public JSONObject getRawData() {
+    public Map<String, Object> getRawData() {
         throw new NotImplementedException();
     }
 }

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -1,7 +1,6 @@
 package de.komoot.photon.opensearch;
 
 import de.komoot.photon.searcher.PhotonResult;
-import org.json.JSONObject;
 
 import java.util.Map;
 

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -78,10 +78,10 @@ public class OpenSearchResult implements PhotonResult {
     }
 
     @Override
-    public JSONObject getRawData() {
-        return new JSONObject()
-                .put("infos", new JSONObject(infos))
-                .put("localeTags", new JSONObject(localeTags))
-                .put("score", score);
+    public Map<String, Object> getRawData() {
+        return Map.of(
+                "score", score,
+                "infos", infos,
+                "localeTags", localeTags);
     }
 }

--- a/buildSrc/shared.gradle
+++ b/buildSrc/shared.gradle
@@ -57,7 +57,6 @@ dependencies {
     implementation 'org.locationtech.jts.io:jts-io-common:1.20.0'
     implementation 'com.sparkjava:spark-core:2.9.4'
     implementation 'net.postgis:postgis-jdbc:2024.1.0'
-    implementation 'org.json:json:20240303'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
 
     testImplementation(platform("org.junit:junit-bom:5.11.3"))

--- a/src/main/java/de/komoot/photon/ConfigClassificationTerm.java
+++ b/src/main/java/de/komoot/photon/ConfigClassificationTerm.java
@@ -1,0 +1,36 @@
+package de.komoot.photon;
+
+public class ConfigClassificationTerm {
+
+    private String key;
+    private String value;
+    private String[] terms;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String[] getTerms() {
+        return terms;
+    }
+
+    public void setTerms(String[] terms) {
+        this.terms = terms;
+    }
+
+    public String getClassificationString() {
+        return Utils.buildClassificationString(key, value);
+    }
+}

--- a/src/main/java/de/komoot/photon/ConfigSynonyms.java
+++ b/src/main/java/de/komoot/photon/ConfigSynonyms.java
@@ -1,0 +1,29 @@
+package de.komoot.photon;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ConfigSynonyms {
+
+    private List<String> searchSynonyms = null;
+    private ConfigClassificationTerm[] classificationTerms = null;
+
+    public List<String> getSearchSynonyms() {
+        return searchSynonyms;
+    }
+
+    @JsonProperty("search_synonyms")
+    public void setSearchSynonyms(List<String> searchSynonyms) {
+        this.searchSynonyms = searchSynonyms;
+    }
+
+    public ConfigClassificationTerm[] getClassificationTerms() {
+        return classificationTerms;
+    }
+
+    @JsonProperty("classification_terms")
+    public void setClassificationTerms(ConfigClassificationTerm[] classificationTerms) {
+        this.classificationTerms = classificationTerms;
+    }
+}

--- a/src/main/java/de/komoot/photon/SearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/SearchRequestHandler.java
@@ -4,7 +4,6 @@ import de.komoot.photon.query.BadRequestException;
 import de.komoot.photon.query.PhotonRequest;
 import de.komoot.photon.query.PhotonRequestFactory;
 import de.komoot.photon.searcher.*;
-import org.json.JSONObject;
 import spark.Request;
 import spark.Response;
 import spark.RouteImpl;
@@ -20,6 +19,7 @@ import static spark.Spark.halt;
 public class SearchRequestHandler extends RouteImpl {
     private final PhotonRequestFactory photonRequestFactory;
     private final SearchHandler requestHandler;
+    private final ResultFormatter formatter = new GeocodeJsonFormatter();
     private final boolean supportGeometries;
 
     SearchRequestHandler(String path, SearchHandler dbHandler, String[] languages, String defaultLanguage, int maxResults, boolean supportGeometries) {
@@ -31,20 +31,16 @@ public class SearchRequestHandler extends RouteImpl {
     }
 
     @Override
-    public String handle(Request request, Response response) throws BadRequestException {
-        PhotonRequest photonRequest = null;
+    public String handle(Request request, Response response) {
+        PhotonRequest photonRequest;
         try {
             photonRequest = photonRequestFactory.create(request);
         } catch (BadRequestException e) {
-            JSONObject json = new JSONObject();
-            json.put("message", e.getMessage());
-            throw halt(e.getHttpStatus(), json.toString());
+            throw halt(e.getHttpStatus(), formatter.formatError(e.getMessage()));
         }
 
         if (!supportGeometries && photonRequest.getReturnGeometry()) {
-            JSONObject json = new JSONObject();
-            json.put("message", "You're explicitly requesting a geometry, but geometries are not imported!");
-            throw halt(400, json.toString());
+            throw halt(400, formatter.formatError("You're explicitly requesting a geometry, but geometries are not imported!"));
         }
 
         List<PhotonResult> results = requestHandler.search(photonRequest);
@@ -62,6 +58,8 @@ public class SearchRequestHandler extends RouteImpl {
             debugInfo = requestHandler.dumpQuery(photonRequest);
         }
 
-        return new GeocodeJsonFormatter(photonRequest.getDebug(), photonRequest.getLanguage(), photonRequest.getReturnGeometry()).convert(results, debugInfo);
+        return formatter.convert(
+                results, photonRequest.getLanguage(), photonRequest.getReturnGeometry(),
+                photonRequest.getDebug(), debugInfo);
     }
 }

--- a/src/main/java/de/komoot/photon/StatusRequestHandler.java
+++ b/src/main/java/de/komoot/photon/StatusRequestHandler.java
@@ -2,15 +2,17 @@ package de.komoot.photon;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import spark.Request;
 import spark.Response;
 import spark.RouteImpl;
 
 public class StatusRequestHandler extends RouteImpl {
-    private Server server;
+    private final Server server;
+    private final ObjectMapper mapper = new ObjectMapper();
 
     protected StatusRequestHandler(String path, Server server) {
         super(path);
@@ -25,11 +27,7 @@ public class StatusRequestHandler extends RouteImpl {
             importDateStr = dbProperties.getImportDate().toInstant().toString();
         }
         
-        final JSONObject out = new JSONObject();
-        out.put("status", "Ok");
-        out.put("import_date", importDateStr);
-
-        return out.toString();
+        return mapper.writeValueAsString(Map.of("status", "Ok", "import_date", importDateStr));
     }
     
 }

--- a/src/main/java/de/komoot/photon/StructuredSearchRequestHandler.java
+++ b/src/main/java/de/komoot/photon/StructuredSearchRequestHandler.java
@@ -4,7 +4,6 @@ import de.komoot.photon.query.BadRequestException;
 import de.komoot.photon.query.PhotonRequestFactory;
 import de.komoot.photon.query.StructuredPhotonRequest;
 import de.komoot.photon.searcher.*;
-import org.json.JSONObject;
 import spark.Request;
 import spark.Response;
 import spark.RouteImpl;
@@ -17,6 +16,7 @@ import static spark.Spark.halt;
 public class StructuredSearchRequestHandler extends RouteImpl {
     private final PhotonRequestFactory photonRequestFactory;
     private final StructuredSearchHandler requestHandler;
+    private final ResultFormatter formatter = new GeocodeJsonFormatter();
     private final boolean supportGeometries;
 
     StructuredSearchRequestHandler(String path, StructuredSearchHandler dbHandler, String[] languages, String defaultLanguage, int maxResults, boolean supportGeometries) {
@@ -33,15 +33,11 @@ public class StructuredSearchRequestHandler extends RouteImpl {
         try {
             photonRequest = photonRequestFactory.createStructured(request);
         } catch (BadRequestException e) {
-            JSONObject json = new JSONObject();
-            json.put("message", e.getMessage());
-            throw halt(e.getHttpStatus(), json.toString());
+            throw halt(e.getHttpStatus(), formatter.formatError(e.getMessage()));
         }
 
         if (!supportGeometries && photonRequest.getReturnGeometry()) {
-            JSONObject json = new JSONObject();
-            json.put("message", "You're requesting a Geometry, but Geometries are not imported!");
-            throw halt(400, json.toString());
+            throw halt(400, formatter.formatError("You're requesting a Geometry, but Geometries are not imported!"));
         }
 
         List<PhotonResult> results = requestHandler.search(photonRequest);
@@ -54,12 +50,8 @@ public class StructuredSearchRequestHandler extends RouteImpl {
             results = results.subList(0, photonRequest.getLimit());
         }
 
-
-        String debugInfo = null;
-     /*   if (photonRequest.getDebug()) {
-            debugInfo = requestHandler.dumpQuery(photonRequest);
-        }
- */
-        return new GeocodeJsonFormatter(photonRequest.getDebug(), photonRequest.getLanguage(), photonRequest.getReturnGeometry()).convert(results, debugInfo);
+        return formatter.convert(
+                results, photonRequest.getLanguage(), photonRequest.getReturnGeometry(),
+                photonRequest.getDebug(), null);
     }
 }

--- a/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
@@ -1,10 +1,15 @@
 package de.komoot.photon.searcher;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.komoot.photon.Constants;
-import org.json.JSONArray;
-import org.json.JSONObject;
+import spark.Spark;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Format a database result into a Photon GeocodeJson response.
@@ -13,91 +18,95 @@ public class GeocodeJsonFormatter implements ResultFormatter {
     private static final String[] KEYS_LANG_UNSPEC = {Constants.OSM_TYPE, Constants.OSM_ID, Constants.OSM_KEY, Constants.OSM_VALUE, Constants.OBJECT_TYPE, Constants.POSTCODE, Constants.HOUSENUMBER, Constants.COUNTRYCODE};
     private static final String[] KEYS_LANG_SPEC = {Constants.NAME, Constants.COUNTRY, Constants.CITY, Constants.DISTRICT, Constants.LOCALITY, Constants.STREET, Constants.STATE, Constants.COUNTY};
 
+    private final ObjectMapper mapper = new ObjectMapper();
+
     @Override
     public String formatError(String msg) {
-        return new JSONObject().put("message", msg).toString();
+        try {
+            return mapper.writeValueAsString(Map.of("message", msg));
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
     }
 
     @Override
     public String convert(List<PhotonResult> results, String language,
                           boolean withGeometry, boolean withDebugInfo, String queryDebugInfo) {
-        final JSONArray features = new JSONArray(results.size());
+        try {
+            final var writer = new StringWriter();
+            final var gen = mapper.createGenerator(writer);
 
-        for (PhotonResult result : results) {
-            if (withGeometry && (result.get("geometry") != null || result.getGeometry() != null)) {
-                if (result.get("geometry") != null) {
-                    features.put(new JSONObject()
-                            .put("type", "Feature")
-                            .put("properties", getResultProperties(result, language))
-                            .put("geometry", result.get("geometry")));
-                }
-                else {
-                    // We need to un-escape the JSON String first
-                    JSONObject jsonObject = new JSONObject(result.getGeometry());
-
-                    features.put(new JSONObject()
-                            .put("type", "Feature")
-                            .put("properties", getResultProperties(result, language))
-                            .put("geometry", jsonObject));
-                }
-            } else {
-                final double[] coordinates = result.getCoordinates();
-
-                features.put(new JSONObject()
-                        .put("type", "Feature")
-                        .put("properties", getResultProperties(result, language))
-                        .put("geometry", new JSONObject()
-                                .put("type", "Point")
-                                .put("coordinates", coordinates)));
-            }
-        }
-
-        final JSONObject out = new JSONObject();
-        out.put("type", "FeatureCollection")
-           .put("features", features);
-
-        if (withDebugInfo || queryDebugInfo != null) {
-            final JSONObject extraProps = new JSONObject();
-            if (queryDebugInfo != null) {
-                extraProps.put("debug", new JSONObject(queryDebugInfo));
-            }
             if (withDebugInfo) {
-                final JSONArray rawResults = new JSONArray();
-                results.forEach(res -> rawResults.put(new JSONObject(res.getRawData())));
-                extraProps.put("raw_data", rawResults);
+                gen.useDefaultPrettyPrinter();
             }
-            out.put("properties", extraProps);
 
-            return out.toString(4);
+            gen.writeStartObject();
+            gen.writeStringField("type", "FeatureCollection");
+            gen.writeArrayFieldStart("features");
+
+            for (PhotonResult result : results) {
+                gen.writeStartObject();
+                gen.writeStringField("type", "Feature");
+
+                gen.writeObjectFieldStart("properties");
+
+                for (String key : KEYS_LANG_UNSPEC) {
+                    put(gen, key, result.get(key));
+                }
+
+                for (String key : KEYS_LANG_SPEC) {
+                    put(gen, key, result.getLocalised(key, language));
+                }
+
+                put(gen, "extent", result.getExtent());
+
+                put(gen, "extra", result.getMap("extra"));
+
+                gen.writeEndObject();
+
+                if (withGeometry && result.getGeometry() != null) {
+                    gen.writeFieldName("geometry");
+                    gen.writeRawValue(result.getGeometry());
+                } else {
+                    gen.writeObjectFieldStart("geometry");
+                    gen.writeStringField("type", "Point");
+                    gen.writeObjectField("coordinates",  result.getCoordinates());
+                    gen.writeEndObject();
+                }
+
+                gen.writeEndObject();
+            }
+
+            gen.writeEndArray();
+
+            if (withDebugInfo || queryDebugInfo != null) {
+                gen.writeObjectFieldStart("properties");
+                if (queryDebugInfo != null) {
+                    gen.writeFieldName("debug");
+                    gen.writeRawValue(queryDebugInfo);
+                }
+                if (withDebugInfo) {
+                    gen.writeArrayFieldStart("raw_data");
+                    for (var res : results) {
+                        gen.writePOJO(res.getRawData());
+                    }
+                    gen.writeEndArray();
+                }
+                gen.writeEndObject();
+            }
+
+            gen.writeEndObject();
+            gen.close();
+            return writer.toString();
+        } catch (IOException e) {
+            throw Spark.halt(400, "{\"message\": \"Error creating json.\"}");
         }
-
-        return out.toString();
     }
 
-    private JSONObject getResultProperties(PhotonResult result, String language) {
-        JSONObject props = new JSONObject();
 
-        for (String key : KEYS_LANG_UNSPEC) {
-            put(props, key, result.get(key));
-        }
-
-        for (String key : KEYS_LANG_SPEC) {
-            put(props, key, result.getLocalised(key, language));
-        }
-
-        final double[] extent = result.getExtent();
-        if (extent != null) {
-            props.put("extent", extent);
-        }
-
-        put(props, "extra", result.getMap("extra"));
-
-        return props;
-    }
-
-    private void put(JSONObject out, String key, Object value) {
+    private void put(JsonGenerator gen, String key, Object value) throws IOException {
         if (value != null) {
-            out.put(key, value);
+            gen.writeObjectField(key, value);
         }
     }
 }

--- a/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/GeocodeJsonFormatter.java
@@ -63,7 +63,7 @@ public class GeocodeJsonFormatter implements ResultFormatter {
             }
             if (withDebugInfo) {
                 final JSONArray rawResults = new JSONArray();
-                results.forEach(res -> rawResults.put(res.getRawData()));
+                results.forEach(res -> rawResults.put(new JSONObject(res.getRawData())));
                 extraProps.put("raw_data", rawResults);
             }
             out.put("properties", extraProps);

--- a/src/main/java/de/komoot/photon/searcher/PhotonResult.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonResult.java
@@ -1,7 +1,5 @@
 package de.komoot.photon.searcher;
 
-import org.json.JSONObject;
-
 import java.util.Map;
 
 /**
@@ -31,5 +29,5 @@ public interface PhotonResult {
 
     double getScore();
 
-    JSONObject getRawData();
+    Map<String, Object> getRawData();
 }

--- a/src/main/java/de/komoot/photon/searcher/ResultFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/ResultFormatter.java
@@ -7,5 +7,8 @@ import java.util.List;
  */
 public interface ResultFormatter {
 
-    String convert(List<PhotonResult> results, String debugInfo);
+    String convert(List<PhotonResult> results, String language,
+                   boolean withGeometry, boolean withDebugInfo, String queryDebugInfo);
+
+    String formatError(String msg);
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/H2DataAdapter.java
@@ -1,8 +1,10 @@
 package de.komoot.photon.nominatim.testdb;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.locationtech.jts.geom.Geometry;
 import de.komoot.photon.nominatim.DBDataAdapter;
-import org.json.JSONObject;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.sql.ResultSet;
@@ -11,19 +13,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class H2DataAdapter implements DBDataAdapter {
-
+    private static final TypeReference<HashMap<String, String>> mapTypeRef = new TypeReference<>() {};
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     @Override
     public Map<String, String> getMap(ResultSet rs, String columnName) throws SQLException {
         Map<String, String> out = new HashMap<>();
         String json = rs.getString(columnName);
-        if (json != null) {
-            JSONObject obj = new JSONObject(json);
-            for (String key : obj.keySet()) {
-                out.put(key, obj.getString(key));
-            }
+        try {
+            return json == null ? Map.of() : objectMapper.readValue(rs.getString(columnName), mapTypeRef);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
         }
-
-        return out;
     }
 
     @Override

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -1,9 +1,10 @@
 package de.komoot.photon.nominatim.testdb;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import de.komoot.photon.PhotonDoc;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -11,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PlacexTestRow {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static long placeIdSequence = 10000;
     private Long placeId;
     private Long parentPlaceId;
@@ -47,9 +49,11 @@ public class PlacexTestRow {
             return null;
         }
 
-        JSONObject json = new JSONObject(map);
-
-        return json.toString();
+        try {
+            return objectMapper.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public PlacexTestRow id(long pid) {

--- a/src/test/java/de/komoot/photon/searcher/GeocodeJsonFormatterTest.java
+++ b/src/test/java/de/komoot/photon/searcher/GeocodeJsonFormatterTest.java
@@ -14,13 +14,13 @@ class GeocodeJsonFormatterTest {
 
     @Test
     void testConvertPointToGeojson() {
-        GeocodeJsonFormatter formatter = new GeocodeJsonFormatter(false, "en", false);
+        GeocodeJsonFormatter formatter = new GeocodeJsonFormatter();
         List<PhotonResult> allPointResults = new ArrayList<>();
         allPointResults.add(createDummyPointResult("99999", "Park Foo", "leisure", "park"));
         allPointResults.add(createDummyPointResult("88888", "Bar Park", "leisure", "park"));
 
         // Test Points
-        String geojsonString = formatter.convert(allPointResults, null);
+        String geojsonString = formatter.convert(allPointResults, "en", false, false, null);
         JSONObject jsonObj = new JSONObject(geojsonString);
         assertEquals("FeatureCollection", jsonObj.getString("type"));
         JSONArray features = jsonObj.getJSONArray("features");
@@ -36,14 +36,14 @@ class GeocodeJsonFormatterTest {
 
     @Test
     void testConvertGeometryToGeojson() {
-        GeocodeJsonFormatter formatter = new GeocodeJsonFormatter(false, "en", true);
+        GeocodeJsonFormatter formatter = new GeocodeJsonFormatter();
 
         List<PhotonResult> allResults = new ArrayList<>();
         allResults.add(createDummyGeometryResult("99999", "Park Foo", "leisure", "park"));
         allResults.add(createDummyGeometryResult("88888", "Bar Park", "leisure", "park"));
 
         // Test Geometry
-        String geojsonString = formatter.convert(allResults, null);
+        String geojsonString = formatter.convert(allResults, "en", true, false, null);
         JSONObject jsonObj = new JSONObject(geojsonString);
         assertEquals("FeatureCollection", jsonObj.getString("type"));
         JSONArray features = jsonObj.getJSONArray("features");

--- a/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
+++ b/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
@@ -7,7 +7,7 @@ public class MockPhotonResult implements PhotonResult {
 
     final Map<String, Object> data = new HashMap<>();
     final double[] coordinates = new double[]{42, 21};
-    final String geometry = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[-100.0,40.0],[-100.0,45.0],[-90.0,45.0],[-90.0,40.0],[-100.0,40.0]]],[[[-80.0,35.0],[-80.0,40.0],[-70.0,40.0],[-70.0,35.0],[-80.0,35.0]]]]}";
+    String geometry = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[-100.0,40.0],[-100.0,45.0],[-90.0,45.0],[-90.0,40.0],[-100.0,40.0]]],[[[-80.0,35.0],[-80.0,40.0],[-70.0,40.0],[-70.0,35.0],[-80.0,35.0]]]]}";
     final double[] extent = new double[]{0, 1, 2, 3};
     final Map<String, String> localized = new HashMap<>();
 
@@ -46,6 +46,11 @@ public class MockPhotonResult implements PhotonResult {
         return 99;
     }
 
+    @Override
+    public Map<String, Object> getRawData() {
+        return Map.of();
+    }
+
     public MockPhotonResult put(String key, Object value) {
         data.put(key, value);
         return this;
@@ -56,8 +61,8 @@ public class MockPhotonResult implements PhotonResult {
         return this;
     }
 
-    @Override
-    public Map<String, Object> getRawData() {
-        return Map.of();
+    public MockPhotonResult putGeometry(String geometry) {
+        this.geometry = geometry;
+        return this;
     }
 }

--- a/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
+++ b/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
@@ -1,7 +1,5 @@
 package de.komoot.photon.searcher;
 
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,7 +57,7 @@ public class MockPhotonResult implements PhotonResult {
     }
 
     @Override
-    public JSONObject getRawData() {
-        return new JSONObject();
+    public Map<String, Object> getRawData() {
+        return Map.of();
     }
 }


### PR DESCRIPTION
This replaces most of the uses of the json library with jackson's streaming parser/generator. We already use jackson anyway, so there is no point in depending on two json libraries. Switching to jackson also resolves the long-standing annoyance that the order of fields in Photon's output was rather random.

The only place where json is left is the IndexSetting class for the ES backend. The class is rather closely tied to the rest of the code.