### PR TITLE
Fix accidental rename of version field in database

### DIFF
--- a/app/es_embedded/src/main/java/de/komoot/photon/Server.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/Server.java
@@ -269,7 +269,7 @@ public class Server {
 
         final var dbProps = new DatabaseProperties();
 
-        dbProps.setVersion(properties.get(FIELD_VERSION));
+        dbProps.setDatabaseVersion(properties.get(FIELD_VERSION));
 
         final String langString = properties.get(FIELD_LANGUAGES);
         dbProps.setLanguages(langString == null ? null : langString.split(","));

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -21,7 +21,7 @@ public class DatabaseProperties {
     private boolean supportGeometries = false;
     private ConfigExtraTags extraTags = new ConfigExtraTags();
 
-    public void setVersion(String version) {
+    public void setDatabaseVersion(String version) {
         if (!DATABASE_VERSION.equals(version)) {
             LOGGER.error("Database has incompatible version '{}'. Expected: {}",
                     version, DATABASE_VERSION);
@@ -29,7 +29,7 @@ public class DatabaseProperties {
         }
     }
 
-    public String getVersion() {
+    public String getDatabaseVersion() {
         return DATABASE_VERSION;
     }
 


### PR DESCRIPTION
#890 accidentally renamed the version field in the properties entry from 'databaseVersion' to 'version'. Revert that.