### PR TITLE
Harden JSON import and streamline format

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -35,7 +35,7 @@ public class PhotonDoc {
             Map.entry(AddressType.OTHER, "quarter")
             );
 
-    private long placeId = -1;
+    private Long placeId = null;
     private String osmType = null;
     private long osmId = -1;
     private String tagKey = "place";
@@ -319,7 +319,7 @@ public class PhotonDoc {
         }
     }
 
-    public long getPlaceId() {
+    public Long getPlaceId() {
         return this.placeId;
     }
 

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -48,7 +48,6 @@ public class PhotonDoc {
     private double importance = 0;
     private String countryCode = null;
     private int rankAddress = 30;
-    private Integer adminLevel = null;
 
     private Map<AddressType, Map<String, String>> addressParts = new EnumMap<>(AddressType.class);
     private ContextMap context = new ContextMap();
@@ -81,7 +80,6 @@ public class PhotonDoc {
         this.countryCode = other.countryCode;
         this.centroid = other.centroid;
         this.rankAddress = other.rankAddress;
-        this.adminLevel = other.adminLevel;
         this.addressParts = other.addressParts;
         this.context = other.context;
         this.geometry = other.geometry;
@@ -172,11 +170,6 @@ public class PhotonDoc {
 
     public PhotonDoc rankAddress(int rank) {
         this.rankAddress = rank;
-        return this;
-    }
-
-    public PhotonDoc adminLevel(int level) {
-        this.adminLevel = (level < 1 || level >= 15) ? null : level;
         return this;
     }
 
@@ -358,10 +351,6 @@ public class PhotonDoc {
 
     public int getRankAddress() {
         return this.rankAddress;
-    }
-
-    public Integer getAdminLevel() {
-        return this.adminLevel;
     }
 
     public Map<AddressType, Map<String, String>> getAddressParts() {

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -38,8 +38,8 @@ public class PhotonDoc {
     private long placeId = -1;
     private String osmType = null;
     private long osmId = -1;
-    private String tagKey = null;
-    private String tagValue = null;
+    private String tagKey = "place";
+    private String tagValue = "yes";
 
     private NameMap name = new NameMap();
     private String postcode = null;

--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -45,7 +45,6 @@ public class PhotonDoc {
     private String postcode = null;
     private Map<String, String> extratags = Map.of();
     private Envelope bbox = null;
-    private long parentPlaceId = 0; // 0 if unset
     private double importance = 0;
     private String countryCode = null;
     private int rankAddress = 30;
@@ -78,7 +77,6 @@ public class PhotonDoc {
         this.postcode = other.postcode;
         this.extratags = other.extratags;
         this.bbox = other.bbox;
-        this.parentPlaceId = other.parentPlaceId;
         this.importance = other.importance;
         this.countryCode = other.countryCode;
         this.centroid = other.centroid;
@@ -163,11 +161,6 @@ public class PhotonDoc {
             }
         }
 
-        return this;
-    }
-
-    public PhotonDoc parentPlaceId(long parentPlaceId) {
-        this.parentPlaceId = parentPlaceId;
         return this;
     }
 
@@ -355,10 +348,6 @@ public class PhotonDoc {
         return this.bbox;
     }
 
-    public long getParentPlaceId() {
-        return this.parentPlaceId;
-    }
-
     public double getImportance() {
         return this.importance;
     }
@@ -407,7 +396,6 @@ public class PhotonDoc {
                 ", postcode='" + postcode + '\'' +
                 ", extratags=" + extratags +
                 ", bbox=" + bbox +
-                ", parentPlaceId=" + parentPlaceId +
                 ", importance=" + importance +
                 ", countryCode='" + countryCode + '\'' +
                 ", rankAddress=" + rankAddress +

--- a/src/main/java/de/komoot/photon/json/DumpFields.java
+++ b/src/main/java/de/komoot/photon/json/DumpFields.java
@@ -18,7 +18,6 @@ public class DumpFields {
     public static final String PLACE_OBJECT_ID = "object_id";
     public static final String PLACE_CATEGORIES = "categories";
     public static final String PLACE_RANK_ADDRESS = "rank_address";
-    public static final String PLACE_ADMIN_LEVEL = "admin_level";
     public static final String PLACE_IMPORTANCE = "importance";
     public static final String PLACE_NAMES = "name";
     public static final String PLACE_HOUSENUMBER = "housenumber";

--- a/src/main/java/de/komoot/photon/json/DumpFields.java
+++ b/src/main/java/de/komoot/photon/json/DumpFields.java
@@ -20,7 +20,6 @@ public class DumpFields {
     public static final String PLACE_RANK_ADDRESS = "rank_address";
     public static final String PLACE_ADMIN_LEVEL = "admin_level";
     public static final String PLACE_IMPORTANCE = "importance";
-    public static final String PLACE_PARENT_PLACE_ID = "parent_place_id";
     public static final String PLACE_NAMES = "name";
     public static final String PLACE_HOUSENUMBER = "housenumber";
     public static final String PLACE_ADDRESS = "address";

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -126,10 +126,6 @@ public class JsonDumper implements Importer {
 
         writer.writeNumberField(DumpFields.PLACE_IMPORTANCE, doc.getImportance());
 
-        if (doc.getRankAddress() > 28) {
-            writer.writeNumberField(DumpFields.PLACE_PARENT_PLACE_ID, doc.getParentPlaceId());
-        }
-
         if (!doc.getName().isEmpty()) {
             writer.writeObjectFieldStart(DumpFields.PLACE_NAMES);
             for (var entry : doc.getName().entrySet()) {

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -108,7 +108,9 @@ public class JsonDumper implements Importer {
 
     public void writeNominatimDocument(PhotonDoc doc) throws IOException {
         writer.writeStartObject();
-        writer.writeNumberField(DumpFields.PLACE_ID, doc.getPlaceId());
+        if (doc.getPlaceId() != null) {
+            writer.writeNumberField(DumpFields.PLACE_ID, doc.getPlaceId());
+        }
         writer.writeStringField(DumpFields.PLACE_OBJECT_TYPE, doc.getOsmType());
         writer.writeNumberField(DumpFields.PLACE_OBJECT_ID, doc.getOsmId());
 

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -120,10 +120,6 @@ public class JsonDumper implements Importer {
 
         writer.writeNumberField(DumpFields.PLACE_RANK_ADDRESS, doc.getRankAddress());
 
-        if (doc.getAdminLevel() != null) {
-            writer.writeNumberField(DumpFields.PLACE_ADMIN_LEVEL, doc.getAdminLevel());
-        }
-
         writer.writeNumberField(DumpFields.PLACE_IMPORTANCE, doc.getImportance());
 
         if (!doc.getName().isEmpty()) {

--- a/src/main/java/de/komoot/photon/json/JsonReader.java
+++ b/src/main/java/de/komoot/photon/json/JsonReader.java
@@ -124,7 +124,7 @@ public class JsonReader {
                         addressCache.clear();
                         currentCountry = cc;
                     }
-                    if (hasAddressLines) {
+                    if (hasAddressLines && parseDoc.getPlaceId() != null) {
                         var row = parseDoc.asAddressRow(languages);
                         if (row != null) {
                             addressCache.put(parseDoc.getPlaceId(), row);

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -113,13 +113,6 @@ public class NominatimPlaceDocument {
         }
     }
 
-    @JsonProperty(DumpFields.PLACE_ADMIN_LEVEL)
-    void setAdminLevel(Integer adminLevel) {
-        if (adminLevel != null) {
-            doc.adminLevel(adminLevel);
-        }
-    }
-
     @JsonProperty(DumpFields.PLACE_IMPORTANCE)
     void setImportance(Double importance) {
         if (importance != null && !importance.isNaN() && !importance.isInfinite()) {

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -72,8 +72,10 @@ public class NominatimPlaceDocument {
     }
 
     @JsonProperty(DumpFields.PLACE_ID)
-    void setPlaceId(long placeId) {
-        doc.placeId(placeId);
+    void setPlaceId(Long placeId) {
+        if (placeId != null) {
+            doc.placeId(placeId);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_OBJECT_TYPE)
@@ -82,18 +84,22 @@ public class NominatimPlaceDocument {
     }
 
     @JsonProperty(DumpFields.PLACE_OBJECT_ID)
-    void setOsmId(long osmId) {
-        doc.osmId(osmId);
+    void setOsmId(Long osmId) {
+        if (osmId != null) {
+            doc.osmId(osmId);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_CATEGORIES)
-    void setCategories(String[] categories) {
-        for (var cat : categories) {
-            if (cat.startsWith("osm.")) {
-                String[] parts = cat.split("\\.");
-                doc.tagKey(parts[1]);
-                doc.tagValue(parts.length > 2 ? parts[2] : "yes");
-                return;
+    void setCategories(List<String> categories) {
+        if (categories != null) {
+            for (var cat : categories) {
+                if (cat != null && cat.startsWith("osm.")) {
+                    String[] parts = cat.split("\\.");
+                    doc.tagKey(parts[1]);
+                    doc.tagValue(parts.length > 2 ? parts[2] : "yes");
+                    return;
+                }
             }
         }
         doc.tagKey("place");
@@ -101,26 +107,38 @@ public class NominatimPlaceDocument {
     }
 
     @JsonProperty(DumpFields.PLACE_RANK_ADDRESS)
-    void setRankAddress(int rankAddress) {
-        doc.rankAddress(rankAddress);
+    void setRankAddress(Integer rankAddress) {
+        if (rankAddress != null) {
+            doc.rankAddress(rankAddress);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_ADMIN_LEVEL)
-    void setAdminLevel(int adminLevel) { doc.adminLevel(adminLevel); }
+    void setAdminLevel(Integer adminLevel) {
+        if (adminLevel != null) {
+            doc.adminLevel(adminLevel);
+        }
+    }
 
     @JsonProperty(DumpFields.PLACE_IMPORTANCE)
-    void setImportance(double importance) {
-        doc.importance(importance);
+    void setImportance(Double importance) {
+        if (importance != null && !importance.isNaN() && !importance.isInfinite()) {
+            doc.importance(importance);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_PARENT_PLACE_ID)
-    void setParentPlaceId(long parentPlaceId) {
-        doc.parentPlaceId(parentPlaceId);
+    void setParentPlaceId(Long parentPlaceId) {
+        if (parentPlaceId != null) {
+            doc.parentPlaceId(parentPlaceId);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_NAMES)
     void setNames(Map<String, String> names) {
-        this.names = names;
+        if (names != null) {
+            this.names = names;
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_HOUSENUMBER)
@@ -130,12 +148,17 @@ public class NominatimPlaceDocument {
 
     @JsonProperty(DumpFields.PLACE_ADDRESS)
     void setAddress(Map<String, String> address) {
-        this.address = address;
+        if (address != null) {
+            this.address = address;
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_EXTRA_TAGS)
     void setExtratags(Map<String, String> extratags) {
-        doc.extraTags(extratags);
+        if (extratags != null) {
+            extratags.values().removeIf(Objects::isNull);
+            doc.extraTags(extratags);
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_POSTCODE)
@@ -149,34 +172,42 @@ public class NominatimPlaceDocument {
     }
 
     @JsonProperty(DumpFields.PLACE_CENTROID)
-    void setCentroid(double[] coordinates) throws IOException {
-        if (coordinates.length != 2) {
-            throw new IOException("Invalid centroid. Must be an array of two doubles.");
+    void setCentroid(Double[] coordinates) throws IOException {
+        if (coordinates != null) {
+            if (coordinates.length != 2 || coordinates[0] == null || coordinates[1] == null) {
+                throw new IOException("Invalid centroid. Must be an array of two doubles.");
+            }
+            doc.centroid(factory.createPoint(new Coordinate(coordinates[0], coordinates[1])));
         }
-        doc.centroid(factory.createPoint(new Coordinate(coordinates[0], coordinates[1])));
     }
 
     @JsonProperty(DumpFields.PLACE_BBOX)
-    void setBbox(double[] coordinates) throws IOException {
-        if (coordinates.length != 4) {
-            throw new IOException("Invalid bbox. Must be an array of four doubles.");
+    void setBbox(Double[] coordinates) throws IOException {
+        if (coordinates != null) {
+            if (coordinates.length != 4 || Arrays.stream(coordinates).anyMatch(Objects::isNull)) {
+                throw new IOException("Invalid bbox. Must be an array of four doubles.");
+            }
+            doc.bbox(factory.createMultiPoint(new Point[]{
+                    factory.createPoint(new Coordinate(coordinates[0], coordinates[1])),
+                    factory.createPoint(new Coordinate(coordinates[2], coordinates[3]))
+            }));
         }
-        doc.bbox(factory.createMultiPoint(new Point[]{
-                factory.createPoint(new Coordinate(coordinates[0], coordinates[1])),
-                factory.createPoint(new Coordinate(coordinates[2], coordinates[3]))
-        }));
     }
 
     @JsonProperty(DumpFields.PLACE_GEOMETRY)
     void setGeometry(JsonNode geojson) throws ParseException {
-        final var geometry = jsonReader.read(geojson.toString());
-        doc.geometry(geometry);
-        doc.bbox(geometry.getEnvelope());
+        if (geojson != null) {
+            final var geometry = jsonReader.read(geojson.toString());
+            doc.geometry(geometry);
+            doc.bbox(geometry.getEnvelope());
+        }
     }
 
     @JsonProperty(DumpFields.PLACE_ADDRESSLINES)
     void setAddressLines(AddressLine[] addressLines) {
-        this.addressLines = addressLines;
+        if (addressLines != null) {
+            this.addressLines = addressLines;
+        }
     }
 
     public void completeAddressLines(Map<Long, AddressRow> addressCache) {

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -127,13 +127,6 @@ public class NominatimPlaceDocument {
         }
     }
 
-    @JsonProperty(DumpFields.PLACE_PARENT_PLACE_ID)
-    void setParentPlaceId(Long parentPlaceId) {
-        if (parentPlaceId != null) {
-            doc.parentPlaceId(parentPlaceId);
-        }
-    }
-
     @JsonProperty(DumpFields.PLACE_NAMES)
     void setNames(Map<String, String> names) {
         if (names != null) {

--- a/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
@@ -14,13 +14,12 @@ public class OsmlineRowMapper implements RowMapper<PhotonDoc> {
                 rs.getLong("place_id"),
                 "W", rs.getLong("osm_id"),
                 "place", "house_number")
-                .parentPlaceId(rs.getLong("parent_place_id"))
                 .countryCode(rs.getString("country_code"))
                 .postcode(rs.getString("postcode"));
     }
 
     public String makeBaseQuery(DBDataAdapter dbutils) {
-        return "SELECT p.place_id, p.osm_id, p.parent_place_id, p.startnumber, p.endnumber," +
+        return "SELECT p.place_id, p.osm_id, p.startnumber, p.endnumber," +
                 "      p.postcode, p.country_code, p.address, p.linegeo, p.step," +
                 "      parent.class as parent_class, parent.type as parent_type," +
                 "      parent.rank_address as parent_rank_address, parent.name as parent_name, " +

--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -33,7 +33,6 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
                 .names(NameMap.makeForPlace(dbutils.getMap(rs, "name"), languages))
                 .extraTags(dbutils.getMap(rs, "extratags"))
                 .bbox(dbutils.extractGeometry(rs, "bbox"))
-                .parentPlaceId(rs.getLong("parent_place_id"))
                 .countryCode(rs.getString("country_code"))
                 .centroid(dbutils.extractGeometry(rs, "centroid"))
                 .rankAddress(rs.getInt("rank_address"))
@@ -60,7 +59,7 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
 
     public String makeBaseSelect() {
         var sql = "SELECT p.place_id, p.osm_type, p.osm_id, p.class, p.type, p.name, p.postcode, p.admin_level," +
-                "       p.address, p.extratags, ST_Envelope(p.geometry) AS bbox, p.parent_place_id," +
+                "       p.address, p.extratags, ST_Envelope(p.geometry) AS bbox," +
                 "       p.rank_address, p.rank_search, p.importance, p.country_code, p.centroid, " +
                 dbutils.jsonArrayFromSelect(
                         "address_place_id",

--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -38,11 +38,6 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
                 .rankAddress(rs.getInt("rank_address"))
                 .postcode(rs.getString("postcode"));
 
-        final var admin_level = rs.getInt("admin_level");
-        if (admin_level > 0 && admin_level < 15) {
-            doc.adminLevel(admin_level);
-        }
-
         if (useGeometryColumn) {
             try {
                 doc.geometry(dbutils.extractGeometry(rs, "geometry"));
@@ -58,7 +53,7 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
     }
 
     public String makeBaseSelect() {
-        var sql = "SELECT p.place_id, p.osm_type, p.osm_id, p.class, p.type, p.name, p.postcode, p.admin_level," +
+        var sql = "SELECT p.place_id, p.osm_type, p.osm_id, p.class, p.type, p.name, p.postcode," +
                 "       p.address, p.extratags, ST_Envelope(p.geometry) AS bbox," +
                 "       p.rank_address, p.rank_search, p.importance, p.country_code, p.centroid, " +
                 dbutils.jsonArrayFromSelect(

--- a/src/main/java/de/komoot/photon/opensearch/Updater.java
+++ b/src/main/java/de/komoot/photon/opensearch/Updater.java
@@ -20,12 +20,15 @@ public class Updater implements de.komoot.photon.Updater {
     }
 
     public void addOrUpdate(Iterable<PhotonDoc> docs) {
-        long placeID = 0;
+        Long placeID = null;
         int objectId = 0;
 
         for (var doc: docs) {
             if (objectId == 0) {
                 placeID = doc.getPlaceId();
+                if (placeID == null) {
+                    throw new RuntimeException("Documents without place_id cannot be used for updates.");
+                }
             }
             final String uid = PhotonDoc.makeUid(placeID, objectId++);
 
@@ -37,7 +40,9 @@ public class Updater implements de.komoot.photon.Updater {
             }
         }
 
-        deleteSubset(placeID, objectId);
+        if (placeID != null) {
+            deleteSubset(placeID, objectId);
+        }
     }
 
     public void delete(long placeId) {

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -11,6 +11,7 @@ import org.locationtech.jts.io.WKTReader;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -65,6 +66,8 @@ public class ESBaseTester {
     protected PhotonResult getById(String id) {
         return server.getByID(id);
     }
+
+    protected List<PhotonResult> getAll() { return server.getAll(); }
 
     public void setUpES(Path dataDirectory) throws IOException {
         server = new TestServer(dataDirectory.toString());

--- a/src/test/java/de/komoot/photon/TestServer.java
+++ b/src/test/java/de/komoot/photon/TestServer.java
@@ -7,6 +7,8 @@ import org.codelibs.opensearch.runner.OpenSearchRunner;
 import org.opensearch.common.settings.Settings;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class TestServer extends Server {
     public static final String TEST_CLUSTER_NAME = "photon-test";
@@ -82,5 +84,19 @@ public class TestServer extends Server {
         }
 
         return null;
+    }
+
+    public List<PhotonResult> getAll() {
+        try {
+            final var response = client.search(s -> s.size(1000), OpenSearchResult.class);
+
+            return response.hits().hits()
+                    .stream().map(h -> h.source())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            //ignore
+        }
+
+        return List.of();
     }
 }

--- a/src/test/java/de/komoot/photon/json/JsonDumperTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonDumperTest.java
@@ -101,7 +101,6 @@ class JsonDumperTest {
                 .rankSearch(27)
                 .rankAddress(26)
                 .importance(0.123)
-                .adminLevel(10)
                 .country("hu")
                 .name("Spot")
                 .name("ref", "34")
@@ -121,7 +120,6 @@ class JsonDumperTest {
                 .containsEntry("categories", List.of("osm.highway.residential"))
                 .containsEntry("rank_address", 26)
                 .containsEntry("importance", 0.123)
-                .containsEntry("admin_level", 10)
                 .containsEntry("country_code", "hu")
                 .doesNotContainKeys("parent_place_id", "postcode", "extra")
                 .containsEntry("name", Map.of(

--- a/src/test/java/de/komoot/photon/json/JsonDumperTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonDumperTest.java
@@ -234,7 +234,6 @@ class JsonDumperTest {
         assertThat(results).hasSize(1);
 
         assertThatPlaceDocument(results, place.getPlaceId())
-                .containsEntry("parent_place_id", 0)
                 .doesNotContainKey("geometry")
                 .node("centroid").isEqualTo("[10.1, -3.45]");
 

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -77,7 +77,6 @@ class JsonReaderTest {
                 .hasFieldOrPropertyWithValue("postcode", null)
                 .hasFieldOrPropertyWithValue("extratags", Map.of())
                 .hasFieldOrPropertyWithValue("bbox", new Envelope(9.5461636, 9.556083, 47.2415541, 47.2966235))
-                .hasFieldOrPropertyWithValue("parentPlaceId", 0L)
                 .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                 .hasFieldOrPropertyWithValue("countryCode", "AT")
                 .hasFieldOrPropertyWithValue("rankAddress", 0)
@@ -108,7 +107,6 @@ class JsonReaderTest {
                         .hasFieldOrPropertyWithValue("postcode", null)
                         .hasFieldOrPropertyWithValue("extratags", Map.of())
                         .hasFieldOrPropertyWithValue("bbox", new Envelope(9.5461636, 9.556083, 47.2415541, 47.2966235))
-                        .hasFieldOrPropertyWithValue("parentPlaceId", 0L)
                         .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                         .hasFieldOrPropertyWithValue("countryCode", "AT")
                         .hasFieldOrPropertyWithValue("rankAddress", 0)
@@ -317,24 +315,6 @@ class JsonReaderTest {
 
         assertThat(importer).singleElement()
                 .hasFieldOrPropertyWithValue("importance", 0.0);
-    }
-
-    @Test
-    void testValidParentPlace() throws IOException {
-        input.println(TEST_SIMPLE_STREAM.replace("\"rank_search\" : 22", "\"parent_place_id\" : 123"));
-        var importer = readJson();
-
-        assertThat(importer).singleElement()
-                .hasFieldOrPropertyWithValue("parentPlaceId", 123L);
-    }
-
-    @Test
-    void testNullParentPlaceIgnored() throws IOException {
-        input.println(TEST_SIMPLE_STREAM.replace("\"rank_search\" : 22", "\"parent_place_id\" : null"));
-        var importer = readJson();
-
-        assertThat(importer).singleElement()
-                .hasFieldOrPropertyWithValue("parentPlaceId", 0L);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -222,7 +222,7 @@ class JsonReaderTest {
 
     @Test
     void testAddressFromAddressField() throws IOException {
-        input.println("{\"type\":\"Place\",\"content\":{\"place_id\" : 105764, \"object_type\" : \"N\", \"object_id\" : 4637485890, \"categories\" : [\"osm.amenity.theatre\"], \"rank_address\" : 30, \"rank_search\" : 30, \"importance\" : 9.99999999995449e-06,\"parent_place_id\":106180,\"name\":{\"name\": \"Kleintheater Schlösslekeller\"},\"address\":{\"city\": \"Vaduz\", \"city:de\": \"VaduzD\", \"city:hu\": \"VaduzHU\", \"other1\": \"This\", \"other2\": \"That\", \"other1:de\": \"Dies\", \"other2:de\": \"Das\"},\"postcode\":\"9490\",\"country_code\":\"li\",\"addresslines\":[{\"place_id\":106180,\"rank_address\":26,\"fromarea\":false,\"isaddress\":true},{\"place_id\":105903,\"rank_address\":16,\"isaddress\":true,\"fromarea\":true}, {\"place_id\":106289,\"rank_address\":12,\"isaddress\":true,\"fromarea\":true}],\"centroid\":[9.52394930,47.12904370]}}");
+        input.println("{\"type\":\"Place\",\"content\":{\"place_id\" : 105764, \"object_type\" : \"N\", \"object_id\" : 4637485890, \"categories\" : [\"osm.amenity.theatre\"], \"rank_address\" : 30, \"rank_search\" : 30, \"importance\" : 9.99999999995449e-06,\"parent_place_id\":106180,\"name\":{\"name\": \"Kleintheater Schlösslekeller\"},\"address\":{\"city\": \"Vaduz\", \"city:de\": \"VaduzD\", \"city:hu\": \"VaduzHU\", \"other1\": \"This\", \"other2\": \"That\", \"other1:de\": \"Dies\", \"other2:de\": \"Das\", \"other3\": null},\"postcode\":\"9490\",\"country_code\":\"li\",\"addresslines\":[{\"place_id\":106180,\"rank_address\":26,\"fromarea\":false,\"isaddress\":true},{\"place_id\":105903,\"rank_address\":16,\"isaddress\":true,\"fromarea\":true}, {\"place_id\":106289,\"rank_address\":12,\"isaddress\":true,\"fromarea\":true}],\"centroid\":[9.52394930,47.12904370]}}");
 
         var importer = readJson();
 
@@ -260,5 +260,133 @@ class JsonReaderTest {
 
         assertThat(reader.getImportDate()).hasSameTimeAs("2021-01-06T15:53:42+00:00");
 
+    }
+
+    @Test
+    void testNullPlaceIdIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("100818", "null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("placeId", -1L);
+    }
+
+    @Test
+    void testOmitOsmTypeId() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"object_type\":\"W\",\"object_id\":223306798,", ""));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("osmType", null)
+                .hasFieldOrPropertyWithValue("osmId", -1L);
+    }
+
+    @Test
+    void testNullCategories() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("[\"osm.waterway.stream\"]", "null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("tagKey", "place")
+                .hasFieldOrPropertyWithValue("tagValue", "yes");
+    }
+
+    @Test
+    void testNullCategory() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("[\"osm.waterway.stream\"]", "[null, \"osm.waterway.stream\"]"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("tagKey", "waterway")
+                .hasFieldOrPropertyWithValue("tagValue", "stream");
+    }
+
+    @Test
+    void testNullRankAddressIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"rank_address\" : 0", "\"rank_address\" : null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("rankAddress", 30);
+    }
+
+    @Test
+    void testNullImportanceIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("0.10667666666666664", "null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("importance", 0.0);
+    }
+
+    @Test
+    void testValidParentPlace() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"rank_search\" : 22", "\"parent_place_id\" : 123"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("parentPlaceId", 123L);
+    }
+
+    @Test
+    void testNullParentPlaceIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"rank_search\" : 22", "\"parent_place_id\" : null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("parentPlaceId", 0L);
+    }
+
+    @Test
+    void testNullNamesIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("{\"name\": \"Spiersbach\", \"name:de\": \"Spiersbach\", \"alt_name\": \"Spirsbach\"}", "null,\"housenumber\": \"1\""));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("name", Map.of())
+                .hasFieldOrPropertyWithValue("houseNumber", "1");
+    }
+
+    @Test
+    void testNullInNamesIgnored() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"Spirsbach\"", "null"));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("name", Map.of("default", "Spiersbach", "de", "Spiersbach"));
+    }
+
+    @Test
+    void testNullAddressIgnored() throws IOException {
+        input.println("{\"type\":\"Place\",\"content\":{\"place_id\" : 105764, \"object_type\" : \"N\", \"object_id\" : 4637485890, \"categories\" : [\"osm.amenity.theatre\"], \"rank_address\" : 30, \"rank_search\" : 30, \"importance\" : 9.99999999995449e-06,\"parent_place_id\":106180,\"name\":{\"name\": \"Kleintheater Schlösslekeller\"},\"address\":null,\"postcode\":\"9490\",\"country_code\":\"li\",\"addresslines\":[{\"place_id\":106180,\"rank_address\":26,\"fromarea\":false,\"isaddress\":true},{\"place_id\":105903,\"rank_address\":16,\"isaddress\":true,\"fromarea\":true}, {\"place_id\":106289,\"rank_address\":12,\"isaddress\":true,\"fromarea\":true}],\"centroid\":[9.52394930,47.12904370]}}");
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("addressParts", Map.of())
+                .hasFieldOrPropertyWithValue("context", Map.of());
+
+    }
+
+    @Test
+    void testNullExtraIgnored() throws IOException {
+        configExtraTags = new ConfigExtraTags(List.of("ALL"));
+        input.println(TEST_SIMPLE_STREAM.replace("{\"boat\": \"no\"}", "null"));
+
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("extratags", Map.of());
+    }
+
+
+    @Test
+    void testNullInExtraIgnored() throws IOException {
+        configExtraTags = new ConfigExtraTags(List.of("ALL"));
+        input.println(TEST_SIMPLE_STREAM.replace("\"boat\": \"no\"", "\"access\": \"yes\", \"foot\": null"));
+
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("extratags", Map.of("access", "yes"));
     }
 }

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -80,7 +80,6 @@ class JsonReaderTest {
                 .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                 .hasFieldOrPropertyWithValue("countryCode", "AT")
                 .hasFieldOrPropertyWithValue("rankAddress", 0)
-                .hasFieldOrPropertyWithValue("adminLevel", null)
                 .hasFieldOrPropertyWithValue("houseNumber", null)
                 .hasFieldOrPropertyWithValue("centroid", geomFactory.createPoint(new Coordinate(9.53713454, 47.27052526)))
                 .hasFieldOrPropertyWithValue("geometry", null);
@@ -110,7 +109,6 @@ class JsonReaderTest {
                         .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                         .hasFieldOrPropertyWithValue("countryCode", "AT")
                         .hasFieldOrPropertyWithValue("rankAddress", 0)
-                        .hasFieldOrPropertyWithValue("adminLevel", null)
                         .hasFieldOrPropertyWithValue("houseNumber", null)
                         .hasFieldOrPropertyWithValue("addressParts", Map.of())
                         .hasFieldOrPropertyWithValue("centroid", geomFactory.createPoint(new Coordinate(9.53713454, 47.27052526)))

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -268,7 +268,7 @@ class JsonReaderTest {
         var importer = readJson();
 
         assertThat(importer).singleElement()
-                .hasFieldOrPropertyWithValue("placeId", -1L);
+                .hasFieldOrPropertyWithValue("placeId", null);
     }
 
     @Test

--- a/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/CollectingImporter.java
@@ -55,13 +55,13 @@ public class CollectingImporter extends AbstractList<PhotonDoc> implements Impor
     }
 
     public ListAssert<PhotonDoc> assertThatAllByRow(OsmlineTestRow row) {
-        return assertThat(docs.stream().filter(d -> d.getPlaceId() == row.getPlaceId()))
+        return assertThat(docs.stream().filter(d -> d.getPlaceId().equals(row.getPlaceId())))
                 .isNotEmpty()
                 .allSatisfy(row::assertEquals);
     }
 
     public ListAssert<PhotonDoc> assertThatAllByRow(PlacexTestRow row) {
-        return assertThat(docs.stream().filter(d -> d.getPlaceId() == row.getPlaceId()))
+        return assertThat(docs.stream().filter(d -> d.getPlaceId().equals(row.getPlaceId())))
                 .isNotEmpty()
                 .allSatisfy(row::assertEquals);
     }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -18,7 +18,6 @@ public class PlacexTestRow {
     private Long parentPlaceId;
     private String osmType = "N";
     private Long osmId;
-    private Integer adminLevel;
     private String key;
     private String value;
     private Map<String, String> names = new HashMap<>();
@@ -94,11 +93,6 @@ public class PlacexTestRow {
         return this;
     }
 
-    public PlacexTestRow adminLevel(int value) {
-        adminLevel = value;
-        return this;
-    }
-
     public PlacexTestRow addr(String type, String value) {
         address.put(type, value);
         return this;
@@ -143,12 +137,12 @@ public class PlacexTestRow {
     public PlacexTestRow add(JdbcTemplate jdbc) {
         jdbc.update(
                 "INSERT INTO placex (place_id, parent_place_id, osm_type, osm_id,"
-                        + " class, type, rank_search, rank_address, admin_level,"
+                        + " class, type, rank_search, rank_address,"
                         + " centroid, geometry, name, extratags, country_code,"
                         + " importance, address, postcode, indexed_status)"
-                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ? FORMAT JSON, ?, ?, ? FORMAT JSON, ?, 0)",
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ? FORMAT JSON, ?, ?, ? FORMAT JSON, ?, 0)",
                 placeId, parentPlaceId, osmType, osmId,
-                key, value, rankSearch, rankAddress, adminLevel,
+                key, value, rankSearch, rankAddress,
                 centroid, geometry, asJson(names), asJson(extraTags), countryCode,
                 importance, asJson(address), postcode);
         return this;


### PR DESCRIPTION
With this change almost all fields in an JSON import file can be safely left out. You only need to make sure that either a housenumber or a name is present, otherwise Photon will silently drop the record.

Fields may also be set to `null` which now has the same effect as leaving out the field completely.

The fields `parent_place_id` and `admin_level` are now completely ignored by Photon and can safely be dropped. They are a left-over from copying all of Nominatim's data but are not needed by Photon anymore.

`place_id` can now be left our as well. OpenSearch can create its own unique ID for the document if needed. Just be aware that updating the data is not possible without the explicit place_id.

Switched the import from using `index()` to using `create()`, so that Photon now spits out a warning when multiple documents with the same place_id are imported. Only the first document imported will be kept.