### PR TITLE
Allow empty queries then when categories are present

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -17,7 +17,11 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
     double importance_factor = 40.0;
 
     public SearchQueryBuilder(String query, boolean lenient, boolean suggestAddresses) {
-        if (!suggestAddresses && (query.length() < 4 || query.matches("^\\p{IsAlphabetic}+$"))) {
+        if (query.isEmpty()) {
+            // Empty query is used for category-only searches (e.g. /api?include=osm.place.city),
+            // see SimpleSearchRequestFactory.create
+            innerQuery.query(q -> q.matchAll(ma -> ma));
+        } else if (!suggestAddresses && (query.length() < 4 || query.matches("^\\p{IsAlphabetic}+$"))) {
             importance_factor = setupShortQuery(query, lenient);
         } else {
             importance_factor = setupFullQuery(query, lenient, suggestAddresses);

--- a/src/main/java/de/komoot/photon/query/SimpleSearchRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/SimpleSearchRequestFactory.java
@@ -20,9 +20,17 @@ public class SimpleSearchRequestFactory extends SearchRequestFactoryBase impleme
         checkParams(context, FREE_SEARCH_PARAMETERS);
 
         final var request = new SimpleSearchRequest();
-
         completeSearchRequest(request, context);
-        request.setQuery(context.queryParamAsClass("q", String.class).get());
+
+        var query = context.queryParamAsClass("q", String.class);
+        if (query.getOrDefault("").isEmpty()) {
+            if (request.getIncludeCategories().isEmpty()) {
+                throw new BadRequestException(400, "q parameter is required when no include categories are specified");
+            }
+            request.setQuery("");
+        } else {
+            request.setQuery(query.get());
+        }
 
         return request;
     }

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -319,6 +319,15 @@ class ApiIntegrationTest extends ApiBaseTester {
         assertHttpError("/api?debug=1", 400);
     }
 
+    @Test
+    void testEmptyQueryWithInclude() throws Exception {
+        assertThatJson(readURL("/api?include=osm.place.city")).isObject()
+                .node("features").isArray().hasSize(1)
+                .element(0).isObject()
+                .node("properties").isObject()
+                .containsEntry("osm_value", "city");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "lat=52.54714", "lon=13.39026",
@@ -357,4 +366,3 @@ class ApiIntegrationTest extends ApiBaseTester {
         assertEquals(200, connect("/metrics").getResponseCode());
     }
 }
-


### PR DESCRIPTION
Makes it possible to use the `include` query parameter without `q` being present.