### PR TITLE
Improvments for startup and shutdown

### DIFF
--- a/app/es_embedded/src/main/java/de/komoot/photon/Server.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/Server.java
@@ -80,7 +80,7 @@ public class Server {
         }
     }
 
-    public Server start(String clusterName, String[] transportAddresses) {
+    public void start(String clusterName, String[] transportAddresses) {
         Settings.Builder sBuilder = Settings.builder();
         sBuilder.put("path.home", this.esDirectory.toString());
         sBuilder.put("network.host", "127.0.0.1"); // http://stackoverflow.com/a/15509589/1245622
@@ -122,7 +122,7 @@ public class Server {
             }
 
         }
-        return this;
+        waitForReady();
     }
 
     public void waitForReady() {

--- a/app/es_embedded/src/main/java/de/komoot/photon/Server.java
+++ b/app/es_embedded/src/main/java/de/komoot/photon/Server.java
@@ -25,8 +25,6 @@ import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
@@ -64,7 +62,7 @@ public class Server {
 
     protected Client esClient;
 
-    private File esDirectory;
+    private final File esDirectory;
 
     protected static class MyNode extends Node {
         public MyNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins) {

--- a/app/es_embedded/src/test/java/de/komoot/photon/TestServer.java
+++ b/app/es_embedded/src/test/java/de/komoot/photon/TestServer.java
@@ -4,6 +4,7 @@ import de.komoot.photon.elasticsearch.*;
 import de.komoot.photon.searcher.PhotonResult;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetResponse;
+import java.io.IOException;
 
 public class TestServer extends Server {
     public static final String TEST_CLUSTER_NAME = "photon-test";
@@ -28,7 +29,11 @@ public class TestServer extends Server {
     }
 
     public void startTestServer(String clusterName) {
-        start(TEST_CLUSTER_NAME, new String[]{});
+        try {
+            start(TEST_CLUSTER_NAME, new String[]{}, true);
+        } catch (IOException e) {
+            throw new RuntimeException("Setup error", e);
+        }
     }
 
     public void stopTestServer() {

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -36,13 +36,28 @@ public class Server {
 
     protected OpenSearchClient client;
     private OpenSearchRunner runner = null;
-    protected final String dataDirectory;
+    protected final File dataDirectory;
 
     public Server(String mainDirectory) {
-        dataDirectory = new File(mainDirectory, "photon_data").getAbsolutePath();
+        dataDirectory = new File(mainDirectory, "photon_data");
     }
 
-    public void start(String clusterName, String[] transportAddresses) throws IOException {
+    public void start(String clusterName, String[] transportAddresses, boolean create) throws IOException {
+        if (!create && transportAddresses.length == 0) {
+            if (!dataDirectory.isDirectory()) {
+                LOGGER.error("Data directory '{}' doesn't exist.", dataDirectory.getAbsolutePath());
+                throw new IOException("OpenSearch database not found.");
+            }
+
+            final File nodeDirectory = new File(dataDirectory, "node_1");
+
+            if (!nodeDirectory.isDirectory()) {
+                LOGGER.error("Data directory '{}' seems to be empty. Are you using an index for OpenSearch?",
+                        dataDirectory.getAbsolutePath());
+                throw new IOException("OpenSearch database not found.");
+            }
+        }
+
         HttpHost[] hosts;
         if (transportAddresses.length == 0) {
             hosts = startInternal(clusterName);
@@ -81,7 +96,7 @@ public class Server {
             settingsBuilder.put("indices.query.bool.max_clause_count", "30000");
             settingsBuilder.put("index.codec", "best_compression");
         }).build(OpenSearchRunner.newConfigs()
-                .basePath(dataDirectory)
+                .basePath(dataDirectory.getAbsolutePath())
                 .clusterName(clusterName)
                 .numOfNode(1)
         );

--- a/app/opensearch/src/main/java/de/komoot/photon/Server.java
+++ b/app/opensearch/src/main/java/de/komoot/photon/Server.java
@@ -42,7 +42,7 @@ public class Server {
         dataDirectory = new File(mainDirectory, "photon_data").getAbsolutePath();
     }
 
-    public Server start(String clusterName, String[] transportAddresses) {
+    public void start(String clusterName, String[] transportAddresses) throws IOException {
         HttpHost[] hosts;
         if (transportAddresses.length == 0) {
             hosts = startInternal(clusterName);
@@ -69,7 +69,7 @@ public class Server {
 
         client = new OpenSearchClient(transport);
 
-        return this;
+        waitForReady();
     }
 
     private HttpHost[] startInternal(String clusterName) {

--- a/app/opensearch/src/test/java/de/komoot/photon/TestServer.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/TestServer.java
@@ -20,7 +20,7 @@ public class TestServer extends Server {
         instanceDir = mainDirectory;
     }
 
-    public void startTestServer(String clusterName) {
+    public void startTestServer(String clusterName) throws IOException {
         runner = new OpenSearchRunner();
         runner.onBuild(new OpenSearchRunner.Builder() {
             @Override

--- a/app/opensearch/src/test/java/de/komoot/photon/TestServer.java
+++ b/app/opensearch/src/test/java/de/komoot/photon/TestServer.java
@@ -47,7 +47,7 @@ public class TestServer extends Server {
         runner.ensureYellow();
 
         String[] transportAddresses = {"127.0.0.1:" + runner.node().settings().get("http.port")};
-        start(clusterName, transportAddresses);
+        start(clusterName, transportAddresses, true);
     }
 
     public void stopTestServer() {

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -70,7 +70,7 @@ public class App {
         esServer = new Server(args.getDataDirectory());
 
         LOGGER.info("Start up database cluster, this might take some time.");
-        esServer.start(args.getCluster(), args.getTransportAddresses());
+        esServer.start(args.getCluster(), args.getTransportAddresses(), args.isNominatimImport());
         LOGGER.info("Database cluster is now ready.");
 
         if (args.isNominatimImport()) {

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -67,11 +67,11 @@ public class App {
             return true;
         }
 
-        esServer = new Server(args.getDataDirectory()).start(args.getCluster(), args.getTransportAddresses());
+        esServer = new Server(args.getDataDirectory());
 
-        LOGGER.info("Make sure that the ES cluster is ready, this might take some time.");
-        esServer.waitForReady();
-        LOGGER.info("ES cluster is now ready.");
+        LOGGER.info("Start up database cluster, this might take some time.");
+        esServer.start(args.getCluster(), args.getTransportAddresses());
+        LOGGER.info("Database cluster is now ready.");
 
         if (args.isNominatimImport()) {
             startNominatimImport(args, esServer);

--- a/src/test/java/de/komoot/photon/api/ApiBaseTester.java
+++ b/src/test/java/de/komoot/photon/api/ApiBaseTester.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,12 +17,20 @@ import static org.assertj.core.api.Assertions.assertThatIOException;
 
 public class ApiBaseTester extends ESBaseTester {
     private static final int LISTEN_PORT = 30234;
+    private String photonDirectory;
+
+    @Override
+    public void setUpES(Path dataDirectory) throws IOException {
+        super.setUpES(dataDirectory);
+        photonDirectory = dataDirectory.toString();
+    }
 
     protected void startAPI(String... extraParams) throws Exception {
         final String[] params = Stream.concat(
                 Stream.of("-cluster", TEST_CLUSTER_NAME,
                         "-listen-port", Integer.toString(LISTEN_PORT),
-                        "-transport-addresses", "127.0.0.1"),
+                        "-transport-addresses", "127.0.0.1",
+                        "-data-dir", photonDirectory),
                 Arrays.stream(extraParams)).toArray(String[]::new);
 
         App.main(params);


### PR DESCRIPTION
On startup, Photon will now only create the database directory when in import mode. In all other mode if expects the directory to be existing and will bail out if it cannot be found. This should make it easier for users to understand the error when they have downloaded the wrong index dump (ElasticSearch vs. OpenSearch). OpenSearch makes an exception when using an external OS instance. The data directory will be ignored in this case. The situation is slightly different for ElasticSearch because it still needs to copy in the painless plugin.

On shutdown, Photon now catches when the API is stopped via Ctrl-C or similar and properly shuts down the node first when running with an internally started database. I've seen very rare cases of database corruption in the past. Proper shutdown hopefully solves those.