### PR TITLE
Replace rankAddress in PhotonDoc with addressType

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -58,7 +58,7 @@ public class PhotonDoc {
     @Nullable private Envelope bbox = null;
     private double importance = 0;
     @Nullable private String countryCode = null;
-    private int rankAddress = 30;
+    private AddressType addressType = AddressType.OTHER;
 
     private Map<AddressType, Map<String, String>> addressParts = new EnumMap<>(AddressType.class);
     private ContextMap context = new ContextMap();
@@ -91,7 +91,7 @@ public class PhotonDoc {
         this.importance = other.importance;
         this.countryCode = other.countryCode;
         this.centroid = other.centroid;
-        this.rankAddress = other.rankAddress;
+        this.addressType = other.addressType;
         this.addressParts = other.addressParts;
         this.context = other.context;
         this.geometry = other.geometry;
@@ -189,8 +189,8 @@ public class PhotonDoc {
         return this;
     }
 
-    public PhotonDoc rankAddress(int rank) {
-        this.rankAddress = rank;
+    public PhotonDoc addressType(AddressType type) {
+        this.addressType = type;
         return this;
     }
 
@@ -201,11 +201,6 @@ public class PhotonDoc {
 
     public static String makeUid(String placeId, int objectId) {
         return (objectId <= 0) ? placeId : String.format("%s.%d", placeId, objectId);
-    }
-
-    @Nullable
-    public AddressType getAddressType() {
-        return AddressType.fromRank(rankAddress);
     }
 
     public boolean isUsefulForIndex() {
@@ -381,8 +376,8 @@ public class PhotonDoc {
         return this.countryCode;
     }
 
-    public int getRankAddress() {
-        return this.rankAddress;
+    public AddressType getAddressType() {
+        return addressType;
     }
 
     public Map<AddressType, Map<String, String>> getAddressParts() {
@@ -422,7 +417,7 @@ public class PhotonDoc {
                 ", bbox=" + bbox +
                 ", importance=" + importance +
                 ", countryCode='" + countryCode + '\'' +
-                ", rankAddress=" + rankAddress +
+                ", addressType=" + addressType.getName() +
                 ", addressParts=" + addressParts +
                 ", context=" + context +
                 ", houseNumber='" + houseNumber + '\'' +

--- a/src/main/java/de/komoot/photon/json/DumpFields.java
+++ b/src/main/java/de/komoot/photon/json/DumpFields.java
@@ -20,6 +20,7 @@ public class DumpFields {
     public static final String PLACE_OSM_VALUE = "osm_value";
     public static final String PLACE_CATEGORIES = "categories";
     public static final String PLACE_RANK_ADDRESS = "rank_address";
+    public static final String PLACE_ADDRESS_TYPE = "address_type";
     public static final String PLACE_IMPORTANCE = "importance";
     public static final String PLACE_NAMES = "name";
     public static final String PLACE_HOUSENUMBER = "housenumber";

--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -124,7 +124,7 @@ public class JsonDumper implements Importer {
         writer.writeStringField(DumpFields.PLACE_OSM_VALUE, doc.getTagValue());
         writer.writeObjectField(DumpFields.PLACE_CATEGORIES,doc.getCategories());
 
-        writer.writeNumberField(DumpFields.PLACE_RANK_ADDRESS, doc.getRankAddress());
+        writer.writeStringField(DumpFields.PLACE_ADDRESS_TYPE, doc.getAddressType().getName());
         writer.writeNumberField(DumpFields.PLACE_IMPORTANCE, doc.getImportance());
 
         if (!doc.getName().isEmpty()) {

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -6,6 +6,7 @@ import de.komoot.photon.ConfigExtraTags;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.PhotonDocAddressSet;
 import de.komoot.photon.nominatim.model.AddressRow;
+import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.nominatim.model.NameMap;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -59,10 +60,11 @@ public class NominatimPlaceDocument {
 
     @Nullable
     public AddressRow asAddressRow(String[] languages) {
-        if (doc.getRankAddress() > 0 && doc.getRankAddress() < 28 && !names.isEmpty()) {
+        var addressType = doc.getAddressType();
+        if (!names.isEmpty() && addressType != AddressType.HOUSE && addressType != AddressType.OTHER) {
             final var row = AddressRow.make(
                     names, doc.getTagKey(), doc.getTagValue(),
-                    doc.getRankAddress(), languages);
+                    addressType, languages);
             return row.getName().isEmpty() ? null : row;
         }
 
@@ -145,7 +147,18 @@ public class NominatimPlaceDocument {
     @JsonProperty(DumpFields.PLACE_RANK_ADDRESS)
     void setRankAddress(@Nullable Integer rankAddress) {
         if (rankAddress != null) {
-            doc.rankAddress(rankAddress);
+            doc.addressType(AddressType.fromRank(rankAddress));
+        }
+    }
+
+    @JsonProperty(DumpFields.PLACE_ADDRESS_TYPE)
+    void setAddressType(@Nullable String addressType) {
+        if (addressType != null) {
+            try {
+                doc.addressType(AddressType.valueOf(addressType.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                doc.addressType(AddressType.OTHER);
+            }
         }
     }
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -3,6 +3,7 @@ package de.komoot.photon.nominatim;
 import de.komoot.photon.DatabaseProperties;
 import de.komoot.photon.config.PostgresqlConfig;
 import de.komoot.photon.nominatim.model.AddressRow;
+import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.nominatim.model.NameMap;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.jspecify.annotations.NullMarked;
@@ -67,7 +68,7 @@ public class NominatimConnector {
                 var names = AddressRow.make(dbutils.getMap(rs, "name"),
                         "place",
                         "country",
-                        4,
+                        AddressType.COUNTRY,
                         languages).getName();
                 if (!names.isEmpty()) {
                     countryNames.put(rs.getString("country_code"), names);

--- a/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
@@ -5,10 +5,7 @@ import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.PhotonDocAddressSet;
 import de.komoot.photon.PhotonDocInterpolationSet;
 import de.komoot.photon.config.PostgresqlConfig;
-import de.komoot.photon.nominatim.model.AddressRow;
-import de.komoot.photon.nominatim.model.NominatimAddressCache;
-import de.komoot.photon.nominatim.model.OsmlineRowMapper;
-import de.komoot.photon.nominatim.model.PlaceRowMapper;
+import de.komoot.photon.nominatim.model.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NullMarked;
@@ -99,7 +96,7 @@ public class NominatimImporter extends NominatimConnector {
                                 dbutils.getMap(rs, "parent_name"),
                                 rs.getString("parent_class"),
                                 rs.getString("parent_type"),
-                                rs.getInt("parent_rank_address"),
+                                AddressType.fromRank(rs.getInt("parent_rank_address")),
                                 dbProperties.getLanguages())));
                     }
                     doc.addAddresses(addressCache.getAddressList(rs.getString("addresslines")));
@@ -120,7 +117,7 @@ public class NominatimImporter extends NominatimConnector {
                                 dbutils.getMap(rs, "parent_name"),
                                 rs.getString("parent_class"),
                                 rs.getString("parent_type"),
-                                rs.getInt("parent_rank_address"),
+                                AddressType.fromRank(rs.getInt("parent_rank_address")),
                                 dbProperties.getLanguages())));
                     }
                     doc.addAddresses(addressCache.getAddressList(rs.getString("addresslines")));

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -91,7 +91,7 @@ public class NominatimUpdater extends NominatimConnector {
                         dbutils.getMap(rs, "parent_name"),
                         rs.getString("parent_class"),
                         rs.getString("parent_type"),
-                        rs.getInt("parent_rank_address"),
+                        AddressType.fromRank(rs.getInt("parent_rank_address")),
                         dbProperties.getLanguages())));
             }
             doc.addAddresses(
@@ -118,7 +118,7 @@ public class NominatimUpdater extends NominatimConnector {
                         dbutils.getMap(rs, "parent_name"),
                         rs.getString("parent_class"),
                         rs.getString("parent_type"),
-                        rs.getInt("parent_rank_address"),
+                        AddressType.fromRank(rs.getInt("parent_rank_address")),
                         dbProperties.getLanguages())));
             }
             doc.addAddresses(

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -23,7 +23,7 @@ public class AddressRow {
     }
 
     public static AddressRow make(Map<String, String> name, String osmKey, String osmValue,
-                                  int rankAddress, String[] languages) {
+                                  AddressType addressType, String[] languages) {
         ContextMap context = new ContextMap();
 
         if (("place".equals(osmKey) && "postcode".equals(osmValue))
@@ -31,7 +31,7 @@ public class AddressRow {
             return new AddressRow(
                     new NameMap().setName("ref", name, "ref"),
                     context,
-                    AddressType.fromRank(rankAddress),
+                    addressType,
                     true
             );
         } else {
@@ -42,7 +42,7 @@ public class AddressRow {
         return new AddressRow(
                 new NameMap().setLocaleNames(name, languages),
                 context,
-                AddressType.fromRank(rankAddress),
+                addressType,
                 false);
     }
 

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressType.java
@@ -1,7 +1,6 @@
 package de.komoot.photon.nominatim.model;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,27 +40,13 @@ public enum AddressType {
      * Convert a Nominatim address rank into a Photon address type.
      *
      * @param addressRank Nominatim address rank.
-     * @return The corresponding address type or null if not covered.
+     * @return The corresponding address type or Other if not covered.
      */
-    @Nullable
     public static AddressType fromRank(int addressRank) {
-        for (AddressType a : AddressType.values()) {
-            if (a.coversRank(addressRank)) {
-                return a;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Check if the given address rank is mapped to the given address type.
-     *
-     * @param addressRank Nominatim address rank.
-     * @return True, if the type covers the rank.
-     */
-    public boolean coversRank(int addressRank) {
-        return addressRank >= minRank && addressRank <= maxRank;
+        return Arrays.stream(AddressType.values())
+                .filter(a -> addressRank >= a.minRank && addressRank <= a.maxRank)
+                .findFirst()
+                .orElse(OTHER);
     }
 
     public String getName() {

--- a/src/main/java/de/komoot/photon/nominatim/model/NominatimAddressCache.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/NominatimAddressCache.java
@@ -34,7 +34,7 @@ public class NominatimAddressCache {
                     dbutils.getMap(rs, "name"),
                     rs.getString("class"),
                     rs.getString("type"),
-                    rs.getInt("rank_address"),
+                    AddressType.fromRank(rs.getInt("rank_address")),
                     languages);
             if (!row.getName().isEmpty()) {
                 addresses.put(

--- a/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
@@ -19,6 +19,7 @@ public class OsmlineRowMapper implements RowMapper<PhotonDoc> {
                 "place", "house_number")
                 .countryCode(rs.getString("country_code"))
                 .categories(List.of("osm.place.house_number"))
+                .addressType(AddressType.HOUSE)
                 .postcode(rs.getString("postcode"));
     }
 

--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -42,6 +42,7 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
         } else if (!CATEGORY_PATTERN.matcher(osmValue).matches()) {
             osmValue = "yes";
         }
+        var addressType = AddressType.fromRank(rs.getInt("rank_address"));
         PhotonDoc doc = new PhotonDoc(Long.toString(rs.getLong("place_id")),
                 rs.getString("osm_type"), rs.getLong("osm_id"),
                 osmKey, osmValue)
@@ -51,7 +52,7 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
                 .bbox(dbutils.extractGeometry(rs, "bbox"))
                 .countryCode(rs.getString("country_code"))
                 .centroid(Objects.requireNonNull(dbutils.extractGeometry(rs, "centroid")))
-                .rankAddress(rs.getInt("rank_address"))
+                .addressType(addressType)
                 .postcode(rs.getString("postcode"));
 
         if (useGeometryColumn) {

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -1,6 +1,7 @@
 package de.komoot.photon;
 
 import de.komoot.photon.nominatim.model.AddressRow;
+import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.nominatim.model.NameMap;
 import de.komoot.photon.searcher.PhotonResult;
 import org.junit.jupiter.api.AfterEach;
@@ -39,7 +40,7 @@ public class ESBaseTester {
             nameMap.put(names[i], names[i+1]);
         }
 
-        return AddressRow.make(nameMap, "place", "city", 16, dbProperties.getLanguages()).getName();
+        return AddressRow.make(nameMap, "place", "city", AddressType.CITY, dbProperties.getLanguages()).getName();
     }
 
     protected Point makePoint(double x, double y) {

--- a/src/test/java/de/komoot/photon/api/ApiDedupeTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiDedupeTest.java
@@ -7,6 +7,8 @@ import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
 import java.nio.file.Path;
 import java.util.List;
+
+import de.komoot.photon.nominatim.model.AddressType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +34,7 @@ class ApiDedupeTest extends ApiBaseTester {
                     .tagKey("highway")
                     .tagValue("residential")
                     .postcode("1000")
-                    .rankAddress(26)
+                    .addressType(AddressType.STREET)
                     .centroid(makePoint(15.94174, 45.80355))
                     .names(makeDocNames("name", "Pfanove"))
             )
@@ -46,7 +48,7 @@ class ApiDedupeTest extends ApiBaseTester {
                     .tagKey("highway")
                     .tagValue("residential")
                     .postcode("1000")
-                    .rankAddress(26)
+                    .addressType(AddressType.STREET)
                     .centroid(makePoint(15.94192, 45.802429))
                     .names(makeDocNames("name", "Pfanove"))
             )

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -3,6 +3,7 @@ package de.komoot.photon.api;
 import de.komoot.photon.App;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +38,7 @@ class ApiIntegrationTest extends ApiBaseTester {
         instance.add(List.of(new PhotonDoc()
                 .placeId("1000").osmType("N").osmId(1000).tagKey("place").tagValue("city")
                 .categories(List.of("osm.place.city"))
-                .importance(0.6).rankAddress(16)
+                .importance(0.6).addressType(AddressType.CITY)
                 .centroid(makePoint(13.38886, 52.51704))
                 .geometry(makeDocGeometry("POINT(13.38886 52.51704)"))
                 .names(makeDocNames("name", "berlin"))
@@ -45,7 +46,7 @@ class ApiIntegrationTest extends ApiBaseTester {
         instance.add(List.of(new PhotonDoc()
                 .placeId("1001").osmType("R").osmId(1001).tagKey("place").tagValue("suburb")
                 .categories(List.of("osm.place.suburb"))
-                .importance(0.3).rankAddress(17)
+                .importance(0.3).addressType(AddressType.DISTRICT)
                 .centroid(makePoint(13.39026, 52.54714))
                 .geometry(makeDocGeometry("POLYGON ((6.4440619 52.1969454, 6.4441094 52.1969158, 6.4441408 52.1969347, 6.4441138 52.1969516, 6.4440933 52.1969643, 6.4440619 52.1969454))"))
                 .names(makeDocNames("name", "berlin"))
@@ -53,7 +54,7 @@ class ApiIntegrationTest extends ApiBaseTester {
         instance.add(List.of(new PhotonDoc()
                 .placeId("1002").osmType("W").osmId(1002).tagKey("place").tagValue("hamlet")
                 .categories(List.of("osm.place.hamlet"))
-                .importance(0.3).rankAddress(25)
+                .importance(0.3).addressType(AddressType.LOCALITY)
                 .centroid(makePoint(13.39026, 52.54714))
                 .geometry(makeDocGeometry("LINESTRING (30 10, 10 30, 40 40)"))
                 .names(makeDocNames("name", "berlin"))

--- a/src/test/java/de/komoot/photon/json/JsonDumperTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonDumperTest.java
@@ -121,7 +121,7 @@ class JsonDumperTest {
                 .containsEntry("osm_key", "highway")
                 .containsEntry("osm_value", "residential")
                 .containsEntry("categories", List.of("osm.highway.residential"))
-                .containsEntry("rank_address", 26)
+                .containsEntry("address_type", "street")
                 .containsEntry("importance", 0.123)
                 .containsEntry("country_code", "hu")
                 .doesNotContainKeys("parent_place_id", "postcode", "extra")

--- a/src/test/java/de/komoot/photon/json/JsonReaderTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonReaderTest.java
@@ -79,7 +79,7 @@ class JsonReaderTest {
                 .hasFieldOrPropertyWithValue("bbox", new Envelope(9.5461636, 9.556083, 47.2415541, 47.2966235))
                 .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                 .hasFieldOrPropertyWithValue("countryCode", "AT")
-                .hasFieldOrPropertyWithValue("rankAddress", 0)
+                .hasFieldOrPropertyWithValue("addressType", AddressType.OTHER)
                 .hasFieldOrPropertyWithValue("houseNumber", null)
                 .hasFieldOrPropertyWithValue("centroid", geomFactory.createPoint(new Coordinate(9.53713454, 47.27052526)))
                 .hasFieldOrPropertyWithValue("geometry", null);
@@ -108,7 +108,7 @@ class JsonReaderTest {
                         .hasFieldOrPropertyWithValue("bbox", new Envelope(9.5461636, 9.556083, 47.2415541, 47.2966235))
                         .hasFieldOrPropertyWithValue("importance", 0.10667666666666664)
                         .hasFieldOrPropertyWithValue("countryCode", "AT")
-                        .hasFieldOrPropertyWithValue("rankAddress", 0)
+                        .hasFieldOrPropertyWithValue("addressType", AddressType.OTHER)
                         .hasFieldOrPropertyWithValue("houseNumber", null)
                         .hasFieldOrPropertyWithValue("addressParts", Map.of())
                         .hasFieldOrPropertyWithValue("centroid", geomFactory.createPoint(new Coordinate(9.53713454, 47.27052526)))
@@ -132,7 +132,7 @@ class JsonReaderTest {
         input.println(TEST_SIMPLE_STREAM.replaceFirst("100818", "1".repeat(61)));
 
         assertThatIOException()
-                .isThrownBy(() -> readJson())
+                .isThrownBy(this::readJson)
                 .withMessageContaining("exceed 60 char");
     }
 
@@ -141,7 +141,7 @@ class JsonReaderTest {
         input.println(TEST_SIMPLE_STREAM.replaceFirst("100818", "\"a b@\""));
 
         assertThatIOException()
-                .isThrownBy(() -> readJson())
+                .isThrownBy(this::readJson)
                 .withMessageContaining("must only consist of letters");
     }
 
@@ -348,7 +348,7 @@ class JsonReaderTest {
         var importer = readJson();
 
         assertThat(importer).singleElement()
-                .hasFieldOrPropertyWithValue("rankAddress", 30);
+                .hasFieldOrPropertyWithValue("addressType", AddressType.OTHER);
     }
 
     @Test
@@ -460,4 +460,14 @@ class JsonReaderTest {
                 .hasFieldOrPropertyWithValue("tagValue", "yes");
 
     }
+
+    @Test
+    void testAddressType() throws IOException {
+        input.println(TEST_SIMPLE_STREAM.replace("\"rank_address\" : 0", "\"address_type\" : \"house\""));
+        var importer = readJson();
+
+        assertThat(importer).singleElement()
+                .hasFieldOrPropertyWithValue("addressType", AddressType.HOUSE);
+    }
+
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/Helpers.java
@@ -1,7 +1,7 @@
 package de.komoot.photon.nominatim.testdb;
 
+import org.jspecify.annotations.Nullable;
 import org.locationtech.jts.geom.Geometry;
-import org.springframework.lang.Nullable;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/src/test/java/de/komoot/photon/nominatim/testdb/OsmlineTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/OsmlineTestRow.java
@@ -1,6 +1,7 @@
 package de.komoot.photon.nominatim.testdb;
 
 import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -52,7 +53,7 @@ public class OsmlineTestRow {
         Assertions.assertEquals(osmId, (Long) doc.getOsmId());
         Assertions.assertEquals("place", doc.getTagKey());
         Assertions.assertEquals("house_number", doc.getTagValue());
-        Assertions.assertEquals(30, (Integer) doc.getRankAddress());
+        Assertions.assertEquals(AddressType.HOUSE, doc.getAddressType());
     }
 
     public Long getPlaceId() {

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -162,7 +162,6 @@ public class PlacexTestRow {
         Assertions.assertEquals(osmId, (Long) doc.getOsmId());
         Assertions.assertEquals(key, doc.getTagKey());
         Assertions.assertEquals(value, doc.getTagValue());
-        Assertions.assertEquals(rankAddress, (Integer) doc.getRankAddress());
         Assertions.assertEquals(new WKTReader().read(centroid), doc.getCentroid());
         if (names.containsKey("name")) {
             Assertions.assertEquals(names.get("name"), doc.getName().get("default"));

--- a/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/StructuredQueryTest.java
@@ -28,16 +28,6 @@ public class StructuredQueryTest extends ESBaseTester {
     private static final String STREET = "Some street";
     public static final String DISTRICT_POST_CODE = "12346";
 
-    private static int getRank(AddressType type) {
-        for (int i = 0; i < 50; ++i) {
-            if (type.coversRank(i)) {
-                return i;
-            }
-        }
-
-        return 99;
-    }
-
     @BeforeAll
     void setUp(@TempDir Path dataDirectory) throws Exception {
         getProperties().setLanguages(new String[]{LANGUAGE, "de", "fr"});
@@ -48,14 +38,14 @@ public class StructuredQueryTest extends ESBaseTester {
                 .names(makeDocNames("name", "Germany"))
                 .countryCode(COUNTRY_CODE)
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.COUNTRY));
+                .addressType(AddressType.COUNTRY);
 
         var city = new PhotonDoc("1", "R", 1, "place", "city")
                 .names(makeDocNames("name", CITY))
                 .countryCode(COUNTRY_CODE)
                 .postcode("12345")
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.CITY));
+                .addressType(AddressType.CITY);
 
         Map<String, String> address = new HashMap<>();
         address.put("city", CITY);
@@ -65,7 +55,7 @@ public class StructuredQueryTest extends ESBaseTester {
                 .postcode(DISTRICT_POST_CODE)
                 .addAddresses(address, getProperties().getLanguages())
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.DISTRICT));
+                .addressType(AddressType.DISTRICT);
 
         var street = new PhotonDoc("3", "W", 3, "place", "street")
                 .names(makeDocNames("name", STREET))
@@ -73,7 +63,7 @@ public class StructuredQueryTest extends ESBaseTester {
                 .postcode("12345")
                 .addAddresses(address, getProperties().getLanguages())
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.STREET));
+                .addressType(AddressType.STREET);
 
         address.put("street", STREET);
         var house = new PhotonDoc("4", "R", 4, "place", "house")
@@ -82,7 +72,7 @@ public class StructuredQueryTest extends ESBaseTester {
                 .addAddresses(address, getProperties().getLanguages())
                 .houseNumber(HOUSE_NUMBER)
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.HOUSE));
+                .addressType(AddressType.HOUSE);
 
         var busStop = new PhotonDoc("8", "N", 8, "highway", "house")
                 .names(makeDocNames("name", CITY + ' ' + STREET))
@@ -91,7 +81,7 @@ public class StructuredQueryTest extends ESBaseTester {
                 .addAddresses(address, getProperties().getLanguages())
                 .houseNumber(HOUSE_NUMBER)
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.HOUSE));
+                .addressType(AddressType.HOUSE);
 
         instance.add(List.of(country));
         instance.add(List.of(city));
@@ -142,7 +132,7 @@ public class StructuredQueryTest extends ESBaseTester {
         var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
         assertEquals(1, results.size());
-        var result = results.get(0);
+        var result = results.getFirst();
         assertEquals(request.getHouseNumber(), result.get(DocFields.HOUSENUMBER));
     }
 
@@ -167,7 +157,7 @@ public class StructuredQueryTest extends ESBaseTester {
         var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
         assertEquals(1, results.size());
-        var result = results.get(0);
+        var result = results.getFirst();
         assertEquals(0, result.get(DocFields.OSM_ID));
     }
 
@@ -253,7 +243,7 @@ public class StructuredQueryTest extends ESBaseTester {
         var queryHandler = getServer().createStructuredSearchHandler(1);
         var results = queryHandler.search(request);
 
-        return results.get(0);
+        return results.getFirst();
     }
 
     private void addHamletHouse(Importer instance, int id, String houseNumber) {
@@ -266,7 +256,7 @@ public class StructuredQueryTest extends ESBaseTester {
                 .addAddresses(hamletAddress, getProperties().getLanguages())
                 .houseNumber(houseNumber)
                 .importance(1.0)
-                .rankAddress(getRank(AddressType.HOUSE));
+                .addressType(AddressType.HOUSE);
 
         instance.add(List.of(doc));
     }

--- a/src/test/java/de/komoot/photon/opensearch/SuggestAddressesTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/SuggestAddressesTest.java
@@ -3,6 +3,7 @@ package de.komoot.photon.opensearch;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.query.SimpleSearchRequest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,7 +33,7 @@ class SuggestAddressesTest extends ESBaseTester {
                 .names(makeDocNames("name", STREET_NAME))
                 .countryCode("DE")
                 .importance(0.5)
-                .rankAddress(26);
+                .addressType(AddressType.STREET);
 
         // Add a house on that street
         var address = new HashMap<String, String>();
@@ -42,7 +43,7 @@ class SuggestAddressesTest extends ESBaseTester {
                 .houseNumber("42")
                 .addAddresses(address, getProperties().getLanguages())
                 .importance(0.1)
-                .rankAddress(30);
+                .addressType(AddressType.HOUSE);
 
         // Add houses on same street name in different cities (Auelestr scenario)
         var addressTriesen = new HashMap<String, String>();
@@ -53,7 +54,7 @@ class SuggestAddressesTest extends ESBaseTester {
                 .houseNumber("16")
                 .addAddresses(addressTriesen, getProperties().getLanguages())
                 .importance(0.1)
-                .rankAddress(30);
+                .addressType(AddressType.HOUSE);
 
         var addressVaduz = new HashMap<String, String>();
         addressVaduz.put("street", "Auelestr");
@@ -63,14 +64,14 @@ class SuggestAddressesTest extends ESBaseTester {
                 .houseNumber("16")
                 .addAddresses(addressVaduz, getProperties().getLanguages())
                 .importance(0.1)
-                .rankAddress(30);
+                .addressType(AddressType.HOUSE);
 
         // Add a street with pure alphabetic name (triggers short query path)
         var alphabeticStreet = new PhotonDoc("5", "W", 5, "highway", "residential")
                 .names(makeDocNames("name", "Romsdalsveien"))
                 .countryCode("NO")
                 .importance(0.5)
-                .rankAddress(26);
+                .addressType(AddressType.STREET);
 
         // Add a house on that street
         var addressRomsdalsveien = new HashMap<String, String>();
@@ -80,14 +81,14 @@ class SuggestAddressesTest extends ESBaseTester {
                 .houseNumber("10")
                 .addAddresses(addressRomsdalsveien, getProperties().getLanguages())
                 .importance(0.1)
-                .rankAddress(30);
+                .addressType(AddressType.HOUSE);
 
         // Add a street with spaces in name (triggers full query path)
         var multiWordStreet = new PhotonDoc("7", "W", 7, "highway", "residential")
                 .names(makeDocNames("name", "Nils Gotlands veg"))
                 .countryCode("NO")
                 .importance(0.5)
-                .rankAddress(26);
+                .addressType(AddressType.STREET);
 
         // Add a house on that street
         var addressNilsGotlands = new HashMap<String, String>();
@@ -97,7 +98,7 @@ class SuggestAddressesTest extends ESBaseTester {
                 .houseNumber("5")
                 .addAddresses(addressNilsGotlands, getProperties().getLanguages())
                 .importance(0.1)
-                .rankAddress(30);
+                .addressType(AddressType.HOUSE);
 
         instance.add(List.of(street, house, houseTriesen, houseVaduz, alphabeticStreet, houseRomsdalsveien,
                 multiWordStreet, houseNilsGotlands));

--- a/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryFilterLayerTest.java
@@ -3,6 +3,7 @@ package de.komoot.photon.query;
 import de.komoot.photon.ESBaseTester;
 import de.komoot.photon.Importer;
 import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
 import de.komoot.photon.searcher.PhotonResult;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
@@ -24,14 +25,14 @@ class QueryFilterLayerTest extends ESBaseTester {
 
         int id = 0;
 
-        int[] docRanks = {10, 13, 14, 22}; // state, city * 2, locality
-        for (int rank : docRanks) {
+        AddressType[] docRanks = {AddressType.STATE, AddressType.CITY, AddressType.CITY, AddressType.LOCALITY};
+        for (var rank : docRanks) {
             instance.add(List.of(new PhotonDoc()
                             .placeId(Integer.toString(id)).osmType("W").osmId(++id).tagKey("place").tagValue("value")
                             .names(makeDocNames("name", "berlin"))
                             .centroid(makePoint(10, 10))
 
-                            .rankAddress(rank)));
+                            .addressType(rank)));
         }
 
         instance.finish();


### PR DESCRIPTION
Photon only works with address types while address ranks are a Nominatim-specific detail. Just keeping the type makes processing easier down the line.

For the JSON dump, it will also just export the address type as a string. The importer can now work with either input, the Nominatim address_rank or the Photon address_type. If a string with an unknown type is given, it falls back to OTHER.