### PR TITLE
Add SSL/TLS and basic auth support for external OpenSearch connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
         }
     }
 
-    implementation 'org.opensearch.client:opensearch-java:3.5.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.5.1'
+    implementation 'org.opensearch.client:opensearch-java:3.6.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.6'
 
     implementation('org.codelibs.opensearch:opensearch-runner:3.4.0.0') {
         exclude(module: 'repository-url')

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,6 +33,50 @@ OpenSearch nodes. It takes a comma-separated list of node addresses.
 photon uses to the 'photon' cluster by default. This can be changed with the
 **-cluster** parameter if necessary.
 
+## Securing the OpenSearch Connection
+
+When connecting to an external OpenSearch cluster, photon supports basic
+authentication and SSL/TLS encryption.
+
+### Basic authentication
+
+To enable basic authentication, provide credentials with the
+**-opensearch-user** and **-opensearch-password** parameters:
+
+    java -jar photon.jar serve \
+        -transport-addresses opensearch.example.com:9200 \
+        -opensearch-user photon \
+        -opensearch-password secret
+
+### SSL/TLS with a custom CA
+
+To enable SSL/TLS, add the **-opensearch-ssl** flag. By default, photon
+uses the JVM default trust store for certificate validation. When the
+cluster uses a self-signed certificate or a private CA, provide a PKCS12
+trust store with **-opensearch-truststore** and optionally
+**-opensearch-truststore-password**:
+
+    java -jar photon.jar serve \
+        -transport-addresses opensearch.example.com:9200 \
+        -opensearch-ssl \
+        -opensearch-user photon \
+        -opensearch-password secret \
+        -opensearch-truststore /path/to/truststore.p12 \
+        -opensearch-truststore-password changeit
+
+### Mutual TLS (mTLS)
+
+For mutual TLS, provide a client certificate via **-opensearch-keystore**
+and **-opensearch-keystore-password** in addition to the trust store:
+
+    java -jar photon.jar serve \
+        -transport-addresses opensearch.example.com:9200 \
+        -opensearch-ssl \
+        -opensearch-truststore /path/to/truststore.p12 \
+        -opensearch-truststore-password changeit \
+        -opensearch-keystore /path/to/client-keystore.p12 \
+        -opensearch-keystore-password clientpass
+
 ## Running a photon server
 
 When you already have a database, either because you downloaded a database

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -59,17 +59,6 @@ public class Server {
             }
         }
 
-        HttpHost[] hosts;
-        if (config.getTransportAddresses().isEmpty()) {
-            hosts = startInternal(dataDirectory, config.getCluster());
-        } else {
-            hosts = config.getTransportAddresses().stream()
-                    .map(addr -> addr.split(":", 2))
-                    .map(parts -> new HttpHost("http", parts[0],
-                        parts.length > 1 ? Integer.parseInt(parts[1]) : 9201))
-                    .toArray(HttpHost[]::new);
-        }
-
         final var module = new SimpleModule("PhotonResultDeserializer",
                 new Version(1, 0, 0, null, null, null));
         module.addDeserializer(OpenSearchResult.class, new OpenSearchResultDeserializer());
@@ -77,12 +66,19 @@ public class Server {
         final var mapper = new JacksonJsonpMapper();
         mapper.objectMapper().registerModule(module);
 
-        final var transport = ApacheHttpClient5TransportBuilder
-                .builder(hosts)
-                .setMapper(mapper)
-                .build();
-
-        client = new OpenSearchClient(transport);
+        if (config.getTransportAddresses().isEmpty()) {
+            final var hosts = startInternal(dataDirectory, config.getCluster());
+            final var transport = ApacheHttpClient5TransportBuilder
+                    .builder(hosts).setMapper(mapper).build();
+            client = new OpenSearchClient(transport);
+        } else {
+            try {
+                final var transport = new OpenSearchTransportBuilder(config, mapper).build();
+                client = new OpenSearchClient(transport);
+            } catch (java.security.GeneralSecurityException e) {
+                throw new IOException("Failed to configure SSL for OpenSearch connection", e);
+            }
+        }
 
         waitForReady();
     }

