### PR TITLE
Reorganise and streamline query code

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/BaseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/BaseQueryBuilder.java
@@ -1,0 +1,39 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.searcher.TagFilter;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provides the basic query structure as well as functions to
+ * add sub-queries for the common query parameters.
+ */
+public class BaseQueryBuilder {
+    protected final BoolQuery.Builder outerQuery = new BoolQuery.Builder();
+
+    public Query build() {
+        return outerQuery.build().toQuery();
+    }
+
+    public void addOsmTagFilter(List<TagFilter> filters) {
+        if (!filters.isEmpty()) {
+            outerQuery.filter(new OsmTagFilter().withOsmTagFilters(filters).build());
+        }
+    }
+
+    public void addLayerFilter(Collection<String> layers) {
+        if (!layers.isEmpty()) {
+            outerQuery.filter(f -> f.terms(t -> t
+                    .field("type")
+                    .terms(tm -> tm.value(
+                            layers.stream().map(FieldValue::of).collect(Collectors.toList())
+                    ))
+            ));
+        }
+    }
+}

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -26,10 +26,10 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
         final int limit = request.getLimit();
         final int extLimit = limit > 1 ? (int) Math.round(limit * 1.5) : 1;
 
-        var results = sendQuery(buildQuery(request, false).buildQuery(), extLimit);
+        var results = sendQuery(buildQuery(request, false), extLimit);
 
         if (results.hits().hits().isEmpty()) {
-            results = sendQuery(buildQuery(request, true).buildQuery(), extLimit);
+            results = sendQuery(buildQuery(request, true), extLimit);
         }
 
         List<PhotonResult> ret = new ArrayList<>();
@@ -45,12 +45,14 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
         return "{}";
     }
 
