### PR TITLE
Use constants for fixed field names in json dump

### DIFF
--- a/src/main/java/de/komoot/photon/json/DumpFields.java
+++ b/src/main/java/de/komoot/photon/json/DumpFields.java
@@ -1,0 +1,34 @@
+package de.komoot.photon.json;
+
+public class DumpFields {
+
+    private DumpFields() {}
+
+    public static final String HEADER_VERSION = "version";
+    public static final String HEADER_GENERATOR = "generator";
+    public static final String HEADER_DB_VERSION = "database_version";
+    public static final String HEADER_DB_TIME = "data_timestamp";
+    public static final String HEADER_FEATURES = "features";
+
+    public static final String DOCUMENT_TYPE = "type";
+    public static final String DOCUMENT_CONTENT = "content";
+
+    public static final String PLACE_ID = "place_id";
+    public static final String PLACE_OBJECT_TYPE = "object_type";
+    public static final String PLACE_OBJECT_ID = "object_id";
+    public static final String PLACE_CATEGORIES = "categories";
+    public static final String PLACE_RANK_ADDRESS = "rank_address";
+    public static final String PLACE_ADMIN_LEVEL = "admin_level";
+    public static final String PLACE_IMPORTANCE = "importance";
+    public static final String PLACE_PARENT_PLACE_ID = "parent_place_id";
+    public static final String PLACE_NAMES = "name";
+    public static final String PLACE_HOUSENUMBER = "housenumber";
+    public static final String PLACE_ADDRESS = "address";
+    public static final String PLACE_EXTRA_TAGS = "extra";
+    public static final String PLACE_POSTCODE = "postcode";
+    public static final String PLACE_COUNTRY_CODE = "country_code";
+    public static final String PLACE_CENTROID = "centroid";
+    public static final String PLACE_BBOX = "bbox";
+    public static final String PLACE_GEOMETRY = "geometry";
+    public static final String PLACE_ADDRESSLINES = "addresslines";
+}

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -76,11 +76,11 @@ public class JsonDumper implements Importer {
         writeStartDocument(NominatimDumpHeader.DOCUMENT_TYPE);
 
         writer.writeStartObject();
-        writer.writeStringField("version", NominatimDumpHeader.EXPECTED_VERSION);
-        writer.writeStringField("generator", "photon");
-        writer.writeStringField("database_version", Server.DATABASE_VERSION);
-        writer.writeObjectField("data_timestamp", dbProperties.getImportDate());
-        writer.writeObjectField("features", new NominatimDumpFileFeatures());
+        writer.writeStringField(DumpFields.HEADER_VERSION, NominatimDumpHeader.EXPECTED_VERSION);
+        writer.writeStringField(DumpFields.HEADER_GENERATOR, "photon");
+        writer.writeStringField(DumpFields.HEADER_DB_VERSION, Server.DATABASE_VERSION);
+        writer.writeObjectField(DumpFields.HEADER_DB_TIME, dbProperties.getImportDate());
+        writer.writeObjectField(DumpFields.HEADER_FEATURES, new NominatimDumpFileFeatures());
         writer.writeEndObject();
         writeEndDocument();
 
@@ -108,28 +108,28 @@ public class JsonDumper implements Importer {
 
     public void writeNominatimDocument(PhotonDoc doc) throws IOException {
         writer.writeStartObject();
-        writer.writeNumberField("place_id", doc.getPlaceId());
-        writer.writeStringField("object_type", doc.getOsmType());
-        writer.writeNumberField("object_id", doc.getOsmId());
+        writer.writeNumberField(DumpFields.PLACE_ID, doc.getPlaceId());
+        writer.writeStringField(DumpFields.PLACE_OBJECT_TYPE, doc.getOsmType());
+        writer.writeNumberField(DumpFields.PLACE_OBJECT_ID, doc.getOsmId());
 
-        writer.writeArrayFieldStart("categories");
+        writer.writeArrayFieldStart(DumpFields.PLACE_CATEGORIES);
         writer.writeString(String.format("osm.%s.%s", doc.getTagKey(), doc.getTagValue()));
         writer.writeEndArray();
 
-        writer.writeNumberField("rank_address", doc.getRankAddress());
+        writer.writeNumberField(DumpFields.PLACE_RANK_ADDRESS, doc.getRankAddress());
 
         if (doc.getAdminLevel() != null) {
-            writer.writeNumberField("admin_level", doc.getAdminLevel());
+            writer.writeNumberField(DumpFields.PLACE_ADMIN_LEVEL, doc.getAdminLevel());
         }
 
-        writer.writeNumberField("importance", doc.getImportance());
+        writer.writeNumberField(DumpFields.PLACE_IMPORTANCE, doc.getImportance());
 
         if (doc.getRankAddress() > 28) {
-            writer.writeNumberField("parent_place_id", doc.getParentPlaceId());
+            writer.writeNumberField(DumpFields.PLACE_PARENT_PLACE_ID, doc.getParentPlaceId());
         }
 
         if (!doc.getName().isEmpty()) {
-            writer.writeObjectFieldStart("name");
+            writer.writeObjectFieldStart(DumpFields.PLACE_NAMES);
             for (var entry : doc.getName().entrySet()) {
                 writer.writeStringField(
                         convertNameKey(entry.getKey(), "name"),
@@ -139,7 +139,7 @@ public class JsonDumper implements Importer {
         }
 
         if (doc.getHouseNumber() != null) {
-            writer.writeStringField("housenumber", doc.getHouseNumber());
+            writer.writeStringField(DumpFields.PLACE_HOUSENUMBER, doc.getHouseNumber());
         }
 
         final Map<String, String> addressNames = new HashMap<>();
@@ -177,28 +177,28 @@ public class JsonDumper implements Importer {
         }
 
         if (!addressNames.isEmpty()) {
-            writer.writeObjectField("address", addressNames);
+            writer.writeObjectField(DumpFields.PLACE_ADDRESS, addressNames);
         }
 
-        dbProperties.configExtraTags().writeFilteredExtraTags(writer, "extra", doc.getExtratags());
+        dbProperties.configExtraTags().writeFilteredExtraTags(writer, DumpFields.PLACE_EXTRA_TAGS, doc.getExtratags());
 
         if (doc.getPostcode() != null) {
-            writer.writeStringField("postcode", doc.getPostcode());
+            writer.writeStringField(DumpFields.PLACE_POSTCODE, doc.getPostcode());
         }
 
         if (doc.getCountryCode() != null) {
-            writer.writeStringField("country_code", doc.getCountryCode().toLowerCase());
+            writer.writeStringField(DumpFields.PLACE_COUNTRY_CODE, doc.getCountryCode().toLowerCase());
         }
 
         final var coords = doc.getCentroid().getCoordinate();
-        writer.writeArrayFieldStart("centroid");
+        writer.writeArrayFieldStart(DumpFields.PLACE_CENTROID);
         writer.writeNumber(coords.x);
         writer.writeNumber(coords.y);
         writer.writeEndArray();
 
         final var bbox = doc.getBbox();
         if (bbox != null) {
-            writer.writeArrayFieldStart("bbox");
+            writer.writeArrayFieldStart(DumpFields.PLACE_BBOX);
             writer.writeNumber(bbox.getMinX());
             writer.writeNumber(bbox.getMaxY());
             writer.writeNumber(bbox.getMaxX());
@@ -208,7 +208,7 @@ public class JsonDumper implements Importer {
 
         final var geom = doc.getGeometry();
         if (geom != null) {
-            writer.writeFieldName("geometry");
+            writer.writeFieldName(DumpFields.PLACE_GEOMETRY);
             writer.writeRawValue(geojsonWriter.write(geom));
         }
 
@@ -217,8 +217,8 @@ public class JsonDumper implements Importer {
 
     private void writeStartDocument(String type) throws IOException {
         writer.writeStartObject();
-        writer.writeStringField("type", type);
-        writer.writeFieldName("content");
+        writer.writeStringField(DumpFields.DOCUMENT_TYPE, type);
+        writer.writeFieldName(DumpFields.DOCUMENT_CONTENT);
     }
 
     private void writeEndDocument() throws IOException {

--- a/src/main/java/de/komoot/photon/json/JsonReader.java
+++ b/src/main/java/de/komoot/photon/json/JsonReader.java
@@ -192,15 +192,16 @@ public class JsonReader {
         }
 
         final String fieldName = parser.nextFieldName();
-        if (!"type".equals(fieldName)) {
-            LOGGER.error("Unexpected field '{}' instead of 'type' at {}", fieldName, parser.currentLocation());
+        if (!DumpFields.DOCUMENT_TYPE.equals(fieldName)) {
+            LOGGER.error("Unexpected field '{}' instead of '{}' at {}",
+                    fieldName, DumpFields.DOCUMENT_TYPE, parser.currentLocation());
             throw new UsageException("Invalid dump file.");
         }
 
         final String documentType = parser.nextTextValue();
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
-            if ("content".equals(parser.currentName())) {
+            if (DumpFields.DOCUMENT_CONTENT.equals(parser.currentName())) {
                 parser.nextToken();
                 return documentType;
             } else {
@@ -210,7 +211,8 @@ public class JsonReader {
             }
         }
 
-        LOGGER.error("Missing 'content' field at {}", parser.currentLocation());
+        LOGGER.error("Missing '{}' field at {}",
+                DumpFields.DOCUMENT_CONTENT, parser.currentLocation());
         throw new UsageException("Invalid dump file.");
     }
 

--- a/src/main/java/de/komoot/photon/json/NominatimDumpHeader.java
+++ b/src/main/java/de/komoot/photon/json/NominatimDumpHeader.java
@@ -21,6 +21,7 @@ public class NominatimDumpHeader {
     private NominatimDumpFileFeatures features;
     private Map<String, String> extraProperties = new HashMap<>();
 
+    @JsonProperty(DumpFields.HEADER_VERSION)
     void setVersion(String version) {
         if (!EXPECTED_VERSION.equals(version)) {
             LOGGER.error("Dump file header has version '{}'. Expect version '{}'",
@@ -29,16 +30,17 @@ public class NominatimDumpHeader {
         }
     }
 
+    @JsonProperty(DumpFields.HEADER_GENERATOR)
     void setGenerator(String generator) {
         this.generator = generator;
     }
 
-    @JsonProperty("data_timestamp")
+    @JsonProperty(DumpFields.HEADER_DB_TIME)
     void setDataTimestamp(Date timestamp) {
         dataTimestamp = timestamp;
     }
 
-    @JsonProperty("features")
+    @JsonProperty(DumpFields.HEADER_FEATURES)
     void setFeatures(NominatimDumpFileFeatures features) { this.features = features; }
 
     public Date getDataTimestamp() {

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -71,22 +71,22 @@ public class NominatimPlaceDocument {
         return doc.getCountryCode();
     }
 
-    @JsonProperty("place_id")
+    @JsonProperty(DumpFields.PLACE_ID)
     void setPlaceId(long placeId) {
         doc.placeId(placeId);
     }
 
-    @JsonProperty("object_type")
+    @JsonProperty(DumpFields.PLACE_OBJECT_TYPE)
     void setOsmType(String osmType) {
         doc.osmType(osmType);
     }
 
-    @JsonProperty("object_id")
+    @JsonProperty(DumpFields.PLACE_OBJECT_ID)
     void setOsmId(long osmId) {
         doc.osmId(osmId);
     }
 
-    @JsonProperty("categories")
+    @JsonProperty(DumpFields.PLACE_CATEGORIES)
     void setCategories(String[] categories) {
         for (var cat : categories) {
             if (cat.startsWith("osm.")) {
@@ -100,65 +100,55 @@ public class NominatimPlaceDocument {
         doc.tagValue("yes");
     }
 
-    @JsonProperty("tag_key")
-    void setTagKey(String tagKey) {
-        doc.tagKey(tagKey);
-    }
-
-    @JsonProperty("tag_value")
-    void setTagValue(String tagValue) {
-        doc.tagValue(tagValue);
-    }
-
-    @JsonProperty("rank_address")
+    @JsonProperty(DumpFields.PLACE_RANK_ADDRESS)
     void setRankAddress(int rankAddress) {
         doc.rankAddress(rankAddress);
     }
 
-    @JsonProperty("admin_level")
+    @JsonProperty(DumpFields.PLACE_ADMIN_LEVEL)
     void setAdminLevel(int adminLevel) { doc.adminLevel(adminLevel); }
 
-    @JsonProperty("importance")
+    @JsonProperty(DumpFields.PLACE_IMPORTANCE)
     void setImportance(double importance) {
         doc.importance(importance);
     }
 
-    @JsonProperty("parent_place_id")
+    @JsonProperty(DumpFields.PLACE_PARENT_PLACE_ID)
     void setParentPlaceId(long parentPlaceId) {
         doc.parentPlaceId(parentPlaceId);
     }
 
-    @JsonProperty("name")
+    @JsonProperty(DumpFields.PLACE_NAMES)
     void setNames(Map<String, String> names) {
         this.names = names;
     }
 
-    @JsonProperty("housenumber")
+    @JsonProperty(DumpFields.PLACE_HOUSENUMBER)
     void setHousenumber(String housenumber) {
         doc.houseNumber(housenumber);
     }
 
-    @JsonProperty("address")
+    @JsonProperty(DumpFields.PLACE_ADDRESS)
     void setAddress(Map<String, String> address) {
         this.address = address;
     }
 
-    @JsonProperty("extratags")
+    @JsonProperty(DumpFields.PLACE_EXTRA_TAGS)
     void setExtratags(Map<String, String> extratags) {
         doc.extraTags(extratags);
     }
 
-    @JsonProperty("postcode")
+    @JsonProperty(DumpFields.PLACE_POSTCODE)
     void setPostcode(String postcode) {
         doc.postcode(postcode);
     }
 
-    @JsonProperty("country_code")
+    @JsonProperty(DumpFields.PLACE_COUNTRY_CODE)
     void setCountryCode(String countryCode) {
         doc.countryCode(countryCode);
     }
 
-    @JsonProperty("centroid")
+    @JsonProperty(DumpFields.PLACE_CENTROID)
     void setCentroid(double[] coordinates) throws IOException {
         if (coordinates.length != 2) {
             throw new IOException("Invalid centroid. Must be an array of two doubles.");
@@ -166,7 +156,7 @@ public class NominatimPlaceDocument {
         doc.centroid(factory.createPoint(new Coordinate(coordinates[0], coordinates[1])));
     }
 
-    @JsonProperty("bbox")
+    @JsonProperty(DumpFields.PLACE_BBOX)
     void setBbox(double[] coordinates) throws IOException {
         if (coordinates.length != 4) {
             throw new IOException("Invalid bbox. Must be an array of four doubles.");
@@ -177,14 +167,14 @@ public class NominatimPlaceDocument {
         }));
     }
 
-    @JsonProperty("geometry")
+    @JsonProperty(DumpFields.PLACE_GEOMETRY)
     void setGeometry(JsonNode geojson) throws ParseException {
         final var geometry = jsonReader.read(geojson.toString());
         doc.geometry(geometry);
         doc.bbox(geometry.getEnvelope());
     }
 
-    @JsonProperty("addresslines")
+    @JsonProperty(DumpFields.PLACE_ADDRESSLINES)
     void setAddressLines(AddressLine[] addressLines) {
         this.addressLines = addressLines;
     }

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -30,7 +30,7 @@ class JsonReaderTest {
     private boolean configGeometryColumn = false;
 
     private static final String TEST_SIMPLE_CONTENT =
-            "{\"place_id\":100818,\"object_type\":\"W\",\"object_id\":223306798,\"categories\" : [\"osm.waterway.stream\"], \"rank_address\" : 0, \"rank_search\" : 22, \"importance\" : 0.10667666666666664,\"name\":{\"name\": \"Spiersbach\", \"name:de\": \"Spiersbach\", \"alt_name\": \"Spirsbach\"},\"extratags\":{\"boat\": \"no\"},\"country_code\":\"at\",\"centroid\":[9.53713454,47.27052526],\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[9.5461636,47.2415541],[9.5558108,47.2955234],[9.556083,47.2962812],[9.554958,47.2966235]]}}";
+            "{\"place_id\":100818,\"object_type\":\"W\",\"object_id\":223306798,\"categories\" : [\"osm.waterway.stream\"], \"rank_address\" : 0, \"rank_search\" : 22, \"importance\" : 0.10667666666666664,\"name\":{\"name\": \"Spiersbach\", \"name:de\": \"Spiersbach\", \"alt_name\": \"Spirsbach\"},\"extra\":{\"boat\": \"no\"},\"country_code\":\"at\",\"centroid\":[9.53713454,47.27052526],\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[9.5461636,47.2415541],[9.5558108,47.2955234],[9.556083,47.2962812],[9.554958,47.2966235]]}}";
     private static final String TEST_SIMPLE_STREAM =
             "{\"type\":\"Place\",\"content\":" + TEST_SIMPLE_CONTENT + "}";
 


### PR DESCRIPTION
Introduces constants for the field names we use in the json dump. This ensures that the names are in fact the same for dumping and reading. Tests still use raw strings in their test data. Consider this a second line of defense against unintentional format changes.

Also fixes a mismatch between the extratags field in json dumper and reader.

Fixes #919.