### PR TITLE
Modernize index structure

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -387,7 +387,7 @@ public class App {
                         args.getDefaultLanguage(),
                         args.getMaxResults(),
                         dbProperties.getSupportGeometries()),
-                server.createSearchHandler(dbProperties.getLanguages(), args.getQueryTimeout()),
+                server.createSearchHandler(args.getQueryTimeout()),
                 formatter));
 
         if (dbProperties.getSupportStructuredQueries()) {
@@ -397,7 +397,7 @@ public class App {
                             args.getDefaultLanguage(),
                             args.getMaxResults(),
                             dbProperties.getSupportGeometries()),
-                    server.createStructuredSearchHandler(dbProperties.getLanguages(), args.getQueryTimeout()),
+                    server.createStructuredSearchHandler(args.getQueryTimeout()),
                     formatter));
         }
 

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -142,7 +142,6 @@ public class Server {
         new IndexSettingBuilder().setShards(5).createIndex(client, PhotonIndex.NAME);
 
         new IndexMapping(dbProperties.getSupportStructuredQueries())
-                .addLanguages(dbProperties.getLanguages())
                 .putMapping(client, PhotonIndex.NAME);
 
         saveToDatabase(dbProperties);

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -196,12 +196,12 @@ public class Server {
         return new de.komoot.photon.opensearch.Updater(client);
     }
 
-    public SearchHandler<SimpleSearchRequest> createSearchHandler(String[] languages, int queryTimeoutSec) {
-        return new OpenSearchSearchHandler(client, languages, queryTimeoutSec);
+    public SearchHandler<SimpleSearchRequest> createSearchHandler(int queryTimeoutSec) {
+        return new OpenSearchSearchHandler(client, queryTimeoutSec);
     }
 
-    public SearchHandler<StructuredSearchRequest> createStructuredSearchHandler(String[] languages, int queryTimeoutSec) {
-        return new OpenSearchStructuredSearchHandler(client, languages, queryTimeoutSec);
+    public SearchHandler<StructuredSearchRequest> createStructuredSearchHandler(int queryTimeoutSec) {
+        return new OpenSearchStructuredSearchHandler(client, queryTimeoutSec);
     }
 
     public SearchHandler<ReverseRequest> createReverseHandler(int queryTimeoutSec) {

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -31,7 +31,7 @@ public class Server {
      * changes in an incompatible way. If it is already at the next released
      * version, increase the dev version.
      */
-    public static final String DATABASE_VERSION = "1.0.0-1";
+    public static final String DATABASE_VERSION = "1.0.0-2";
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
@@ -11,24 +11,26 @@ import java.util.stream.Collectors;
  * the mapping toward Nominatim's address ranks.
  */
 public enum AddressType {
-    HOUSE("house", 29, 30),
-    STREET("street", 26, 28),
-    LOCALITY("locality", 22, 25),
-    DISTRICT("district", 17, 21),
-    CITY("city", 13, 16),
-    COUNTY("county", 10, 12),
-    STATE("state", 5, 9),
-    COUNTRY("country", 4, 4),
-    OTHER("other", 0, 0);
+    HOUSE("house", 29, 30, 3),
+    STREET("street", 26, 28, 2),
+    LOCALITY("locality", 22, 25, 1),
+    DISTRICT("district", 17, 21, 1),
+    CITY("city", 13, 16, 3),
+    COUNTY("county", 10, 12, 1),
+    STATE("state", 5, 9, 1),
+    COUNTRY("country", 4, 4, 2),
+    OTHER("other", 0, 0, 1);
 
     private final String name;
     private final int minRank;
     private final int maxRank;
+    private final int searchPrio;
 
-    AddressType(String name, int minRank, int maxRank) {
+    AddressType(String name, int minRank, int maxRank, int searchPrio) {
         this.name = name;
         this.minRank = minRank;
         this.maxRank = maxRank;
+        this.searchPrio = searchPrio;
     }
 
     /**
@@ -63,5 +65,9 @@ public enum AddressType {
 
     public static List<String> getNames() {
         return Arrays.stream(AddressType.values()).map(AddressType::getName).collect(Collectors.toList());
+    }
+
+    public int getSearchPrio() {
+        return searchPrio;
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
@@ -229,10 +229,8 @@ public class AddressQueryBuilder {
     }
 
     private Query getFuzzyQuery(String name, String value, float boost) {
-        return getFuzzyQueryCore(name + "_collector", value, boost);
-    }
+        final var field = "collector.field." + name;
 
-    private Query getFuzzyQueryCore(String field, String value, float boost) {
         if (lenient) {
             return QueryBuilders.match()
                     .field(field)
@@ -253,12 +251,7 @@ public class AddressQueryBuilder {
 
     private BoolQuery.Builder getFuzzyNameQueryBuilder(String value, String objectType) {
         var or = QueryBuilders.bool();
-        for (String lang : languages) {
-            float boost = lang.equals(language) ? 1.0f : FACTOR_FOR_WRONG_LANGUAGE;
-            var fieldName = Constants.NAME + '.' + lang + ".raw";
-
-            or.should(getFuzzyQueryCore(fieldName, value, boost));
-        }
+        or.should(getFuzzyQuery("name", value));
 
         return or.minimumShouldMatch("1")
                 .filter(QueryBuilders.term()

--- a/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/AddressQueryBuilder.java
@@ -15,9 +15,6 @@ public class AddressQueryBuilder {
     private static final float DISTRICT_BOOST = 2.0f;
     private static final float STREET_BOOST = 5.0f; // we filter streets in the wrong city / district / ... so we can use a high boost value
     private static final float HOUSE_NUMBER_BOOST = 10.0f;
-    private static final float FACTOR_FOR_WRONG_LANGUAGE = 0.1f;
-    private final String[] languages;
-    private final String language;
 
     private BoolQuery.Builder query = QueryBuilders.bool();
 
@@ -25,10 +22,8 @@ public class AddressQueryBuilder {
 
     private boolean lenient;
 
-    public AddressQueryBuilder(boolean lenient, String language, String[] languages) {
+    public AddressQueryBuilder(boolean lenient) {
         this.lenient = lenient;
-        this.language = language;
-        this.languages = languages;
     }
 
     public Query getQuery() {

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -26,16 +26,21 @@ public class IndexMapping {
         mappings.dynamic(DynamicMapping.False)
                 .source(s -> s.excludes("collector"));
 
-        mappings.properties("osm_type", b -> b.text(p -> p.index(false)));
-        mappings.properties("osm_id", b -> b.unsignedLong(l -> l.index(false)));
+        // Only list fields here that need an index in some form. All other fields will
+        // be passive fields saved in and retrivable by _source.
 
         for (var field : new String[]{"osm_key", "osm_value", "type"}) {
-            mappings.properties(field, b -> b.keyword(p -> p.index(true)));
+            mappings.properties(field, b -> b.keyword(p -> p
+                    .index(true)
+                    .docValues(false)
+            ));
         }
 
         mappings.properties("coordinate", b -> b.geoPoint(p -> p));
-        mappings.properties("geometry", b -> b.geoShape(p -> p));
-        mappings.properties("countrycode", b -> b.keyword(p -> p.index(true)));
+        mappings.properties("countrycode", b -> b.keyword(p -> p
+                .index(true)
+                .docValues(false)
+        ));
         mappings.properties("importance", b -> b.float_(p -> p
                 .index(false)
         ));
@@ -59,10 +64,12 @@ public class IndexMapping {
                 .searchAnalyzer("search_classification")
         ));
 
-        mappings.properties("postcode", b -> b.text(p -> p
-                .index(supportStructuredQueries)
-                .analyzer("index_raw")
-        ));
+        if (supportStructuredQueries) {
+            mappings.properties("postcode", b -> b.text(p -> p
+                    .index(true)
+                    .analyzer("index_raw")
+            ));
+        }
 
         // General collectors.
         mappings.properties("collector.all", b -> b.text(p -> p

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -67,6 +67,7 @@ public class IndexMapping {
         if (supportStructuredQueries) {
             mappings.properties("postcode", b -> b.text(p -> p
                     .index(true)
+                    .norms(false)
                     .analyzer("index_raw")
             ));
         }
@@ -74,11 +75,13 @@ public class IndexMapping {
         // General collectors.
         mappings.properties("collector.all", b -> b.text(p -> p
                 .index(true)
+                .norms(false)
                 .indexOptions(IndexOptions.Freqs)
                 .analyzer("index_fullword")
                 .searchAnalyzer("search")
                 .fields("ngram", ngramField -> ngramField.text(p1 -> p1
                         .index(true)
+                        .norms(false)
                         .indexOptions(IndexOptions.Freqs)
                         .analyzer("index_ngram")
                         .searchAnalyzer("search")
@@ -87,11 +90,13 @@ public class IndexMapping {
 
         mappings.properties("collector.name", b -> b.text(p -> p
                 .index(true)
+                .norms(false)
                 .indexOptions(IndexOptions.Freqs)
                 .analyzer("index_name_ngram")
                 .searchAnalyzer("search")
                 .fields("prefix", prefixField -> prefixField.text(p1 -> p1
                         .index(true)
+                        .norms(false)
                         .indexOptions(IndexOptions.Freqs)
                         .analyzer("index_name_prefix")
                         .searchAnalyzer("search_prefix")
@@ -100,6 +105,7 @@ public class IndexMapping {
 
         mappings.properties("collector.parent", b -> b.text(p -> p
                 .index(true)
+                .norms(false)
                 .indexOptions(IndexOptions.Docs)
                 .analyzer("index_name_ngram")
                 .searchAnalyzer("search")
@@ -109,6 +115,7 @@ public class IndexMapping {
             for (var field : ADDRESS_FIELDS) {
                 mappings.properties(getAddressFieldCollector(field), b -> b.text(p -> p
                         .index(true)
+                        .norms(false)
                         .analyzer("index_raw")
                         .searchAnalyzer("search")
                 ));

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -42,8 +42,15 @@ public class IndexMapping {
 
         mappings.properties("housenumber", b -> b.text(p -> p
                 .index(true)
+                .indexOptions(IndexOptions.Docs)
                 .analyzer("index_housenumber")
                 .searchAnalyzer("standard")
+                .fields("full", f -> f.text(full -> full
+                        .index(true)
+                        .norms(false)
+                        .indexOptions(IndexOptions.Docs)
+                        .analyzer("lowercase_keyword")
+                ))
         ));
 
         mappings.properties("classification", b -> b.text(p -> p

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -61,7 +61,7 @@ public class IndexMapping {
         mappings.properties("classification", b -> b.text(p -> p
                 .index(true)
                 .analyzer("keyword")
-                .searchAnalyzer("search_classification")
+                .searchAnalyzer("search")
         ));
 
         if (supportStructuredQueries) {

--- a/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexMapping.java
@@ -6,70 +6,25 @@ import org.opensearch.client.opensearch._types.mapping.IndexOptions;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 
 public class IndexMapping {
-    private static final String[] ADDRESS_FIELDS = new String[]{"street", "city", "locality", "district", "county", "state", "country", "context"};
+    private static final String[] ADDRESS_FIELDS = new String[]{"name", "street", "city", "district", "county", "state", "country"};
 
     private PutMappingRequest.Builder mappings;
 
-    private boolean supportStructuredQueries;
-
     public IndexMapping(boolean supportStructuredQueries) {
-        this.supportStructuredQueries = supportStructuredQueries;
-        setupBaseMappings();
+        setupBaseMappings(supportStructuredQueries);
     }
 
     public void putMapping(OpenSearchClient client, String indexName) throws IOException {
         client.indices().putMapping(mappings.index(indexName).build());
     }
 
-    public IndexMapping addLanguages(String[] languages) {
-        List<String> nameCollectors = new ArrayList<>();
-        for (var lang: languages) {
-            mappings.properties("collector." + lang,
-                    b -> b.text(p -> p.index(true)
-                                      .analyzer("index_raw"))
-            );
-
-            for (var field: ADDRESS_FIELDS) {
-                var propertyName = String.format("%s.%s", field, lang);
-                var collectors = new ArrayList<>(Arrays.asList("collector.base", "collector." + lang));
-                if (shouldIndexAddressField(field)) {
-                    collectors.add(getAddressFieldCollector(field));
-                }
-
-                mappings.properties(propertyName,
-                        b -> b.text(p -> p
-                                .index(false)
-                                .copyTo(collectors)));
-            }
-
-            mappings.properties("name." + lang,
-                    b -> b.text(p -> p.index(false)
-                            .fields("ngrams", f -> f.text(pi -> pi.index(true).analyzer("index_ngram")))
-                            .fields("raw", f2 -> f2.text(pi2 -> pi2.index(true).analyzer("index_raw")))
-                            .copyTo("collector." + lang, "collector.base")));
-
-            //add language-specific collector to default for name
-            nameCollectors.add("name." + lang);
-        }
-
-        nameCollectors.add("collector.default");
-        nameCollectors.add("collector.base");
-        mappings.properties("name.default", b -> b.text(p -> p.index(false).copyTo(nameCollectors)));
-
-        return this;
-    }
-
-    private void setupBaseMappings() {
+    private void setupBaseMappings(boolean supportStructuredQueries) {
         mappings = new PutMappingRequest.Builder();
 
         mappings.dynamic(DynamicMapping.False)
-                .source(s -> s.excludes("context.*"));
+                .source(s -> s.excludes("collector"));
 
         mappings.properties("osm_type", b -> b.text(p -> p.index(false)));
         mappings.properties("osm_id", b -> b.unsignedLong(l -> l.index(false)));
@@ -81,69 +36,73 @@ public class IndexMapping {
         mappings.properties("coordinate", b -> b.geoPoint(p -> p));
         mappings.properties("geometry", b -> b.geoShape(p -> p));
         mappings.properties("countrycode", b -> b.keyword(p -> p.index(true)));
-        mappings.properties("importance", b -> b.float_(p -> p.index(false)));
-
-        mappings.properties("housenumber", b -> b.text(p -> p.index(true)
-                .analyzer("index_housenumber").searchAnalyzer("standard")
-                .copyTo("collector.default", "collector.base")
+        mappings.properties("importance", b -> b.float_(p -> p
+                .index(false)
         ));
 
-        mappings.properties("classification", b -> b.text(p -> p.index(true)
+        mappings.properties("housenumber", b -> b.text(p -> p
+                .index(true)
+                .analyzer("index_housenumber")
+                .searchAnalyzer("standard")
+        ));
+
+        mappings.properties("classification", b -> b.text(p -> p
+                .index(true)
                 .analyzer("keyword")
                 .searchAnalyzer("search_classification")
-                .copyTo("collector.default", "collector.base")));
+        ));
 
-        // The catch-all collector used to find overall matches.
-        mappings.properties("collector.base", b -> b.text(p -> p
-                .index(true)
-                .indexOptions(IndexOptions.Docs)
-                .analyzer("index_ngram")));
-
-        // Collector for all address parts in the default language.
-        mappings.properties("collector.default", b -> b.text(p -> p
-                .index(true)
-                .analyzer("index_raw")));
-
-        for (var field : ADDRESS_FIELDS) {
-            var collectors = new ArrayList<>(Arrays.asList("collector.default", "collector.base"));
-
-            if (shouldIndexAddressField(field)) {
-                var collectorName = getAddressFieldCollector(field);
-                mappings.properties(collectorName,
-                        b -> b.text(p -> p.index(true)
-                                .searchAnalyzer("search")
-                                .analyzer("index_raw"))
-                );
-
-                collectors.add(collectorName);
-            }
-
-            mappings.properties(field + ".default", b -> b.text(p -> p
-                    .index(false)
-                    .copyTo(collectors)));
-        }
         mappings.properties("postcode", b -> b.text(p -> p
                 .index(supportStructuredQueries)
-                .copyTo("collector.default", "collector.base")));
+                .analyzer("index_raw")
+        ));
 
-        mappings.properties("name.default", b -> b.text(p -> p
-                .index(false)
-                .copyTo("collector.default", "collector.base")));
+        // General collectors.
+        mappings.properties("collector.all", b -> b.text(p -> p
+                .index(true)
+                .indexOptions(IndexOptions.Freqs)
+                .analyzer("index_fullword")
+                .searchAnalyzer("search")
+                .fields("ngram", ngramField -> ngramField.text(p1 -> p1
+                        .index(true)
+                        .indexOptions(IndexOptions.Freqs)
+                        .analyzer("index_ngram")
+                        .searchAnalyzer("search")
+                ))
+        ));
 
-        // Collector for all name parts.
-        mappings.properties("name.other", b -> b.text(pi -> pi.index(true).analyzer("index_raw")));
+        mappings.properties("collector.name", b -> b.text(p -> p
+                .index(true)
+                .indexOptions(IndexOptions.Freqs)
+                .analyzer("index_name_ngram")
+                .searchAnalyzer("search")
+                .fields("prefix", prefixField -> prefixField.text(p1 -> p1
+                        .index(true)
+                        .indexOptions(IndexOptions.Freqs)
+                        .analyzer("index_name_prefix")
+                        .searchAnalyzer("search_prefix")
+                ))
+        ));
 
-        for (var suffix : new String[]{"alt", "int", "loc", "old", "reg", "housename"}) {
-            mappings.properties("name." + suffix, b -> b.text(p -> p.index(false)
-                    .copyTo("collector.default", "name.other", "collector.base")));
+        mappings.properties("collector.parent", b -> b.text(p -> p
+                .index(true)
+                .indexOptions(IndexOptions.Docs)
+                .analyzer("index_name_ngram")
+                .searchAnalyzer("search")
+        ));
+
+        if (supportStructuredQueries) {
+            for (var field : ADDRESS_FIELDS) {
+                mappings.properties(getAddressFieldCollector(field), b -> b.text(p -> p
+                        .index(true)
+                        .analyzer("index_raw")
+                        .searchAnalyzer("search")
+                ));
+            }
         }
     }
 
     private String getAddressFieldCollector(String field) {
-        return field + "_collector";
-    }
-
-    private boolean shouldIndexAddressField(String field) {
-        return supportStructuredQueries && !Objects.equals(field, "locality") && !Objects.equals(field, "context");
+        return "collector.field." + field;
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -235,5 +235,10 @@ public class IndexSettingBuilder {
                 .filter(NORMALIZATION_FILTERS)
                 .filter("prefix_edge_ngram", "unique")
         ));
+
+        settings.analyzer("lowercase_keyword", f -> f.custom(d -> d
+                .tokenizer("keyword")
+                .filter("lowercase")
+        ));
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/NameCollector.java
+++ b/src/main/java/de/komoot/photon/opensearch/NameCollector.java
@@ -1,0 +1,43 @@
+package de.komoot.photon.opensearch;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Collects strings with a priorities, discarding duplicate strings while
+ * keeping the highest priority.
+ */
+public class NameCollector {
+
+    private final Map<String, Integer> terms = new HashMap<>();
+
+    public NameCollector() {
+    }
+
+    public NameCollector(Collection<String> termCollection) {
+        addAll(termCollection, 1);
+    }
+
+    public void add(String term, int searchPrio) {
+        final var cleaned = term.replace("|", " ");
+        final var currentPrio = terms.get(cleaned);
+        if (currentPrio == null || currentPrio < searchPrio) {
+            terms.put(cleaned, Integer.max(searchPrio, 1));
+        }
+    }
+
+    public void addAll(Collection<String> termCollection, int searchPrio) {
+        for (var term : termCollection) {
+            add(term, searchPrio);
+        }
+    }
+
+    public String toCollectorString() {
+        return terms.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+                .map(e -> String.format("%s|%d", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(";"));
+    }
+}

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -14,12 +14,10 @@ import java.util.List;
 
 public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchRequest> {
     private final OpenSearchClient client;
-    private final String[] supportedLanguages;
     private final String queryTimeout;
 
-    public OpenSearchSearchHandler(OpenSearchClient client, String[] supportedLanguages, int queryTimeout) {
+    public OpenSearchSearchHandler(OpenSearchClient client, int queryTimeout) {
         this.client = client;
-        this.supportedLanguages = supportedLanguages;
         this.queryTimeout = queryTimeout + "s";
     }
 
@@ -48,7 +46,7 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
     }
 
     private SearchQueryBuilder buildQuery(SimpleSearchRequest request, boolean lenient) {
-        return new SearchQueryBuilder(request.getQuery(), request.getLanguage(), supportedLanguages, lenient).
+        return new SearchQueryBuilder(request.getQuery(), lenient).
                 withOsmTagFilters(request.getOsmTagFilters()).
                 withLayerFilters(request.getLayerFilters()).
                 withLocationBias(request.getLocationForBias(), request.getScaleForBias(), request.getZoomForBias()).

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -17,12 +17,10 @@ import java.io.IOException;
  */
 public class OpenSearchStructuredSearchHandler implements SearchHandler<StructuredSearchRequest> {
     private final OpenSearchClient client;
-    private final String[] supportedLanguages;
     private final String queryTimeout;
 
-    public OpenSearchStructuredSearchHandler(OpenSearchClient client, String[] languages, int queryTimeoutSec) {
+    public OpenSearchStructuredSearchHandler(OpenSearchClient client, int queryTimeoutSec) {
         this.client = client;
-        this.supportedLanguages = languages;
         queryTimeout = queryTimeoutSec + "s";
     }
 
@@ -64,7 +62,7 @@ public class OpenSearchStructuredSearchHandler implements SearchHandler<Structur
     }
 
     public SearchQueryBuilder buildQuery(StructuredSearchRequest photonRequest, boolean lenient) {
-        return new SearchQueryBuilder(photonRequest, photonRequest.getLanguage(), supportedLanguages, lenient).
+        return new SearchQueryBuilder(photonRequest, lenient).
                 withOsmTagFilters(photonRequest.getOsmTagFilters()).
                 withLayerFilters(photonRequest.getLayerFilters()).
                 withLocationBias(photonRequest.getLocationForBias(), photonRequest.getScaleForBias(), photonRequest.getZoomForBias()).

--- a/src/main/java/de/komoot/photon/opensearch/PhotonDocSerializer.java
+++ b/src/main/java/de/komoot/photon/opensearch/PhotonDocSerializer.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import de.komoot.photon.*;
+import de.komoot.photon.nominatim.model.AddressType;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class PhotonDocSerializer extends StdSerializer<PhotonDoc> {
     private final DatabaseProperties dbProperties;
@@ -22,6 +23,10 @@ public class PhotonDocSerializer extends StdSerializer<PhotonDoc> {
     @Override
     public void serialize(PhotonDoc value, JsonGenerator gen, SerializerProvider provider) throws IOException {
         final var atype = value.getAddressType();
+        final var isNamed = !value.getName().isEmpty();
+        final var isAddress = value.getHouseNumber() != null;
+        final var termCollector = new NameCollector();
+        final var nameCollector  = new NameCollector();
 
         gen.writeStartObject();
         gen.writeNumberField(Constants.OSM_ID, value.getOsmId());
@@ -34,6 +39,7 @@ public class PhotonDocSerializer extends StdSerializer<PhotonDoc> {
         String classification = Utils.buildClassificationString(value.getTagKey(), value.getTagValue());
         if (classification != null) {
             gen.writeStringField(Constants.CLASSIFICATION, classification);
+            termCollector.add(classification, 1);
         }
 
         if (value.getCentroid() != null) {
@@ -52,41 +58,79 @@ public class PhotonDocSerializer extends StdSerializer<PhotonDoc> {
             gen.writeRawValue(geoJson);
         }
 
-        if (value.getHouseNumber() != null) {
+        if (isAddress) {
             gen.writeStringField("housenumber", value.getHouseNumber());
+            termCollector.add(value.getHouseNumber(), isNamed ? 4 : 5);
         }
 
         if (value.getPostcode() != null) {
             gen.writeStringField("postcode", value.getPostcode());
+            termCollector.add(value.getPostcode(), 2);
         }
 
-        gen.writeObjectField("name", value.getName());
+        if (isNamed) {
+            gen.writeObjectField("name", value.getName());
+
+            for (var entry : value.getName().entrySet()) {
+                final var key = entry.getKey();
+                final var name = entry.getValue();
+                final boolean isPrimaryName = "default".equals(key)
+                    || Arrays.asList(dbProperties.getLanguages()).contains(key);
+                termCollector.add(name, isPrimaryName ? 5 : 2);
+                nameCollector.add(name, isPrimaryName ? 2 : 1);
+            }
+        }
 
 
         for (var entry : value.getAddressParts().entrySet()) {
-            gen.writeObjectField(entry.getKey().getName(), entry.getValue());
+            final var type = entry.getKey();
+            final var values = entry.getValue();
+            final var prio = (value.getHouseNumber() != null && type == AddressType.STREET) ? 5 : type.getSearchPrio();
+
+            gen.writeObjectField(type.getName(), values);
+            termCollector.addAll(values.values(), prio);
         }
 
         String countryCode = value.getCountryCode();
         if (countryCode != null) {
             gen.writeStringField(Constants.COUNTRYCODE, countryCode);
+            termCollector.add(countryCode, 2);
         }
 
-        writeContext(gen, value.getContext());
         dbProperties.configExtraTags().writeFilteredExtraTags(gen, "extra", value.getExtratags());
         writeExtent(gen, value.getBbox());
 
-        gen.writeEndObject();
-    }
-
-    private void writeContext(JsonGenerator gen, Map<String, Set<String>> contexts) throws IOException {
-        if (!contexts.isEmpty()) {
-            gen.writeObjectFieldStart("context");
-            for (Map.Entry<String, Set<String>> entry : contexts.entrySet()) {
-                gen.writeStringField(entry.getKey(), String.join(", ", entry.getValue()));
-            }
-            gen.writeEndObject();
+        for (var contextVal : value.getContext().values()) {
+            termCollector.addAll(contextVal, 1);
         }
+
+        gen.writeObjectFieldStart("collector");
+        gen.writeStringField("all", termCollector.toCollectorString());
+        if (isNamed) {
+            gen.writeStringField("name", nameCollector.toCollectorString());
+        }
+        if (isAddress) {
+            var parentNames = value.getAddressParts().get(AddressType.STREET);
+            if (parentNames != null) {
+                gen.writeStringField("parent", new NameCollector(parentNames.values()).toCollectorString());
+            }
+        }
+
+        gen.writeObjectFieldStart("field");
+        if (isNamed) {
+            gen.writeObjectField("name",
+                    value.getName().values().stream().distinct().collect(Collectors.toList()));
+        }
+        for (var entry : value.getAddressParts().entrySet()) {
+            gen.writeObjectField(
+                    entry.getKey().getName(),
+                    entry.getValue().values().stream().distinct().collect(Collectors.toList()));
+        }
+        gen.writeEndObject(); // collector.field
+
+        gen.writeEndObject(); // collector
+
+        gen.writeEndObject();
     }
 
     private static void writeExtent(JsonGenerator gen, Envelope bbox) throws IOException {

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -20,7 +20,7 @@ public class SearchQueryBuilder {
     private TermsQuery.Builder layerQueryBuilder;
     private Query finalQuery = null;
 
-    public SearchQueryBuilder(String query, String language, String[] languages, boolean lenient) {
+    public SearchQueryBuilder(String query, boolean lenient) {
         var query4QueryBuilder = QueryBuilders.bool();
 
         // 1. All terms of the query must be contained in the place record somehow. Be more lenient on second try.
@@ -123,10 +123,10 @@ public class SearchQueryBuilder {
                         .field("collector.name")));
     }
 
-    public SearchQueryBuilder(StructuredSearchRequest request, String language, String[] languages, boolean lenient)
+    public SearchQueryBuilder(StructuredSearchRequest request, boolean lenient)
     {
         var hasSubStateField = request.hasCounty() || request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet();
-        var query4QueryBuilder = new AddressQueryBuilder(lenient, language, languages)
+        var query4QueryBuilder = new AddressQueryBuilder(lenient)
                 .addCountryCode(request.getCountryCode(), request.hasState() || hasSubStateField)
                 .addState(request.getState(), hasSubStateField)
                 .addCounty(request.getCounty(), request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -11,116 +11,155 @@ import org.opensearch.client.opensearch._types.query_dsl.*;
 import org.opensearch.client.util.ObjectBuilder;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class SearchQueryBuilder {
     private ObjectBuilder<Query> finalQueryWithoutTagFilterBuilder;
-    private final BoolQuery.Builder queryBuilderForTopLevelFilter;
+    private BoolQuery.Builder queryBuilderForTopLevelFilter;
     private OsmTagFilter osmTagFilter = new OsmTagFilter();
     private GeoBoundingBoxQuery.Builder bboxQueryBuilder;
     private TermsQuery.Builder layerQueryBuilder;
     private Query finalQuery = null;
 
     public SearchQueryBuilder(String query, boolean lenient) {
-        var query4QueryBuilder = QueryBuilders.bool();
-
-        // 1. All terms of the query must be contained in the place record somehow. Be more lenient on second try.
-        query4QueryBuilder.must(base -> base.match(q -> {
-            q.query(fn -> fn.stringValue(query));
-            q.field("collector.all.ngram");
-
-            if (lenient) {
-                q.fuzziness("AUTO");
-                q.prefixLength(2);
-                q.minimumShouldMatch("-34%");
-            } else {
-                q.operator(Operator.And);
-            }
-            return q;
-        }));
-
-        // 2. Prefer records that have the full names in. For address records with house numbers this is the main
-        //    filter criterion because they have no name. Boost the score in this case.
-        query4QueryBuilder.should(shd -> shd.functionScore(fs -> fs
-                .query(q -> q.match(m -> m
-                        .query(qs -> qs.stringValue(query))
-                        .field("collector.all")
-                        .fuzziness(lenient ? "AUTO" : "0")
-                        .prefixLength(2)
-
-                ))
-                .functions(fn -> fn
-                        .filter(flt -> flt
-                                .match(m -> m
-                                        .query(q -> q.stringValue(query))
-                                        .field("housenumber")))
-                        .weight(10.0)
-                )
-        ));
-
-        // 3. Either the name or house number must be in the query terms.
-        var nameNgramQuery = MatchQuery.of(q -> q
-                .query(qs -> qs.stringValue(query))
-                .field("collector.name")
-                .fuzziness(lenient ? "AUTO" : "0")
-                .prefixLength(2)
-                .boost(1f)
-        );
-
-        if (query.indexOf(',') < 0 && query.indexOf(' ') < 0) {
-            query4QueryBuilder.must(m -> m.match(q -> q
-                .query(qs -> qs.stringValue(query))
-                .field("collector.name.prefix")
-                .fuzziness(lenient ? "AUTO" : "0")
-                .prefixLength(2)
-                .boost(2f)
-            ));
+        if (query.length() < 4 || query.matches("^\\p{IsAlphabetic}+$")) {
+            setupShortQuery(query, lenient);
         } else {
-            query4QueryBuilder.must(m -> m.bool(q -> q
-                    .should(nameNgramQuery.toQuery())
-                    .should(shd1 -> shd1
-                            .match(m1 -> m1
-                                    .query(q1 -> q1.stringValue(query))
-                                    .field("housenumber")
-                                    .analyzer("standard")))
-                    .should(shd2 -> shd2
-                            .match(m2 -> m2
-                                    .query(q2 -> q2.stringValue(query))
-                                    .field("classification")
-                                    .boost(0.1f)))
-                    .minimumShouldMatch("1")
-            ));
+            setupFullQuery(query, lenient);
         }
+    }
 
-        // Weigh the resulting score by importance. Use a linear scale function that ensures that the weight
-        // never drops to 0 and cancels out the ES score.
+    public void setupShortQuery(String query, boolean lenient) {
+        final var queryField = FieldValue.of(f -> f.stringValue(query));
+
+        final var prefixMatch = MatchQuery.of(nmb -> nmb
+                                .query(queryField)
+                                .field("collector.name.prefix")
+                                .boost((query.length()) > 3 ? 0.5f : 0.8f));
+
         finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
-                .query(query4QueryBuilder.build().toQuery())
-                .functions(fn1 -> fn1
-                        .linear(df1 -> df1
-                                .field("importance")
-                                .placement(p1 -> p1
-                                        .origin(JsonData.of(1.0))
-                                        .scale(JsonData.of(0.6))
-                                        .decay(0.5))))
-                .functions(fn2 -> fn2
-                        .filter(flt -> flt
-                                .match(m -> m
-                                        .query(q -> q.stringValue(query))
-                                        .field("classification")))
-                        .weight(0.1))
+                .query(q -> q.bool(b -> {
+                    if (lenient) {
+                        b.must(prefixOrFullName -> prefixOrFullName.bool(bi -> bi
+                                .should(iq -> iq.match(prefixMatch))
+                                .should(iq2 -> iq2.match(nmb -> nmb
+                                        .query(queryField)
+                                        .field("collector.name")
+                                        .fuzziness("AUTO")
+                                        .prefixLength(2)
+                                        .boost(0.2f)))
+                        ));
+                    } else {
+                        b.must(iq -> iq.match(prefixMatch));
+                    }
+                    b.should(fullMatch -> fullMatch.match(fmb -> fmb
+                            .query(queryField)
+                            .field("collector.all")
+                            .boost((query.length()) > 3 ? 0.4f : 0.1f)));
+                    return b;
+                }))
+                .functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
+                        .field("importance")
+                        .factor(40.0)
+                        .missing(0.00001)
+                ))
+                .functions(demotePoi -> demotePoi
+                        .weight(0.2)
+                        .filter(fbool -> fbool.bool(c -> c
+                                .mustNot(fp -> fp.term(tp -> tp
+                                        .field(Constants.OBJECT_TYPE)
+                                        .value(FieldValue.of("other"))))))
+                )
                 .scoreMode(FunctionScoreMode.Sum)
+                .boostMode(FunctionBoostMode.Sum)
         );
+    }
 
-        // Filter for later: records that have a house number and no name must only appear when the house number matches.
-        queryBuilderForTopLevelFilter = QueryBuilders.bool()
-                .should(q1 -> q1.bool(qin -> qin
-                        .mustNot(mn -> mn.exists(ex -> ex.field("housenumber")))))
-                .should(q2 -> q2.match(m2 -> m2
-                        .query(iq -> iq.stringValue(query))
-                        .field("housenumber")
-                        .analyzer("standard")))
-                .should(q3 -> q3.exists(ex2 -> ex2
-                        .field("collector.name")));
+    public void setupFullQuery(String query, boolean lenient) {
+        final var queryField = FieldValue.of(f -> f.stringValue(query));
+        final boolean isAlphabetic = query.matches("[\\p{IsAlphabetic} ]+");
+        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
+                .query(coreQuery -> coreQuery.bool(coreBuilder -> {
+                    coreBuilder.must(fullMatch -> fullMatch.match(fmb -> {
+                        fmb.query(queryField);
+                        fmb.field("collector.all.ngram");
+                        fmb.boost(0.1f);
+
+                        if (lenient) {
+                            fmb.minimumShouldMatch("2<-1 6<-2");
+                            fmb.fuzziness("AUTO");
+                            fmb.prefixLength(2);
+                        } else {
+                            fmb.operator(Operator.And);
+                        }
+                        return fmb;
+                    }));
+                    coreBuilder.must(outer -> outer.disMax(outerb -> outerb
+                            .boost(0.2f)
+                            .queries(builder -> builder.match(q -> q
+                                    .query(queryField)
+                                    .field("collector.name")
+                                    .fuzziness(lenient ? "AUTO" : "0")
+                                    .prefixLength(2)
+                                    .boost(isAlphabetic ? 1.5f : 1.0f)
+                            ))
+                            .queries(builder -> builder.bool(b -> b
+                                    .must(hnrWeighted -> hnrWeighted
+                                            .functionScore(hnrFS -> hnrFS
+                                                    .boostMode(FunctionBoostMode.Multiply)
+                                                    .scoreMode(FunctionScoreMode.Sum)
+                                                    .query(hnr -> hnr
+                                                            .match(m1 -> m1
+                                                                    .query(queryField)
+                                                                    .boost(0.6f)
+                                                                    .field("housenumber")
+                                                            ))
+                                                    .functions(fullHnr -> fullHnr
+                                                            .weight(1.0)
+                                                            .filter(hmrExact -> hmrExact
+                                                                    .terms(t -> t
+                                                                            .field("housenumber.full")
+                                                                            .boost(2f)
+                                                                            .terms(tf -> tf.value(
+                                                                                    Arrays.stream(query.toLowerCase().split("[ ,;]+"))
+                                                                                            .map(s -> FieldValue.of(fv -> fv.stringValue(s)))
+                                                                                            .collect(Collectors.toList())
+                                                                            ))
+                                                                    )
+                                                            ))
+                                                    .functions(constFact -> constFact.weight(1.0))
+                                            ))
+                                    .must(parent -> parent
+                                            .match(m2 -> m2
+                                                    .query(queryField)
+                                                    .field("collector.parent")
+                                                    .fuzziness(lenient ? "AUTO" : "0")
+                                                    .prefixLength(2)
+                                            ))
+                            ))
+                    ));
+                    coreBuilder.should(fullWord -> fullWord.match(fwm -> fwm
+                            .query(queryField)
+                            .field("collector.all")
+                    ));
+                    if (!lenient && query.indexOf(',') < 0) {
+                        coreBuilder.should(prefixMatch -> prefixMatch.match(nmb -> nmb
+                                .query(queryField)
+                                .field("collector.name.prefix")
+                                .boost(isAlphabetic ? 0.1f : 0.01f)
+                        ));
+                    }
+
+                    return coreBuilder;
+                }))
+                .functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
+                        .field("importance")
+                        .factor(isAlphabetic ? 40.0 : 20.0)
+                        .missing(0.00001)
+                ))
+                .scoreMode(FunctionScoreMode.Sum)
+                .boostMode(FunctionBoostMode.Sum)
+        );
     }
 
     public SearchQueryBuilder(StructuredSearchRequest request, boolean lenient)

--- a/src/test/java/de/komoot/photon/api/ApiLanguagesTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiLanguagesTest.java
@@ -67,14 +67,4 @@ class ApiLanguagesTest extends ApiBaseTester {
                 .node("features").isArray()
                 .hasSize(2);
     }
-
-    @Test
-    void testUseCommandLineLanguages() throws Exception {
-        importPlaces("en", "fr", "ch");
-        startAPI("-languages", "en,fr");
-
-        assertThatJson(readURL("/api?q=thething")).isObject()
-                .node("features").isArray()
-                .hasSize(1);
-    }
 }

--- a/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
@@ -141,7 +141,7 @@ public class StructuredQueryTest extends ESBaseTester {
         request.setDistrict(HAMLET);
         request.setHouseNumber("2");
 
-        var queryHandler = getServer().createStructuredSearchHandler(new String[]{LANGUAGE}, 1);
+        var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
         assertEquals(1, results.size());
         var result = results.get(0);
@@ -154,7 +154,7 @@ public class StructuredQueryTest extends ESBaseTester {
         request.setCountryCode(COUNTRY_CODE);
         request.setCity(CITY);
         request.setStreet(STREET);
-        var queryHandler = getServer().createStructuredSearchHandler(new String[]{LANGUAGE}, 1);
+        var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
         for (var result : results)
         {
@@ -166,7 +166,7 @@ public class StructuredQueryTest extends ESBaseTester {
     void returnsOnlyCountryForCountryRequests() {
         var request = new StructuredSearchRequest();
         request.setCountryCode(COUNTRY_CODE);
-        var queryHandler = getServer().createStructuredSearchHandler(new String[]{LANGUAGE}, 1);
+        var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
         assertEquals(1, results.size());
         var result = results.get(0);
@@ -179,7 +179,7 @@ public class StructuredQueryTest extends ESBaseTester {
         request.setCountryCode(COUNTRY_CODE);
         request.setCity(CITY);
 
-        var queryHandler = getServer().createStructuredSearchHandler(new String[]{LANGUAGE}, 1);
+        var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
 
         for (var result : results) {
@@ -252,7 +252,7 @@ public class StructuredQueryTest extends ESBaseTester {
     }
 
     private PhotonResult search(StructuredSearchRequest request) {
-        var queryHandler = getServer().createStructuredSearchHandler(new String[]{LANGUAGE}, 1);
+        var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
 
         return results.get(0);

--- a/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryBasicSearchTest.java
@@ -41,7 +41,7 @@ class QueryBasicSearchTest extends ESBaseTester {
             request.setLanguage(lang);
         }
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private void assertWorking(SoftAssertions soft, String... queries) {

--- a/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByClassificationTest.java
@@ -37,7 +37,7 @@ class QueryByClassificationTest extends ESBaseTester {
         final var request = new SimpleSearchRequest();
         request.setQuery(query);
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private void updateClassification(String key, String value, String... terms) throws IOException {

--- a/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
@@ -46,7 +46,7 @@ class QueryByLanguageTest extends ESBaseTester {
         request.setQuery(query);
         request.setLanguage(lang);
 
-        return getServer().createSearchHandler(languageList, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryByLanguageTest.java
@@ -62,9 +62,6 @@ class QueryByLanguageTest extends ESBaseTester {
         assertThat(search("original", "en")).hasSize(1);
         assertThat(search("finish", "en")).hasSize(1);
         assertThat(search("russian", "en")).hasSize(0);
-
-        assertThat(search("finish", "fi").get(0).getScore())
-                .isGreaterThan(search("finish", "en").get(0).getScore());
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
@@ -48,7 +48,7 @@ class QueryFilterLayerTest extends ESBaseTester {
         request.setQuery("berlin");
         request.addLayerFilters(Arrays.stream(layers).collect(Collectors.toSet()));
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private List<PhotonResult> reverse(String... layers) {

--- a/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterTagValueTest.java
@@ -69,7 +69,7 @@ class QueryFilterTagValueTest extends ESBaseTester {
             request.addOsmTagFilter(TagFilter.buildOsmTagFilter(param));
         }
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private List<PhotonResult> reverseWithTags(String[] params) {

--- a/src/test/java/de/komoot/photon/query/QueryGeometryTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryGeometryTest.java
@@ -37,7 +37,7 @@ class QueryGeometryTest extends ESBaseTester {
         final var request = new SimpleSearchRequest();
         request.setQuery("muffle flu");
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
 

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -38,11 +38,11 @@ class QueryRelevanceTest extends ESBaseTester {
         final var request = new SimpleSearchRequest();
         request.setQuery(query);
 
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private List<PhotonResult> search(SimpleSearchRequest request) {
-        return getServer().createSearchHandler(new String[]{"en"}, 1).search(request);
+        return getServer().createSearchHandler(1).search(request);
     }
 
     private SimpleSearchRequest createBiasedRequest()


### PR DESCRIPTION
This is a major rewrite of the index and query structure, streamlining the necessary indexes and making use of features of the latest OpenSearch version.

### Custom collectors

The import code now creates its own name collections for the collector indexes instead of using the built-in copyTo functions. This allows us more fine-grained control on which terms end up in the index. It allows in particular to (ab)use the term frequency to boost the more important parts of an address (name, city). The analysers for this structure become a bit more involved: tokenization now effectively happens during token filtering, while the tokenizer only splits up the "document" into separate place names.

### Remove language-dependent indexes

The language-dependent index have caused a lot of head-ache and effectively prevented [using Photon with many languages](https://github.com/komoot/photon/issues/933). The effect of scoring by selected language is at the same time very low. Experience with Nominatim shows that it is usually sufficient to rerank results later according to the localized output. Alternatively we might look into storing the language in the [token payload](https://docs.opensearch.org/2.19/analyzers/token-filters/delimited-payload/) later. Needs some more research how the payload can be used efficiently. Documentation on that is rather sparse.

### Remove most statistic keeping

The usual statistics about token position, document length and term frequency are unfortunately useless for the use case of geocoding. That's because we are doing kind of the inverse of what full-text search is intended for: instead of searching for a short phrase in a database of large documents, we have a database of short phrases which we want to match up against one large document. This PR drops token position and document length for the most part and repurposes term frequency to give us a better score on the relevant parts of the address (see above). 

### Streamline mappings

We were keeping a lot of unnecessary indexes that OpenSearch would create automatically. For a large part of the data it is sufficient to keep it in the _source field. No extra mapping necessary.

### Query structure changes

Importance is now added to the overall score of the query instead of using it as a multiplicator. While OpenSearch's scores for matching the text are still all over the place, the relative differences seem to be fairly consistent. That makes the additive model a bit easier to handle.

Single-term queries are now handled separately from the rest: they will only search in the name collectors and have a much stronger bias on importance and prefix matching. 

Given that all this changes the structure of the query significantly, it probably will take a bit of times to get the weights on the different query parts right again.

---

With all these changes, a planet database comes now to around 80GB and queries are around 40% faster on average.

Fixes #933.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces language-specific indexes with collector-based mappings/analyzers, rewrites query/serialization to use collectors, updates handlers/tests accordingly, and bumps DB version.
> 
> - **Index & Mappings**:
>   - Introduce collector-based fields: `collector.all`, `collector.name`, `collector.parent`, and `collector.field.*` (e.g., `collector.field.name`, `collector.field.street`).
>   - Simplify mappings: drop language-dependent fields/copyTo; reduce to essential indexed fields; tweak `postcode` handling; remove `context` from source.
>   - Overhaul analyzers/filters/tokenizers for collectors (e.g., `index_fullword`, `index_ngram`, `index_name_ngram`, `index_name_prefix`, `search_prefix`).
> - **Serialization**:
>   - `PhotonDocSerializer`: build `collector` payloads using new `NameCollector`; encode priorities; populate `collector.field` lists; add parent/name/all collectors.
>   - `AddressType`: add `searchPrio` for prioritizing address parts.
> - **Query**:
>   - `SearchQueryBuilder`: major rewrite to target collector fields; separate short vs full queries; additive importance via `field_value_factor`; demote non-POI types; remove language scoring.
>   - `AddressQueryBuilder`: remove language-specific logic; query against `collector.field.*`.
> - **API/Server**:
>   - Remove language arrays from `createSearchHandler`/`createStructuredSearchHandler` and related call sites.
>   - `Server.recreateIndex`: stop adding languages to mappings; bump `DATABASE_VERSION` to `1.0.0-2`.
> - **Tests**:
>   - Update to new handler signatures and mappings; remove command-line language selection test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa290dd4cd210ad7ff00e6cdb6e309f359592e5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->