### PR TITLE
Add ProcessorMetrics

### DIFF
--- a/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
+++ b/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
@@ -7,7 +7,6 @@ import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
-import io.micrometer.core.instrument.binder.system.DiskSpaceMetrics;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
@@ -16,8 +15,6 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.File;
 
 public class MetricsConfig {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -38,9 +35,12 @@ public class MetricsConfig {
 
     private void registerJvmMetrics(MeterRegistry registry) {
         new ClassLoaderMetrics().bindTo(registry);
-        new JvmMemoryMetrics().bindTo(registry);
+        new FileDescriptorMetrics().bindTo(registry);
         new JvmGcMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
         new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new UptimeMetrics().bindTo(registry);
     }
 
     @NotNull


### PR DESCRIPTION
We rely on CPU metrics from all our other services, so I guess it makes sense here as well.

Ref #962