--- a/src/main/java/de/komoot/photon/config/PhotonDBConfig.java
+++ b/src/main/java/de/komoot/photon/config/PhotonDBConfig.java
@@ -2,6 +2,7 @@ package de.komoot.photon.config;
 
 import com.beust.jcommander.Parameter;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -36,6 +37,47 @@ public class PhotonDBConfig {
             """)
     private String cluster = "photon";
 
+    @Nullable
+    @Parameter(names = "-opensearch-user", category = GROUP, description = """
+            Username for basic authentication with an external OpenSearch cluster
+            """)
+    private String opensearchUser;
+
+    @Nullable
+    @Parameter(names = "-opensearch-password", category = GROUP, password = true, description = """
+            Password for basic authentication with an external OpenSearch cluster
+            """)
+    private String opensearchPassword;
+
+    @Parameter(names = "-opensearch-ssl", category = GROUP, description = """
+            Enable SSL/TLS for the connection to an external OpenSearch cluster
+            """)
+    private boolean opensearchSsl = false;
+
+    @Nullable
+    @Parameter(names = "-opensearch-truststore", category = GROUP, description = """
+            Path to a PKCS12 truststore for server certificate validation
+            """)
+    private String opensearchTruststore;
+
+    @Nullable
+    @Parameter(names = "-opensearch-truststore-password", category = GROUP, password = true, description = """
+            Password for the truststore
+            """)
+    private String opensearchTruststorePassword;
+
+    @Nullable
+    @Parameter(names = "-opensearch-keystore", category = GROUP, description = """
+            Path to a PKCS12 keystore for client certificate authentication (mTLS)
+            """)
+    private String opensearchKeystore;
+
+    @Nullable
+    @Parameter(names = "-opensearch-keystore-password", category = GROUP, password = true, description = """
+            Password for the keystore
+            """)
+    private String opensearchKeystorePassword;
+
     public String getDataDirectory() {
         return this.dataDirectory;
     }
@@ -46,5 +88,37 @@ public class PhotonDBConfig {
 
     public List<String> getTransportAddresses() {
         return this.transportAddresses;
+    }
+
+    public @Nullable String getOpensearchUser() {
+        return opensearchUser;
+    }
+
+    public @Nullable String getOpensearchPassword() {
+        return opensearchPassword;
+    }
+
+    public boolean isOpensearchSsl() {
+        return opensearchSsl;
+    }
+
+    public @Nullable String getOpensearchTruststore() {
+        return opensearchTruststore;
+    }
+
+    public @Nullable String getOpensearchTruststorePassword() {
+        return opensearchTruststorePassword;
+    }
+
+    public @Nullable String getOpensearchKeystore() {
+        return opensearchKeystore;
+    }
+
+    public @Nullable String getOpensearchKeystorePassword() {
+        return opensearchKeystorePassword;
+    }
+
+    public boolean hasAuthentication() {
+        return opensearchUser != null && opensearchPassword != null;
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchTransportBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchTransportBuilder.java
@@ -1,0 +1,109 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.config.PhotonDBConfig;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.jspecify.annotations.NullMarked;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+/**
+ * Builds a configured {@link ApacheHttpClient5Transport} for connecting to an
+ * external OpenSearch cluster with optional basic authentication and SSL/TLS.
+ */
+@NullMarked
+public class OpenSearchTransportBuilder {
+    private final PhotonDBConfig config;
+    private final JacksonJsonpMapper mapper;
+
+    public OpenSearchTransportBuilder(PhotonDBConfig config, JacksonJsonpMapper mapper) {
+        this.config = config;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Build a transport configured with the authentication and SSL settings
+     * from the photon database configuration.
+     */
+    public ApacheHttpClient5Transport build() throws GeneralSecurityException, IOException {
+        final var hosts = buildHosts();
+        final var builder = ApacheHttpClient5TransportBuilder.builder(hosts).setMapper(mapper);
+
+        if (config.isOpensearchSsl() || config.hasAuthentication()) {
+            final var sslContext = config.isOpensearchSsl() ? buildSslContext() : null;
+
+            builder.setHttpClientConfigCallback(httpClientBuilder -> {
+                if (config.hasAuthentication()) {
+                    final var credentialsProvider = new BasicCredentialsProvider();
+                    for (var host : hosts) {
+                        credentialsProvider.setCredentials(
+                                new AuthScope(host),
+                                new UsernamePasswordCredentials(
+                                        config.getOpensearchUser(),
+                                        config.getOpensearchPassword().toCharArray()));
+                    }
+                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                }
+
+                if (sslContext != null) {
+                    final var tlsStrategy = ClientTlsStrategyBuilder.create()
+                            .setSslContext(sslContext)
+                            .buildAsync();
+                    final var cm = PoolingAsyncClientConnectionManagerBuilder.create()
+                            .setTlsStrategy(tlsStrategy).build();
+                    httpClientBuilder.setConnectionManager(cm);
+                }
+
+                return httpClientBuilder;
+            });
+        }
+
+        return builder.build();
+    }
+
+    HttpHost[] buildHosts() {
+        final var scheme = config.isOpensearchSsl() ? "https" : "http";
+        return config.getTransportAddresses().stream()
+                .map(addr -> addr.split(":", 2))
+                .map(parts -> new HttpHost(scheme, parts[0],
+                        parts.length > 1 ? Integer.parseInt(parts[1]) : 9201))
+                .toArray(HttpHost[]::new);
+    }
+
+    SSLContext buildSslContext() throws GeneralSecurityException, IOException {
+        final var builder = SSLContextBuilder.create();
+
+        if (config.getOpensearchTruststore() != null) {
+            final var truststore = KeyStore.getInstance("PKCS12");
+            try (var in = new FileInputStream(config.getOpensearchTruststore())) {
+                final var pw = config.getOpensearchTruststorePassword();
+                truststore.load(in, pw != null ? pw.toCharArray() : null);
+            }
+            builder.loadTrustMaterial(truststore, null);
+        }
+
+        if (config.getOpensearchKeystore() != null) {
+            final var keystore = KeyStore.getInstance("PKCS12");
+            try (var in = new FileInputStream(config.getOpensearchKeystore())) {
+                final var pw = config.getOpensearchKeystorePassword();
+                keystore.load(in, pw != null ? pw.toCharArray() : null);
+            }
+            final var pw = config.getOpensearchKeystorePassword();
+            builder.loadKeyMaterial(keystore, pw != null ? pw.toCharArray() : null);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/test/java/de/komoot/photon/config/PhotonDBConfigTest.java
+++ b/src/test/java/de/komoot/photon/config/PhotonDBConfigTest.java
@@ -1,0 +1,49 @@
+package de.komoot.photon.config;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PhotonDBConfigTest {
+
+    @Test
+    void testParseAllOpenSearchAuthParameters() {
+        final var config = new PhotonDBConfig();
+
+        JCommander.newBuilder().addObject(config).build().parse(
+                "-opensearch-user", "myuser",
+                "-opensearch-password", "mypass",
+                "-opensearch-ssl",
+                "-opensearch-truststore", "/path/to/truststore.p12",
+                "-opensearch-truststore-password", "truststorepass",
+                "-opensearch-keystore", "/path/to/keystore.p12",
+                "-opensearch-keystore-password", "keystorepass"
+        );
+
+        assertThat(config.getOpensearchUser()).isEqualTo("myuser");
+        assertThat(config.getOpensearchPassword()).isEqualTo("mypass");
+        assertThat(config.isOpensearchSsl()).isTrue();
+        assertThat(config.getOpensearchTruststore()).isEqualTo("/path/to/truststore.p12");
+        assertThat(config.getOpensearchTruststorePassword()).isEqualTo("truststorepass");
+        assertThat(config.getOpensearchKeystore()).isEqualTo("/path/to/keystore.p12");
+        assertThat(config.getOpensearchKeystorePassword()).isEqualTo("keystorepass");
+        assertThat(config.hasAuthentication()).isTrue();
+    }
+
+    @Test
+    void testDefaultsWhenNoAuthParametersProvided() {
+        final var config = new PhotonDBConfig();
+
+        JCommander.newBuilder().addObject(config).build().parse();
+
+        assertThat(config.getOpensearchUser()).isNull();
+        assertThat(config.getOpensearchPassword()).isNull();
+        assertThat(config.isOpensearchSsl()).isFalse();
+        assertThat(config.getOpensearchTruststore()).isNull();
+        assertThat(config.getOpensearchTruststorePassword()).isNull();
+        assertThat(config.getOpensearchKeystore()).isNull();
+        assertThat(config.getOpensearchKeystorePassword()).isNull();
+        assertThat(config.hasAuthentication()).isFalse();
+    }
+}

--- a/src/test/java/de/komoot/photon/opensearch/OpenSearchTransportBuilderTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/OpenSearchTransportBuilderTest.java
@@ -1,0 +1,90 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.ReflectionTestUtil;
+import de.komoot.photon.config.PhotonDBConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class OpenSearchTransportBuilderTest {
+
+    private static String truststorePath;
+    private static final String TRUSTSTORE_PASSWORD = "testpass";
+
+    @BeforeAll
+    static void createTestTruststore(@TempDir Path tempDir) throws Exception {
+        truststorePath = tempDir.resolve("test-truststore.p12").toString();
+
+        final var ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+        try (var out = new FileOutputStream(truststorePath)) {
+            ks.store(out, TRUSTSTORE_PASSWORD.toCharArray());
+        }
+    }
+
+    private PhotonDBConfig createConfig(List<String> addresses, boolean ssl,
+                                        String truststore, String truststorePassword) {
+        final var config = new PhotonDBConfig(".", "photon", addresses);
+        if (ssl) {
+            ReflectionTestUtil.setFieldValue(config, PhotonDBConfig.class, "opensearchSsl", true);
+        }
+        if (truststore != null) {
+            ReflectionTestUtil.setFieldValue(config, PhotonDBConfig.class, "opensearchTruststore", truststore);
+        }
+        if (truststorePassword != null) {
+            ReflectionTestUtil.setFieldValue(config, PhotonDBConfig.class, "opensearchTruststorePassword", truststorePassword);
+        }
+        return config;
+    }
+
+    @Test
+    void testBuildHostsParsingAndScheme() {
+        final var httpConfig = new PhotonDBConfig(".", "photon", List.of("node1:9200", "node2"));
+        final var httpHosts = new OpenSearchTransportBuilder(httpConfig, new JacksonJsonpMapper()).buildHosts();
+
+        assertThat(httpHosts).hasSize(2);
+        assertThat(httpHosts[0].getSchemeName()).isEqualTo("http");
+        assertThat(httpHosts[0].getHostName()).isEqualTo("node1");
+        assertThat(httpHosts[0].getPort()).isEqualTo(9200);
+        assertThat(httpHosts[1].getPort()).isEqualTo(9201); // default port
+
+        final var sslConfig = createConfig(List.of("secure.example.com:9200"), true, null, null);
+        final var sslHosts = new OpenSearchTransportBuilder(sslConfig, new JacksonJsonpMapper()).buildHosts();
+
+        assertThat(sslHosts[0].getSchemeName()).isEqualTo("https");
+    }
+
+    @Test
+    void testBuildSslContextWithTruststore() throws Exception {
+        final var config = createConfig(List.of("localhost:9200"), true,
+                truststorePath, TRUSTSTORE_PASSWORD);
+        final var builder = new OpenSearchTransportBuilder(config, new JacksonJsonpMapper());
+
+        final var sslContext = builder.buildSslContext();
+
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.getProtocol()).isEqualTo("TLS");
+    }
+
+    @Test
+    void testBuildWithAuthAndSsl() throws Exception {
+        final var config = createConfig(List.of("localhost:9200"), true,
+                truststorePath, TRUSTSTORE_PASSWORD);
+        ReflectionTestUtil.setFieldValue(config, PhotonDBConfig.class, "opensearchUser", "admin");
+        ReflectionTestUtil.setFieldValue(config, PhotonDBConfig.class, "opensearchPassword", "secret");
+        final var builder = new OpenSearchTransportBuilder(config, new JacksonJsonpMapper());
+
+        final var transport = builder.build();
+
+        assertThat(transport).isNotNull();
+        transport.close();
+    }
+}


### PR DESCRIPTION
## Summary

Add support for basic authentication, SSL/TLS and mutual TLS (mTLS) when connecting to an external OpenSearch cluster.

#942

## Motivation

In production environments (e.g. Kubernetes), external OpenSearch clusters typically require authentication and encrypted connections. This was not possible until now.

## Changes

- **PhotonDBConfig**: 7 new CLI parameters (`-opensearch-user`, `-opensearch-password`, `-opensearch-ssl`, `-opensearch-truststore`, `-opensearch-truststore-password`, `-opensearch-keystore`, `-opensearch-keystore-password`)
- **OpenSearchTransportBuilder** (new): configures the Apache HttpClient 5 transport with basic auth and/or SSL following the official OpenSearch Java client documentation
- **Server**: delegates external transport construction to `OpenSearchTransportBuilder`
- **docs/usage.md**: new section documenting the three usage scenarios (basic auth, SSL with custom CA, mTLS)

## Usage examples

Basic authentication only:

    java -jar photon.jar serve \
        -transport-addresses opensearch.example.com:9200 \
        -opensearch-user photon -opensearch-password secret

With SSL and a custom CA:

    java -jar photon.jar serve \
        -transport-addresses opensearch.example.com:9200 \
        -opensearch-ssl \
        -opensearch-user photon -opensearch-password secret \
        -opensearch-truststore /path/to/truststore.p12 \
        -opensearch-truststore-password changeit

With mutual TLS (mTLS):

    java -jar photon.jar serve \
        -transport-addresses opensearch.example.com:9200 \
        -opensearch-ssl \
        -opensearch-truststore /path/to/truststore.p12 \
        -opensearch-truststore-password changeit \
        -opensearch-keystore /path/to/client-keystore.p12 \
        -opensearch-keystore-password clientpass

## Tests

- `OpenSearchTransportBuilderTest`: host parsing/scheme selection, SSL context construction with truststore, full auth+SSL smoke test
- `PhotonDBConfigTest`: CLI parameter parsing round-trip and defaults

## Proof of actual usage

Tested against an external OpenSearch 3.x cluster with basic auth and SSL enabled:

<img width="599" height="209" alt="Capture d’écran 2026-02-11 à 21 57 13" src="https://github.com/user-attachments/assets/b4a362e5-4418-425d-811a-a61f736050d0" />
<img width="797" height="157" alt="Capture d’écran 2026-02-11 à 21 56 48" src="https://github.com/user-attachments/assets/c385ddff-b59e-4d22-8e1b-e7e65c20811b" />

## AI disclosure

This PR was developed with AI assistance (Cursor / Claude). All code was reviewed, tested against a real OpenSearch cluster, and validated by the author.