### PR TITLE
Add Micrometer+Prometheus metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
     implementation 'org.locationtech.jts:jts-core:1.20.0'
     implementation 'org.locationtech.jts.io:jts-io-common:1.20.0'
     implementation 'io.javalin:javalin:6.7.0'
+    implementation 'io.javalin:javalin-micrometer:6.7.0'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.14.5'
     implementation 'net.postgis:postgis-jdbc:2025.1.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
 

--- a/src/main/java/de/komoot/photon/CommandLineArgs.java
+++ b/src/main/java/de/komoot/photon/CommandLineArgs.java
@@ -85,7 +85,7 @@ public class CommandLineArgs {
 
     @Parameter(names = "-cors-any", description = "Enable cross-site resource sharing for any origin.")
     private boolean corsAnyOrigin = false;
-    
+
     @Parameter(names = "-cors-origin", description = "Comma-separated list of origins for which to enable cross-site resource sharing.")
     private List<String> corsOrigin = new ArrayList<>();
 
@@ -103,6 +103,9 @@ public class CommandLineArgs {
 
     @Parameter(names = "-import-geometry-column", description = "[import-only] Add the 'geometry' column from Nominatim on import (i.e. add Polygons/Linestrings/Multipolygons etc. for cities, countries etc.). WARNING: This will increase the Elasticsearch Index size! (~575GB for Planet)")
     private boolean importGeometryColumn = false;
+
+    @Parameter(names = {"-metrics-enable"}, description = "Set to 'prometheus' to enable built-in Prometheus metrics endpoint")
+    private String metricsEnable = "";
 
     public String[] getLanguages(boolean useDefaultIfEmpty) {
         if (useDefaultIfEmpty && languages.isEmpty()) {
@@ -228,6 +231,10 @@ public class CommandLineArgs {
 
     public boolean getImportGeometryColumn() {
         return importGeometryColumn;
+    }
+
+    public String getMetricsEnable() {
+        return metricsEnable;
     }
 
     public DatabaseProperties getDatabaseProperties() {

--- a/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
+++ b/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
@@ -1,0 +1,79 @@
+package de.komoot.photon.metrics;
+
+import de.komoot.photon.CommandLineArgs;
+import io.javalin.micrometer.MicrometerPlugin;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.DiskSpaceMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+public class MetricsConfig {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private MicrometerPlugin micrometerPlugin;
+    private PrometheusMeterRegistry registry;
+    private final String path = "/metrics";
+
+    private MetricsConfig() {
+    }
+
+    private void init() {
+        registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        registry.config().commonTags("application", "Photon");
+        registerJvmMetrics(registry);
+        micrometerPlugin = new MicrometerPlugin(micrometerPluginConfig -> micrometerPluginConfig.registry = registry);
+        LOGGER.info("Metrics enabled at " + path);
+    }
+
+    private void registerJvmMetrics(MeterRegistry registry) {
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+    }
+
+    @NotNull
+    public MicrometerPlugin getPlugin() {
+        if (micrometerPlugin == null) {
+            throw new IllegalStateException("MetricsConfig not initialized.");
+        }
+        return micrometerPlugin;
+    }
+
+    @NotNull
+    public PrometheusMeterRegistry getRegistry() {
+        if (registry == null) {
+            throw new IllegalStateException("PrometheusMeterRegistry not initialized.");
+        }
+        return registry;
+    }
+
+    @NotNull
+    public String getPath() {
+        return path;
+    }
+
+    public boolean isEnabled() {
+        return registry != null && micrometerPlugin != null;
+    }
+
+    @NotNull
+    public static MetricsConfig setupMetrics(CommandLineArgs args) {
+        MetricsConfig metricsConfig = new MetricsConfig();
+        if (args.getMetricsEnable() != null && args.getMetricsEnable().equalsIgnoreCase("prometheus")) {
+            metricsConfig.init();
+        }
+        return metricsConfig;
+    }
+}

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.FieldSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * API tests that check queries against an already running ES instance and
@@ -59,7 +61,7 @@ class ApiIntegrationTest extends ApiBaseTester {
 
         instance.finish();
         refresh();
-        startAPI();
+        startAPI("-metrics-enable", "prometheus");
     }
 
     @AfterAll
@@ -73,7 +75,7 @@ class ApiIntegrationTest extends ApiBaseTester {
 
     @ParameterizedTest
     @FieldSource("BASE_URLS")
-    void testBogus(String baseUrl)  {
+    void testBogus(String baseUrl) {
         assertHttpError(baseUrl + "&bogus=thing", 400);
     }
 
@@ -163,7 +165,7 @@ class ApiIntegrationTest extends ApiBaseTester {
 
     @ParameterizedTest
     @FieldSource("BASE_URLS")
-    void testBadLimitParameter(String baseUrl)  {
+    void testBadLimitParameter(String baseUrl) {
         assertHttpError(baseUrl + "&limit=NaN", 400);
     }
 
@@ -328,7 +330,7 @@ class ApiIntegrationTest extends ApiBaseTester {
             "lat=52.54714&lon=180.01", "lat=90.01&lon=13.39026",
             "lat=52.54714&lon=-180.01", "lat=-90.01&lon=13.39026"
     })
-    void testSearchBadLocation(String param)  {
+    void testSearchBadLocation(String param) {
         assertHttpError("/api?q=berlin&" + param, 400);
     }
 
@@ -348,6 +350,11 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ValueSource(strings = {"bad", "NaN"})
     void testSearchBadLocationBiasScale(String param) {
         assertHttpError("/api?q=berlin&lat=52.54714&lon=13.39026&location_bias_scale=" + param, 400);
+    }
+
+    @Test
+    void testMetricsEndpoint() throws IOException {
+        assertEquals(200, connect("/metrics").getResponseCode());
     }
 }
 

--- a/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
+++ b/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
@@ -1,0 +1,39 @@
+package de.komoot.photon.metrics;
+
+import de.komoot.photon.CommandLineArgs;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetricsConfigTest {
+    @Test
+    void testInit() {
+        CommandLineArgs args = new CommandLineArgs() {
+            @Override
+            public String getMetricsEnable() {
+                return "prometheus";
+            }
+        };
+
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args);
+        assertNotNull(metricsConfig.getRegistry());
+        assertNotNull(metricsConfig.getPlugin());
+        assertTrue(metricsConfig.isEnabled());
+    }
+
+    @Test
+    void testNoInit() {
+        CommandLineArgs args = new CommandLineArgs() {
+            @Override
+            public String getMetricsEnable() {
+                return "";
+            }
+        };
+
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args);
+        assertThrows(IllegalStateException.class, metricsConfig::getRegistry);
+        assertThrows(IllegalStateException.class, metricsConfig::getPlugin);
+        assertFalse(metricsConfig.isEnabled());
+    }
+
+}


### PR DESCRIPTION
I hope and believe there is an argument to be made for adding Micrometer+Prometheus in Photon.

I've tried just adding the [Prometheus JMX Exporter](https://prometheus.github.io/jmx_exporter/) but it lacks sorely in things like request and latency metrics.

Other related projects, such as [OpenTripPlanner](https://github.com/search?q=repo%3Aentur%2FOpenTripPlanner%20prometheus&type=code)  also uses the same stack for metrics.

This PR utilizes javalin's own micrometer support and strives to be as nonintrusive as possible.