### PR TITLE
Switch to higher compression for OpenSearch

### DIFF
--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -79,6 +79,7 @@ public class Server {
             settingsBuilder.put("discovery.type", "single-node");
             settingsBuilder.putList("discovery.seed_hosts", "127.0.0.1:9201");
             settingsBuilder.put("indices.query.bool.max_clause_count", "30000");
+            settingsBuilder.put("index.codec", "best_compression");
         }).build(OpenSearchRunner.newConfigs()
                 .basePath(dataDirectory)
                 .clusterName(clusterName)
@@ -108,6 +109,7 @@ public class Server {
     public void shutdown() {
         if (runner != null) {
             try {
+                LOGGER.info("Shutting down OpenSearch runner");
                 runner.close();
             } catch (IOException e) {
                 LOGGER.error("IO error on closing database", e);


### PR DESCRIPTION
Switch to [best_compression](https://docs.opensearch.org/docs/2.19/im-plugin/index-codecs/) for index compression. This saves around 10% (or 20GB for the planet) on disk space. OpenSearch is supposedly able to work with zstd as well but that does not seem to be available with opensearch-runner.