### PR TITLE
Fix result filtering for default language

### DIFF
--- a/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/elasticsearch/PhotonQueryBuilder.java
@@ -122,7 +122,7 @@ public class PhotonQueryBuilder {
         queryBuilderForTopLevelFilter = QueryBuilders.boolQuery()
                 .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("housenumber")))
                 .should(QueryBuilders.matchQuery("housenumber", query).analyzer("standard"))
-                .should(QueryBuilders.existsQuery(String.format("name.%s.raw", language)));
+                .should(QueryBuilders.existsQuery(String.format("name.%s.raw", defLang)));
 
         osmTagFilter = new OsmTagFilter();
         

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -139,7 +139,7 @@ public class SearchQueryBuilder {
                         .field("housenumber")
                         .analyzer("standard")))
                 .should(q3 -> q3.exists(ex2 -> ex2
-                        .field(String.format("name.%s.raw", language))));
+                        .field(String.format("name.%s.raw", defLang))));
     }
 
     public SearchQueryBuilder(StructuredSearchRequest request, String language, String[] languages, boolean lenient)

--- a/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
@@ -34,28 +34,38 @@ class QueryBasicSearchTest extends ESBaseTester {
                 .names(makeDocNames(names));
     }
 
-    private List<PhotonResult> search(String query) {
+    private List<PhotonResult> search(String query, String lang) {
         final var request = new SimpleSearchRequest();
         request.setQuery(query);
-        request.setLanguage("en");
+        if (lang != null) {
+            request.setLanguage(lang);
+        }
 
         return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
     }
 
     private void assertWorking(SoftAssertions soft, String... queries) {
-        for (String query : queries) {
-            soft.assertThat(search(query)).hasSize(1);
+        for (var lang : new String[]{"default", "en", null}) {
+            for (String query : queries) {
+                soft.assertThat(search(query, lang))
+                        .withFailMessage("Searching for '%s' (language: %s) failed.", query, lang)
+                        .hasSize(1);
+            }
         }
     }
 
     private void assertNotWorking(SoftAssertions soft, String... queries) {
-        for (String query : queries) {
-            soft.assertThat(search(query)).hasSize(0);
+        for (var lang : new String[]{"en", "default", null}) {
+            for (String query : queries) {
+                soft.assertThat(search(query, lang))
+                        .withFailMessage("Searching for '%s' (language: %s) unexpectedly succeeded.", query, lang)
+                        .hasSize(0);
+            }
         }
     }
 
     @Test
-    void testSearchByDefaultName() throws IOException {
+    void testSearchByDefaultName() {
         Importer instance = makeImporter();
         instance.add(List.of(createDoc("name", "Muffle Flu")));
         instance.finish();
@@ -69,7 +79,7 @@ class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
-    void testSearchNameSkipTerms() throws IOException {
+    void testSearchNameSkipTerms() {
         Importer instance = makeImporter();
         instance.add(List.of(createDoc("name", "Hunted House Hotel")));
         instance.finish();
@@ -83,7 +93,7 @@ class QueryBasicSearchTest extends ESBaseTester {
         soft.assertAll();
     }
     @Test
-    void testSearchByAlternativeNames() throws IOException {
+    void testSearchByAlternativeNames() {
         Importer instance = makeImporter();
         instance.add(List.of(
                 createDoc("name", "original", "alt_name", "alt", "old_name", "older", "int_name", "int",
@@ -102,7 +112,7 @@ class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
-    void testSearchByNameAndAddress() throws IOException {
+    void testSearchByNameAndAddress() {
         Map<String, String> address = new HashMap<>();
         address.put("street", "Callino");
         address.put("city", "Madrid");
@@ -127,7 +137,7 @@ class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
-    void testSearchMustContainANameTerm() throws IOException {
+    void testSearchMustContainANameTerm() {
         Importer instance = makeImporter();
         instance.add(List.of(
                 createDoc("name", "Palermo")
@@ -144,7 +154,7 @@ class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
-    void testSearchWithHousenumberNamed() throws IOException {
+    void testSearchWithHousenumberNamed() {
         Importer instance = makeImporter();
         instance.add(List.of(
                 createDoc("name", "Edeka")
@@ -162,7 +172,7 @@ class QueryBasicSearchTest extends ESBaseTester {
     }
 
     @Test
-    void testSearchWithHousenumberUnnamed() throws IOException {
+    void testSearchWithHousenumberUnnamed() {
         Importer instance = makeImporter();
         instance.add(List.of(
                 createDoc()


### PR DESCRIPTION
Search results are filtered for having either the name or the housenumber in the original query string. The name was being checked against the 'name.<language>' index. This would go wrong when the 'default' language was set, because there is no such thing as a 'name.default' index. Use one of the language-dependent indexes instead which all contain the default names.

Fixes #746.
Fixes #640.