### PR TITLE
Remove term frequency and position tracking from base collector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,11 +116,4 @@ shadowJar {
     // JndiLookup from the fat jar. This is the recommended course of action
     // when you cannot upgrade as per https://logging.apache.org/log4j/2.x/security.html
     exclude 'org/apache/logging/log4j/core/lookup/JndiLookup.class'
-
-    minimize {
-        exclude(dependency("org.opensearch.*:.*:.*"))
-        exclude(dependency("org.springframework:spring-jdbc:.*"))
-        exclude(dependency("org.postgresql:.*:.*"))
-        exclude(dependency("net.postgis:.*:.*"))
-    }
 }

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -30,7 +30,7 @@ public class Server {
      * changes in an incompatible way. If it is already at the next released
      * version, increase the dev version.
      */
-    public static final String DATABASE_VERSION = "0.3.6-1";
+    public static final String DATABASE_VERSION = "1.0.0-0";
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -2,6 +2,7 @@ package de.komoot.photon.opensearch;
 
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.mapping.DynamicMapping;
+import org.opensearch.client.opensearch._types.mapping.IndexOptions;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
 
 import java.io.IOException;
@@ -95,6 +96,8 @@ public class IndexMapping {
         // The catch-all collector used to find overall matches.
         mappings.properties("collector.base", b -> b.text(p -> p
                 .index(true)
+                .indexOptions(IndexOptions.Docs)
+                .norms(false)
                 .analyzer("index_ngram")));
 
         // Collector for all address parts in the default language.

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -97,7 +97,6 @@ public class IndexMapping {
         mappings.properties("collector.base", b -> b.text(p -> p
                 .index(true)
                 .indexOptions(IndexOptions.Docs)
-                .norms(false)
                 .analyzer("index_ngram")));
 
         // Collector for all address parts in the default language.


### PR DESCRIPTION
The base collector is used to pre-filter eligible results. The main contribution to the final scoring should be if terms are presents and how well they match. So remove term frequency and position. That not only improves score comparability for lenient search but also reduces the database base size by a whopping 50%.

Unfortunately a schema-incompatible change, so rather something to look forward to for Photon 1.0.

Closes #936, #696, #433.