### PR TITLE
Add filtering for osm tags ("extra" properties)

### DIFF
--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -125,6 +125,7 @@ public class Server {
 
         new IndexMapping(dbProperties.getSupportStructuredQueries())
                 .addLanguages(dbProperties.getLanguages())
+                .addExtraTags(dbProperties.getExtraTags())
                 .putMapping(client, PhotonIndex.NAME);
 
         saveToDatabase(dbProperties);
@@ -145,6 +146,7 @@ public class Server {
         if (dbProperties.getLanguages() != null) {
             (new IndexMapping(dbProperties.getSupportStructuredQueries()))
                     .addLanguages(dbProperties.getLanguages())
+                    .addExtraTags(dbProperties.getExtraTags())
                     .putMapping(client, PhotonIndex.NAME);
         }
     }

--- a/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -64,6 +64,19 @@ public class IndexMapping {
         return this;
     }
 
+    public IndexMapping addExtraTags(List<String> extraTagsFromCmd) {
+        if (extraTagsFromCmd == null || extraTagsFromCmd.isEmpty()) {
+            return this;
+        }
+
+        mappings.properties("extra", b -> b.object(o -> o.dynamic(DynamicMapping.True)));
+
+        for (String tagKey : extraTagsFromCmd) {
+            mappings.properties("extra." + tagKey, b -> b.keyword(p -> p.index(true)));
+        }
+        return this;
+    }
+
     private void setupBaseMappings() {
         mappings = new PutMappingRequest.Builder();
 

--- a/src/main/java/de/komoot/photon/searcher/TagFilter.java
+++ b/src/main/java/de/komoot/photon/searcher/TagFilter.java
@@ -48,7 +48,7 @@ public class TagFilter {
         String key = null;
         String value = null;
 
-        String[] parts = filter.split(":");
+        String[] parts = splitFilter(filter);
 
         if (parts.length == 2) {
             boolean excludeKey = parts[0].startsWith("!");
@@ -78,6 +78,15 @@ public class TagFilter {
         }
 
         return (kind == null) ? null : new TagFilter(kind, key, value);
+    }
+
+    // Split the filter string by colon, and handle values with colons in "extra" tags.
+    private static String[] splitFilter(String filter) {
+        String[] parts = filter.split(":");
+        if (parts.length > 2 && parts[0].startsWith("extra.")) {
+            return filter.split(":", 2);
+        }
+        return parts;
     }
 
     @Override

--- a/src/test/java/de/komoot/photon/searcher/TagFilterTest.java
+++ b/src/test/java/de/komoot/photon/searcher/TagFilterTest.java
@@ -29,7 +29,8 @@ class TagFilterTest {
                 arguments(":!path", TagFilterKind.EXCLUDE, null, "path"),
                 arguments("!highway:path", TagFilterKind.EXCLUDE, "highway", "path"),
                 arguments("!highway:!path", TagFilterKind.EXCLUDE, "highway", "path"),
-                arguments("amenity:!post_box", TagFilterKind.EXCLUDE_VALUE, "amenity", "post_box")
+                arguments("amenity:!post_box", TagFilterKind.EXCLUDE_VALUE, "amenity", "post_box"),
+                arguments("extra.transport_modes:onstreetTram", TagFilterKind.INCLUDE, "extra.transport_modes", "onstreetTram")
         );
     }
 


### PR DESCRIPTION
Example query: `/api?q=Oslo&osm_tag=extra.transport_modes:onstreetTram`

The extra tag(s) must have been imported, e.g.:

    $ java -jar target/photon-opensearch-0.7.0.jar -nominatim-import \
           -import-file oslo.ndjson -languages no,en -extra-tags transport_modes