### PR TITLE
Add OpenSearch metrics

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -320,7 +320,7 @@ public class App {
                          Support Geometries: {}""",
                 dbProperties.getLanguages(), dbProperties.getImportDate(), dbProperties.getSupportGeometries());
 
-        MetricsConfig metrics = setupMetrics(args);
+        MetricsConfig metrics = setupMetrics(args, server.getClient());
 
         photonServer = Javalin.create(config -> {
             config.router.ignoreTrailingSlashes = true;

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -17,6 +17,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -215,6 +216,11 @@ public class Server {
 
     public SearchHandler<ReverseRequest> createReverseHandler(int queryTimeoutSec) {
         return new OpenSearchReverseHandler(client, queryTimeoutSec);
+    }
+
+    @NotNull
+    protected OpenSearchClient getClient() {
+        return client;
     }
 
     private void registerPhotonDocSerializer(DatabaseProperties dbProperties) {

--- a/src/main/java/de/komoot/photon/metrics/OpenSearchMetrics.java
+++ b/src/main/java/de/komoot/photon/metrics/OpenSearchMetrics.java
@@ -1,0 +1,173 @@
+package de.komoot.photon.metrics;
+
+import de.komoot.photon.opensearch.PhotonIndex;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.HealthStatus;
+
+public class OpenSearchMetrics implements MeterBinder {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final long CACHE_TTL_MS = 30_000;
+
+    private final OpenSearchClient client;
+    private volatile CachedStats cache;
+
+    public OpenSearchMetrics(@NotNull OpenSearchClient client) {
+        this.client = client;
+    }
+
+    private static class CachedStats {
+        final long timestamp;
+        final double documentCount;
+        final double indexSizeBytes;
+        final double searchTotal;
+        final double searchTimeMillis;
+        final double indexingTotal;
+        final double indexingTimeMillis;
+        final double activeShards;
+        final double relocatingShards;
+        final double unassignedShards;
+        final double healthStatus;
+
+        CachedStats(long timestamp, double documentCount, double indexSizeBytes, double searchTotal,
+                    double searchTimeMillis, double indexingTotal, double indexingTimeMillis,
+                    double activeShards, double relocatingShards, double unassignedShards, double healthStatus) {
+            this.timestamp = timestamp;
+            this.documentCount = documentCount;
+            this.indexSizeBytes = indexSizeBytes;
+            this.searchTotal = searchTotal;
+            this.searchTimeMillis = searchTimeMillis;
+            this.indexingTotal = indexingTotal;
+            this.indexingTimeMillis = indexingTimeMillis;
+            this.activeShards = activeShards;
+            this.relocatingShards = relocatingShards;
+            this.unassignedShards = unassignedShards;
+            this.healthStatus = healthStatus;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() - timestamp > CACHE_TTL_MS;
+        }
+    }
+
+    @Override
+    public void bindTo(@NotNull MeterRegistry registry) {
+        Gauge.builder("opensearch.documents.count", client, this::getDocumentCount)
+                .tag("index", PhotonIndex.NAME).register(registry);
+        Gauge.builder("opensearch.index.size.bytes", client, this::getIndexSizeBytes)
+                .tag("index", PhotonIndex.NAME).baseUnit("bytes").register(registry);
+        Gauge.builder("opensearch.search", client, this::getSearchTotal)
+                .tag("index", PhotonIndex.NAME).register(registry);
+        Gauge.builder("opensearch.search.time.millis", client, this::getSearchTimeMillis)
+                .tag("index", PhotonIndex.NAME).baseUnit("milliseconds").register(registry);
+        Gauge.builder("opensearch.indexing", client, this::getIndexingTotal)
+                .tag("index", PhotonIndex.NAME).register(registry);
+        Gauge.builder("opensearch.indexing.time.millis", client, this::getIndexingTimeMillis)
+                .tag("index", PhotonIndex.NAME).baseUnit("milliseconds").register(registry);
+        Gauge.builder("opensearch.cluster.shards.active", client, this::getActiveShards).register(registry);
+        Gauge.builder("opensearch.cluster.shards.relocating", client, this::getRelocatingShards).register(registry);
+        Gauge.builder("opensearch.cluster.shards.unassigned", client, this::getUnassignedShards).register(registry);
+        Gauge.builder("opensearch.cluster.health.status", client, this::getHealthStatus).register(registry);
+    }
+
+    @NotNull
+    private CachedStats getCache() {
+        CachedStats current = cache;
+        if (current == null || current.isExpired()) {
+            synchronized (this) {
+                current = cache;
+                if (current == null || current.isExpired()) {
+                    refreshCache();
+                    current = cache;
+                }
+            }
+        }
+        return current != null ? current : createEmptyCache();
+    }
+
+    @NotNull
+    private CachedStats createEmptyCache() {
+        return new CachedStats(System.currentTimeMillis(), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    }
+
+    private void refreshCache() {
+        double documentCount = 0, indexSizeBytes = 0, searchTotal = 0, searchTimeMillis = 0;
+        double indexingTotal = 0, indexingTimeMillis = 0, activeShards = 0, relocatingShards = 0;
+        double unassignedShards = 0, healthStatus = 0;
+
+        try {
+            documentCount = client.count(c -> c.index(PhotonIndex.NAME)).count();
+            var stats = client.indices().stats(s -> s.index(PhotonIndex.NAME)).indices().get(PhotonIndex.NAME);
+            if (stats != null) {
+                if (stats.primaries().store() != null) {
+                    indexSizeBytes = stats.primaries().store().sizeInBytes();
+                }
+                if (stats.primaries().search() != null) {
+                    searchTotal = stats.primaries().search().queryTotal();
+                    searchTimeMillis = stats.primaries().search().queryTimeInMillis();
+                }
+                if (stats.primaries().indexing() != null) {
+                    indexingTotal = stats.primaries().indexing().indexTotal();
+                    indexingTimeMillis = stats.primaries().indexing().indexTimeInMillis();
+                }
+            }
+            var health = client.cluster().health();
+            activeShards = health.activeShards();
+            relocatingShards = health.relocatingShards();
+            unassignedShards = health.unassignedShards();
+            healthStatus = health.status() == HealthStatus.Green ? 2 : health.status() == HealthStatus.Yellow ? 1 : 0;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to refresh cache", e);
+        }
+
+        cache = new CachedStats(System.currentTimeMillis(), documentCount, indexSizeBytes, searchTotal,
+                searchTimeMillis, indexingTotal, indexingTimeMillis, activeShards, relocatingShards,
+                unassignedShards, healthStatus);
+    }
+
+    private double getDocumentCount(OpenSearchClient client) {
+        return getCache().documentCount;
+    }
+
+    private double getIndexSizeBytes(OpenSearchClient client) {
+        return getCache().indexSizeBytes;
+    }
+
+    private double getSearchTotal(OpenSearchClient client) {
+        return getCache().searchTotal;
+    }
+
+    private double getSearchTimeMillis(OpenSearchClient client) {
+        return getCache().searchTimeMillis;
+    }
+
+    private double getIndexingTotal(OpenSearchClient client) {
+        return getCache().indexingTotal;
+    }
+
+    private double getIndexingTimeMillis(OpenSearchClient client) {
+        return getCache().indexingTimeMillis;
+    }
+
+    private double getActiveShards(OpenSearchClient client) {
+        return getCache().activeShards;
+    }
+
+    private double getRelocatingShards(OpenSearchClient client) {
+        return getCache().relocatingShards;
+    }
+
+    private double getUnassignedShards(OpenSearchClient client) {
+        return getCache().unassignedShards;
+    }
+
+    private double getHealthStatus(OpenSearchClient client) {
+        return getCache().healthStatus;
+    }
+}
+

--- a/src/test/java/de/komoot/photon/api/ApiMetricsTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiMetricsTest.java
@@ -1,0 +1,71 @@
+package de.komoot.photon.api;
+
+import de.komoot.photon.App;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiMetricsTest extends ApiBaseTester {
+
+    @BeforeAll
+    void setUp(@TempDir Path dataDirectory) throws Exception {
+        setUpES(dataDirectory);
+        refresh();
+    }
+
+    @AfterEach
+    void shutdown() {
+        App.shutdown();
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        shutdownES();
+    }
+
+    @Test
+    void testMetricsEndpointReturnsOpenSearchMetrics() throws Exception {
+        startAPI("-metrics-enable", "prometheus");
+
+        String metrics = readURL("/metrics");
+
+        // Check for OpenSearch index metrics
+        assertThat(metrics).contains("opensearch_documents_count{");
+        assertThat(metrics).contains("opensearch_index_size_bytes{");
+        assertThat(metrics).contains("opensearch_search{");
+        assertThat(metrics).contains("opensearch_search_time_millis_milliseconds{");
+        assertThat(metrics).contains("opensearch_indexing{");
+        assertThat(metrics).contains("opensearch_indexing_time_millis_milliseconds{");
+
+        // Check for OpenSearch cluster metrics
+        assertThat(metrics).contains("opensearch_cluster_shards_active{");
+        assertThat(metrics).contains("opensearch_cluster_shards_relocating{");
+        assertThat(metrics).contains("opensearch_cluster_shards_unassigned{");
+        assertThat(metrics).contains("opensearch_cluster_health_status{");
+
+        // Check for index tag on index metrics
+        assertThat(metrics).contains("index=\"photon\"");
+
+        // Check for JVM metrics
+        assertThat(metrics).contains("jvm_memory");
+        assertThat(metrics).contains("jvm_gc");
+        assertThat(metrics).contains("jvm_threads");
+    }
+
+    @Test
+    void testMetricsEndpointReturns404WhenDisabled() throws Exception {
+        startAPI();
+
+        var conn = connect("/metrics");
+        assertThat(conn.getResponseCode()).isEqualTo(404);
+    }
+}

--- a/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
+++ b/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
@@ -2,6 +2,7 @@ package de.komoot.photon.metrics;
 
 import de.komoot.photon.CommandLineArgs;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchClient;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,8 +15,9 @@ class MetricsConfigTest {
                 return "prometheus";
             }
         };
+        OpenSearchClient openSearchClient = new OpenSearchClient(null) {};
 
-        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args);
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args, openSearchClient);
         assertNotNull(metricsConfig.getRegistry());
         assertNotNull(metricsConfig.getPlugin());
         assertTrue(metricsConfig.isEnabled());
@@ -29,8 +31,9 @@ class MetricsConfigTest {
                 return "";
             }
         };
+        OpenSearchClient openSearchClient = new OpenSearchClient(null) {};
 
-        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args);
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics(args, openSearchClient);
         assertThrows(IllegalStateException.class, metricsConfig::getRegistry);
         assertThrows(IllegalStateException.class, metricsConfig::getPlugin);
         assertFalse(metricsConfig.isEnabled());


### PR DESCRIPTION
Additions to the /metrics endpoint:
```
opensearch_cluster_health_status{application="Photon"} 1.0
opensearch_cluster_shards_active{application="Photon"} 5.0
opensearch_cluster_shards_relocating{application="Photon"} 0.0
opensearch_cluster_shards_unassigned{application="Photon"} 5.0
opensearch_documents_count{application="Photon",index="photon"} 2755611.0
opensearch_index_size_bytes{application="Photon",index="photon"} 6.79599092E8
opensearch_indexing{application="Photon",index="photon"} 0.0
opensearch_indexing_time_millis_milliseconds{application="Photon",index="photon"} 0.0
opensearch_search{application="Photon",index="photon"} 95.0
opensearch_search_time_millis_milliseconds{application="Photon",index="photon"} 157.0
```