### PR TITLE
Change order of normalisation filters

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -163,8 +163,8 @@ public class IndexSettingBuilder {
     private void addDefaultSettings() {
         final var NORMALIZATION_FILTERS = List.of(
                 "lowercase",
-                "german_normalization",
-                "asciifolding"
+                "asciifolding",
+                "german_normalization"
         );
 
         // Classification filtering.


### PR DESCRIPTION
ASCII normalisation needs to come before German normalization so that manually ASCII-normalized input behaves the same as input with diacritics.

Fixes #944.