### PR TITLE
Correctly handle addr:street and addr:place appearing together

### DIFF
--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -89,11 +89,20 @@ class PhotonDocAddressSetTest {
     void testPlaceAddress() {
         assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
                 "housenumber", "34;50 b",
-                "place", "Nowhere",
-                "street", "irrelevant")))
+                "place", "Nowhere")))
                 .satisfiesExactly(
                         d -> assertDocWithHnrAndStreet(d, "34", "Nowhere"),
                         d2 -> assertDocWithHnrAndStreet(d2, "50 b", "Nowhere"));
+    }
+
+    @Test
+    void testPlaceAndStreetAddress() {
+        assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
+                "housenumber", "34",
+                "place", "Nowhere",
+                "street", "Chaussee")))
+                .satisfiesExactly(
+                        d -> assertDocWithHnrAndStreet(d, "34", "Chaussee"));
     }
 
     @Test
@@ -102,7 +111,8 @@ class PhotonDocAddressSetTest {
                 "housenumber", "34/50",
                 "conscriptionnumber", "50",
                 "streetnumber", "34",
-                "place", "Nowhere")))
+                "place", "Nowhere",
+                "street", "Chaussee")))
                 .satisfiesExactly(
                         d -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
                         d2 -> assertDocWithHnrAndStreet(d2, "34", "Chaussee"));
@@ -117,6 +127,7 @@ class PhotonDocAddressSetTest {
                         d -> assertDocWithHnrAndStreet(d, "1", "12")
                 );
     }
+
 
     @ParameterizedTest
     @ValueSource(strings = {

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -341,6 +341,7 @@ class NominatimConnectorDBTest {
                 .addr("streetnumber", "34")
                 .addr("conscriptionnumber", "99521")
                 .addr("place", "Village")
+                .addr("street", "Main St")
                 .parent(parent).add(jdbc);
 
         place.addAddresslines(jdbc,


### PR DESCRIPTION
Give preference to `addr:street` when it appear together with `addr:place`. When they do appear together then `addr:place` is usually a synonym for `addr:neighbourhood`. The only exception is when there is a street or conscription number but that case is already covered.

`addr:block_number` keeps its priority over `addr:street`. There are very few cases, where they appear together and these look like mis-taggings on the `addr:street` side. Might be worth investigating, if we ignore block numbers outside Japan. I'm not sure there is any other country where the use is actual valid.

Fixes #914.