### PR TITLE
More future proof dependency version override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ repositories {
 
 dependencies {
     constraints {
-        implementation('commons-io:commons-io:2.20.0') {
+        implementation('commons-io:commons-io') {
+            version { require('[2.20.0,)') }
             because 'force latest version to fix CVE-2024-47554'
         }
     }


### PR DESCRIPTION
This way the override won't downgrade from e.g. 2.21.0