### PR TITLE
support json output directly from Nominatim dump, without database

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -124,16 +124,19 @@ public class App {
         final var dbProps = args.getDatabaseProperties();
 
         try {
-            final var connector = new NominatimImporter(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword(), dbProps);
-            dbProps.setImportDate(connector.getLastImportDate());
-
             final String filename = args.getJsonDump();
             final JsonDumper jsonDumper = new JsonDumper(filename, dbProps);
-            jsonDumper.writeHeader(connector.loadCountryNames(dbProps.getLanguages()));
-
             final var importThread = new ImportThread(jsonDumper);
+
             try {
-                importFromDatabase(args, importThread, dbProps);
+                if (args.getImportFile() == null) {
+                    final var connector = new NominatimImporter(args.getHost(), args.getPort(), args.getDatabase(), args.getUser(), args.getPassword(), dbProps);
+                    dbProps.setImportDate(connector.getLastImportDate());
+                    jsonDumper.writeHeader(connector.loadCountryNames(dbProps.getLanguages()));
+                    importFromDatabase(args, importThread, dbProps);
+                } else {
+                    importFromFile(args, importThread);
+                }
             } finally {
                 importThread.finish();
             }

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -114,6 +114,8 @@ public class JsonDumper implements Importer {
         writer.writeStringField(DumpFields.PLACE_OBJECT_TYPE, doc.getOsmType());
         writer.writeNumberField(DumpFields.PLACE_OBJECT_ID, doc.getOsmId());
 
+        final var addressType = doc.getAddressType();
+        writer.writeStringField(Constants.OBJECT_TYPE, addressType == null ? "other" : addressType.getName());
         writer.writeStringField(DumpFields.PLACE_OSM_KEY, doc.getTagKey());
         writer.writeStringField(DumpFields.PLACE_OSM_VALUE, doc.getTagValue());
         writer.writeObjectField(DumpFields.PLACE_CATEGORIES,doc.getCategories());


### PR DESCRIPTION
When dumping to JSON, support loading the data from a Nominatim dump instead of the database.

The goal of this change is to preprocess the JSON data dumps available from Graphhopper before importing in Komoot search service.

- [ ] Update README with new `-json <output filename> -input-file <nominatim dump filename>`
- [ ] Separate PR for adding the address type to the output