### PR TITLE
Reinstate offset and decay for location bias

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -204,7 +204,11 @@ public class SearchQueryBuilder {
                 .query(finalQueryWithoutTagFilterBuilder.build())
                 .functions(fn1 -> fn1.exp(ex -> ex
                         .field("coordinate")
-                        .placement(p -> p.origin(JsonData.of(params)).scale(JsonData.of(radius + "km")))))
+                        .placement(p -> p
+                                .origin(JsonData.of(params))
+                                .decay(0.8)
+                                .offset(JsonData.of(radius / 10 + "km"))
+                                .scale(JsonData.of(radius + "km")))))
                 .functions(fn2 -> fn2.linear(lin -> lin
                         .field("importance")
                         .placement(p -> p.origin(JsonData.of(1.0)).scale(JsonData.of(fnscale)).decay(0.5))))


### PR DESCRIPTION
The two parameters for exponential decay got lost in the translation to OpenSearch. Thanks to @romanpickl for spotting that.

See #936.