-    private SearchQueryBuilder buildQuery(SimpleSearchRequest request, boolean lenient) {
-        return new SearchQueryBuilder(request.getQuery(), lenient).
-                withOsmTagFilters(request.getOsmTagFilters()).
-                withLayerFilters(request.getLayerFilters()).
-                withLocationBias(request.getLocationForBias(), request.getScaleForBias(), request.getZoomForBias()).
-                withBoundingBox(request.getBbox());
+    private Query buildQuery(SimpleSearchRequest request, boolean lenient) {
+        final var query = new SearchQueryBuilder(request.getQuery(), lenient);
+        query.addOsmTagFilter(request.getOsmTagFilters());
+        query.addLayerFilter(request.getLayerFilters());
+        query.addLocationBias(request.getLocationForBias(), request.getScaleForBias(), request.getZoomForBias());
+        query.addBoundingBox(request.getBbox());
+
+        return query.build();
     }
 
     private SearchResponse<OpenSearchResult> sendQuery(Query query, int limit) {

--- a/src/main/java/de/komoot/photon/opensearch/ReverseQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/ReverseQueryBuilder.java
@@ -1,71 +1,22 @@
 package de.komoot.photon.opensearch;
 
-import de.komoot.photon.searcher.TagFilter;
 import org.locationtech.jts.geom.Point;
-import org.opensearch.client.opensearch._types.FieldValue;
-import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+public class ReverseQueryBuilder extends BaseQueryBuilder {
 
-public class ReverseQueryBuilder {
-    private final double radius;
-    private final Point location;
-    private final String queryStringFilter;
-    private final Set<String> layerFilter;
-
-    private final OsmTagFilter osmTagFilter = new OsmTagFilter();
-
-    public ReverseQueryBuilder(Point location, double radius, String queryStringFilter, Set<String> layerFilter) {
-        this.radius = radius;
-        this.location = location;
-        this.queryStringFilter = queryStringFilter != null && queryStringFilter.trim().length() > 0 ? queryStringFilter.trim() : null;
-        this.layerFilter = layerFilter;
-    }
-
-   public Query buildQuery() {
-        return BoolQuery.of(q -> {
-            q.filter(fq -> fq
+    public ReverseQueryBuilder(Point location, double radius) {
+        outerQuery.filter(fq -> fq
                     .geoDistance(gd -> gd
                             .field("coordinate")
                             .location(l -> l.latlon(ll -> ll.lat(location.getY()).lon(location.getX())))
                             .distance(radius + "km")));
-
-            boolean hasQuery = false;
-
-            if (queryStringFilter != null) {
-                q.must(qst -> qst.queryString(qs -> qs.query(queryStringFilter)));
-                hasQuery = true;
-            }
-
-            if (!layerFilter.isEmpty()) {
-                q.must(ftq -> ftq.terms(tq -> {
-                    List<FieldValue> terms = new ArrayList<>();
-                    for (var filter : layerFilter) {
-                        terms.add(FieldValue.of(filter));
-                    }
-                    return tq.field("type").terms(tt -> tt.value(terms));
-                }));
-                hasQuery = true;
-            }
-
-            if (!hasQuery) {
-                q.must(mq -> mq.matchAll(ma -> ma));
-            }
-
-            final var tagFilters = osmTagFilter.build();
-            if (tagFilters != null) {
-                q.filter(tagFilters);
-            }
-
-            return q;
-        }).toQuery();
     }
 
-    public ReverseQueryBuilder withOsmTagFilters(List<TagFilter> filters) {
-        osmTagFilter.withOsmTagFilters(filters);
-        return this;
+    public void addQueryFilter(String query) {
+        if (query != null && !query.isEmpty()) {
+            outerQuery.must(qst -> qst.queryString(qs -> qs
+                    .query(query)
+            ));
+        }
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -1,6 +1,5 @@
 package de.komoot.photon.opensearch;
 
-import de.komoot.photon.searcher.TagFilter;
 import de.komoot.photon.query.StructuredSearchRequest;
 import de.komoot.photon.Constants;
 import org.locationtech.jts.geom.Envelope;
@@ -8,164 +7,154 @@ import org.locationtech.jts.geom.Point;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.*;
-import org.opensearch.client.util.ObjectBuilder;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class SearchQueryBuilder {
-    private ObjectBuilder<Query> finalQueryWithoutTagFilterBuilder;
-    private BoolQuery.Builder queryBuilderForTopLevelFilter;
-    private OsmTagFilter osmTagFilter = new OsmTagFilter();
-    private GeoBoundingBoxQuery.Builder bboxQueryBuilder;
-    private TermsQuery.Builder layerQueryBuilder;
-    private Query finalQuery = null;
+public class SearchQueryBuilder extends BaseQueryBuilder {
+    public FunctionScoreQuery.Builder innerQuery = new FunctionScoreQuery.Builder();
+    double importance_factor = 40.0;
 
     public SearchQueryBuilder(String query, boolean lenient) {
         if (query.length() < 4 || query.matches("^\\p{IsAlphabetic}+$")) {
-            setupShortQuery(query, lenient);
+            importance_factor = setupShortQuery(query, lenient);
         } else {
-            setupFullQuery(query, lenient);
+            importance_factor = setupFullQuery(query, lenient);
         }
+
+        innerQuery.functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
+                        .field("importance")
+                        .factor(importance_factor)
+                        .missing(0.00001)))
+                .scoreMode(FunctionScoreMode.Sum)
+                .boostMode(FunctionBoostMode.Sum);
     }
 
-    public void setupShortQuery(String query, boolean lenient) {
+    public double setupShortQuery(String query, boolean lenient) {
         final var queryField = FieldValue.of(f -> f.stringValue(query));
 
         final var prefixMatch = MatchQuery.of(nmb -> nmb
-                                .query(queryField)
-                                .field("collector.name.prefix")
-                                .boost((query.length()) > 3 ? 0.5f : 0.8f));
+                .query(queryField)
+                .field("collector.name.prefix")
+                .boost((query.length()) > 3 ? 0.5f : 0.8f));
 
-        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
-                .query(q -> q.bool(b -> {
-                    if (lenient) {
-                        b.must(prefixOrFullName -> prefixOrFullName.bool(bi -> bi
-                                .should(iq -> iq.match(prefixMatch))
-                                .should(iq2 -> iq2.match(nmb -> nmb
-                                        .query(queryField)
-                                        .field("collector.name")
-                                        .fuzziness("AUTO")
-                                        .prefixLength(2)
-                                        .boost(0.2f)))
-                        ));
-                    } else {
-                        b.must(iq -> iq.match(prefixMatch));
-                    }
-                    b.should(fullMatch -> fullMatch.match(fmb -> fmb
-                            .query(queryField)
-                            .field("collector.all")
-                            .boost((query.length()) > 3 ? 0.4f : 0.1f)));
-                    return b;
-                }))
-                .functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
-                        .field("importance")
-                        .factor(40.0)
-                        .missing(0.00001)
-                ))
-                .functions(demotePoi -> demotePoi
-                        .weight(0.2)
-                        .filter(fbool -> fbool.bool(c -> c
-                                .mustNot(fp -> fp.term(tp -> tp
-                                        .field(Constants.OBJECT_TYPE)
-                                        .value(FieldValue.of("other"))))))
-                )
-                .scoreMode(FunctionScoreMode.Sum)
-                .boostMode(FunctionBoostMode.Sum)
+        innerQuery.query(q -> q.bool(b -> {
+            if (lenient) {
+                b.must(prefixOrFullName -> prefixOrFullName.bool(bi -> bi
+                        .should(iq -> iq.match(prefixMatch))
+                        .should(iq2 -> iq2.match(nmb -> nmb
+                                .query(queryField)
+                                .field("collector.name")
+                                .fuzziness("AUTO")
+                                .prefixLength(2)
+                                .boost(0.2f)))
+                ));
+            } else {
+                b.must(iq -> iq.match(prefixMatch));
+            }
+            b.should(fullMatch -> fullMatch.match(fmb -> fmb
+                    .query(queryField)
+                    .field("collector.all")
+                    .boost((query.length()) > 3 ? 0.4f : 0.1f)));
+            return b;
+        }));
+
+        innerQuery.functions(demotePoi -> demotePoi
+                .weight(0.2)
+                .filter(fbool -> fbool.bool(c -> c
+                        .mustNot(fp -> fp.term(tp -> tp
+                                .field(Constants.OBJECT_TYPE)
+                                .value(FieldValue.of("other"))))))
         );
+
+        return 40.0;
     }
 
-    public void setupFullQuery(String query, boolean lenient) {
+    public double setupFullQuery(String query, boolean lenient) {
         final var queryField = FieldValue.of(f -> f.stringValue(query));
         final boolean isAlphabetic = query.matches("[\\p{IsAlphabetic} ]+");
-        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
-                .query(coreQuery -> coreQuery.bool(coreBuilder -> {
-                    coreBuilder.must(fullMatch -> fullMatch.match(fmb -> {
-                        fmb.query(queryField);
-                        fmb.field("collector.all.ngram");
-                        fmb.boost(0.1f);
 
-                        if (lenient) {
-                            fmb.minimumShouldMatch("2<-1 6<-2");
-                            fmb.fuzziness("AUTO");
-                            fmb.prefixLength(2);
-                        } else {
-                            fmb.operator(Operator.And);
-                        }
-                        return fmb;
-                    }));
-                    coreBuilder.must(outer -> outer.disMax(outerb -> outerb
-                            .boost(0.2f)
-                            .queries(builder -> builder.match(q -> q
-                                    .query(queryField)
-                                    .field("collector.name")
-                                    .fuzziness(lenient ? "AUTO" : "0")
-                                    .prefixLength(2)
-                                    .boost(isAlphabetic ? 1.5f : 1.0f)
-                            ))
-                            .queries(builder -> builder.bool(b -> b
-                                    .must(hnrWeighted -> hnrWeighted
-                                            .functionScore(hnrFS -> hnrFS
-                                                    .boostMode(FunctionBoostMode.Multiply)
-                                                    .scoreMode(FunctionScoreMode.Sum)
-                                                    .query(hnr -> hnr
-                                                            .match(m1 -> m1
-                                                                    .query(queryField)
-                                                                    .boost(0.6f)
-                                                                    .field("housenumber")
-                                                            ))
-                                                    .functions(fullHnr -> fullHnr
-                                                            .weight(1.0)
-                                                            .filter(hmrExact -> hmrExact
-                                                                    .terms(t -> t
-                                                                            .field("housenumber.full")
-                                                                            .boost(2f)
-                                                                            .terms(tf -> tf.value(
-                                                                                    Arrays.stream(query.toLowerCase().split("[ ,;]+"))
-                                                                                            .map(s -> FieldValue.of(fv -> fv.stringValue(s)))
-                                                                                            .collect(Collectors.toList())
-                                                                            ))
-                                                                    )
-                                                            ))
-                                                    .functions(constFact -> constFact.weight(1.0))
-                                            ))
-                                    .must(parent -> parent
-                                            .match(m2 -> m2
-                                                    .query(queryField)
-                                                    .field("collector.parent")
-                                                    .fuzziness(lenient ? "AUTO" : "0")
-                                                    .prefixLength(2)
-                                            ))
-                            ))
-                    ));
-                    coreBuilder.should(fullWord -> fullWord.match(fwm -> fwm
+        innerQuery.query(coreQuery -> coreQuery.bool(coreBuilder -> {
+            coreBuilder.must(fullMatch -> fullMatch.match(fmb -> {
+                fmb.query(queryField);
+                fmb.field("collector.all.ngram");
+                fmb.boost(0.1f);
+
+                if (lenient) {
+                    fmb.minimumShouldMatch("2<-1 6<-2");
+                    fmb.fuzziness("AUTO");
+                    fmb.prefixLength(2);
+                } else {
+                    fmb.operator(Operator.And);
+                }
+                return fmb;
+            }));
+            coreBuilder.must(outer -> outer.disMax(outerb -> outerb
+                    .boost(0.2f)
+                    .queries(builder -> builder.match(q -> q
                             .query(queryField)
-                            .field("collector.all")
-                    ));
-                    if (!lenient && query.indexOf(',') < 0) {
-                        coreBuilder.should(prefixMatch -> prefixMatch.match(nmb -> nmb
-                                .query(queryField)
-                                .field("collector.name.prefix")
-                                .boost(isAlphabetic ? 0.1f : 0.01f)
-                        ));
-                    }
+                            .field("collector.name")
+                            .fuzziness(lenient ? "AUTO" : "0")
+                            .prefixLength(2)
+                            .boost(isAlphabetic ? 1.5f : 1.0f)
+                    ))
+                    .queries(builder -> builder.bool(b -> b
+                            .must(hnrWeighted -> hnrWeighted
+                                    .functionScore(hnrFS -> hnrFS
+                                            .boostMode(FunctionBoostMode.Multiply)
+                                            .scoreMode(FunctionScoreMode.Sum)
+                                            .query(hnr -> hnr
+                                                    .match(m1 -> m1
+                                                            .query(queryField)
+                                                            .boost(0.6f)
+                                                            .field("housenumber")
+                                                    ))
+                                            .functions(fullHnr -> fullHnr
+                                                    .weight(1.0)
+                                                    .filter(hmrExact -> hmrExact
+                                                            .terms(t -> t
+                                                                    .field("housenumber.full")
+                                                                    .boost(2f)
+                                                                    .terms(tf -> tf.value(
+                                                                            Arrays.stream(query.toLowerCase().split("[ ,;]+"))
+                                                                                    .map(s -> FieldValue.of(fv -> fv.stringValue(s)))
+                                                                                    .collect(Collectors.toList())
+                                                                    ))
+                                                            )
+                                                    ))
+                                            .functions(constFact -> constFact.weight(1.0))
+                                    ))
+                            .must(parent -> parent
+                                    .match(m2 -> m2
+                                            .query(queryField)
+                                            .field("collector.parent")
+                                            .fuzziness(lenient ? "AUTO" : "0")
+                                            .prefixLength(2)
+                                    ))
+                    ))
+            ));
+            coreBuilder.should(fullWord -> fullWord.match(fwm -> fwm
+                    .query(queryField)
+                    .field("collector.all")
+            ));
+            if (!lenient && query.indexOf(',') < 0) {
+                coreBuilder.should(prefixMatch -> prefixMatch.match(nmb -> nmb
+                        .query(queryField)
+                        .field("collector.name.prefix")
+                        .boost(isAlphabetic ? 0.1f : 0.01f)
+                ));
+            }
 
-                    return coreBuilder;
-                }))
-                .functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
-                        .field("importance")
-                        .factor(isAlphabetic ? 40.0 : 20.0)
-                        .missing(0.00001)
-                ))
-                .scoreMode(FunctionScoreMode.Sum)
-                .boostMode(FunctionBoostMode.Sum)
-        );
+            return coreBuilder;
+        }));
+
+        return isAlphabetic ? 40.0 : 20.0;
     }
 
-    public SearchQueryBuilder(StructuredSearchRequest request, boolean lenient)
-    {
+    public SearchQueryBuilder(StructuredSearchRequest request, boolean lenient) {
         var hasSubStateField = request.hasCounty() || request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet();
-        var query4QueryBuilder = new AddressQueryBuilder(lenient)
+
+        innerQuery.query(new AddressQueryBuilder(lenient)
                 .addCountryCode(request.getCountryCode(), request.hasState() || hasSubStateField)
                 .addState(request.getState(), hasSubStateField)
                 .addCounty(request.getCounty(), request.hasCityOrPostCode() || request.hasDistrict() || request.hasStreet())
@@ -173,128 +162,65 @@ public class SearchQueryBuilder {
                 .addPostalCode(request.getPostCode())
                 .addDistrict(request.getDistrict(), request.hasStreet())
                 .addStreetAndHouseNumber(request.getStreet(), request.getHouseNumber())
-                .getQuery();
-
-        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
-                .query(query4QueryBuilder)
-                .functions(fn1 -> fn1
-                        .linear(df1 -> df1
-                                .field("importance")
-                                .placement(p1 -> p1
-                                        .origin(JsonData.of(1.0))
-                                        .scale(JsonData.of(1.0))
-                                        .decay(0.5))))
-                .scoreMode(FunctionScoreMode.Sum));
+                .getQuery());
 
         var hasHouseNumberQuery = QueryBuilders.exists().field(Constants.HOUSENUMBER).build().toQuery();
         var isHouseQuery = QueryBuilders.term().field(Constants.OBJECT_TYPE).value(FieldValue.of("house")).build().toQuery();
         var typeOtherQuery = QueryBuilders.term().field(Constants.OBJECT_TYPE).value(FieldValue.of("other")).build().toQuery();
-        if (!request.hasHouseNumber())
-        {
-            queryBuilderForTopLevelFilter = QueryBuilders.bool().mustNot(hasHouseNumberQuery)
+
+        if (!request.hasHouseNumber()) {
+            outerQuery.filter(fn -> fn.bool(b -> b
+                    .mustNot(hasHouseNumberQuery)
                     .mustNot(isHouseQuery)
-                    .mustNot(typeOtherQuery);
-        }
-        else {
+                    .mustNot(typeOtherQuery)
+            ));
+        } else {
             var noHouseOrHouseNumber = QueryBuilders.bool().should(hasHouseNumberQuery)
                     .should(QueryBuilders.bool().mustNot(isHouseQuery).build().toQuery())
                     .build()
                     .toQuery();
-            queryBuilderForTopLevelFilter = QueryBuilders.bool().must(noHouseOrHouseNumber)
-                    .mustNot(typeOtherQuery);
-        }
 
-        osmTagFilter = new OsmTagFilter();
+            outerQuery.filter(fn -> fn.bool(b -> b
+                    .must(noHouseOrHouseNumber)
+                    .mustNot(typeOtherQuery)
+            ));
+        }
     }
 
-    public SearchQueryBuilder withLocationBias(Point point, double scale, int zoom) {
-        if (point == null || zoom < 4) return this;
+    public void addLocationBias(Point point, double scale, int zoom) {
+        if (point == null || zoom < 4) return;
 
         if (zoom > 18) {
             zoom = 18;
         }
         double radius = (1 << (18 - zoom)) * 0.25;
-        final double fnscale = (scale <= 0.0) ? 0.0000001 : scale;
+        final double fnscale = Double.min(1.0, Double.max(0.0, scale));
 
-        Map<String, Object> params = new HashMap<>();
-        params.put("lon", point.getX());
-        params.put("lat", point.getY());
-
-        finalQueryWithoutTagFilterBuilder = new Query.Builder().functionScore(fs -> fs
-                .query(finalQueryWithoutTagFilterBuilder.build())
-                .functions(fn1 -> fn1.exp(ex -> ex
+        innerQuery.functions(fn1 -> fn1
+                .weight(38.0 * (1.0 - fnscale))
+                .exp(ex -> ex
                         .field("coordinate")
                         .placement(p -> p
-                                .origin(JsonData.of(params))
+                                .origin(JsonData.of(Map.of("lon", point.getX(), "lat", point.getY())))
                                 .decay(0.8)
                                 .offset(JsonData.of(radius / 10 + "km"))
-                                .scale(JsonData.of(radius + "km")))))
-                .functions(fn2 -> fn2.linear(lin -> lin
-                        .field("importance")
-                        .placement(p -> p.origin(JsonData.of(1.0)).scale(JsonData.of(fnscale)).decay(0.5))))
-                .boostMode(FunctionBoostMode.Multiply)
-                .scoreMode(FunctionScoreMode.Max)
-        );
-
-        return this;
+                                .scale(JsonData.of(radius + "km")))));
     }
 
-    public SearchQueryBuilder withBoundingBox(Envelope bbox) {
+    public void addBoundingBox(Envelope bbox) {
         if (bbox != null) {
-            bboxQueryBuilder = QueryBuilders.geoBoundingBox()
+            outerQuery.filter(q -> q.geoBoundingBox(bb -> bb
                     .field("coordinate")
                     .boundingBox(b -> b.coords(c -> c
                             .top(bbox.getMaxY())
                             .bottom(bbox.getMinY())
                             .left(bbox.getMinX())
-                            .right(bbox.getMaxX())));
+                            .right(bbox.getMaxX())))
+            ));
         }
-
-        return this;
     }
 
-    public SearchQueryBuilder withOsmTagFilters(List<TagFilter> filters) {
-        osmTagFilter.withOsmTagFilters(filters);
-        return this;
-    }
-
-    public SearchQueryBuilder withLayerFilters(Set<String> filters) {
-        if (!filters.isEmpty()) {
-            List<FieldValue> terms = new ArrayList<>();
-            for (var filter : filters) {
-                terms.add(FieldValue.of(filter));
-            }
-            layerQueryBuilder = QueryBuilders.terms().field("type").terms(t -> t.value(terms));
-        }
-
-        return this;
-    }
-
-    public Query buildQuery() {
-        if (finalQuery == null) {
-            finalQuery = BoolQuery.of(q -> {
-                q.must(finalQueryWithoutTagFilterBuilder.build());
-                if (queryBuilderForTopLevelFilter != null) {
-                    q.filter(queryBuilderForTopLevelFilter.build().toQuery());
-                }
-
-                final var tagFilters = osmTagFilter.build();
-                if (tagFilters != null) {
-                    q.filter(tagFilters);
-                }
-
-                if (bboxQueryBuilder != null) {
-                    q.filter(bboxQueryBuilder.build().toQuery());
-                }
-
-                if (layerQueryBuilder != null) {
-                    q.filter(layerQueryBuilder.build().toQuery());
-                }
-
-                return q;
-            }).toQuery();
-        }
-
-        return finalQuery;
+    public Query build() {
+        return outerQuery.must(innerQuery.build().toQuery()).build().toQuery();
     }
 }


### PR DESCRIPTION
This moves common code between the reverse and search endpoints into a common base class BaseQueryBuilder.

To do so, we need to generalise the query structure a bit: there is now one core BoolQuery which will be executed and to which the different functions may add musts, shoulds and filters as required.

Also requires to change how location bias works: this will now also add to the score like importance. This may or may not improve the usability of the parameter. It's really hard to test how it comes out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared BaseQueryBuilder, refactors search/reverse builders and handlers to a unified BoolQuery + function-score model, revises location-bias scoring, and adds tests for scale behavior.
> 
> - **Query Architecture**:
>   - **Base**: Add `BaseQueryBuilder` with shared `BoolQuery` (`outerQuery`) and helpers: `addOsmTagFilter`, `addLayerFilter`, `build`.
>   - **Search**: Refactor `SearchQueryBuilder` to extend base; consolidate inner function-score query, set importance factor dynamically, move bbox/layer/tag filters to outer `BoolQuery`; change location-bias to additive scoring with weighted `exp` decay.
>   - **Reverse**: Refactor `ReverseQueryBuilder` to extend base; constructor simplified to `(Point, radius)`; add `addQueryFilter`; layer/tag filters now via base.
> - **Handlers**:
>   - Update `OpenSearchSearchHandler`, `OpenSearchStructuredSearchHandler`, and `OpenSearchReverseHandler` to use new builder API (`add*` methods, `build()`), and streamline result mapping.
> - **Tests**:
>   - Add parameterized tests in `QueryRelevanceTest` verifying location preference trade-off based on `scale` for importance vs. location bias.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8015daaa02b1590ce9b4896bef3a906e63d33571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->