### PR TITLE
Add experimental reverse-only mode

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -402,23 +402,25 @@ public class App {
 
         photonServer.get("/status", new StatusRequestHandler(server));
 
-        photonServer.get("/api", new GenericSearchHandler<>(
-                new SimpleSearchRequestFactory(
-                        dbProperties.getLanguages(),
-                        args.getDefaultLanguage(),
-                        args.getMaxResults(),
-                        dbProperties.getSupportGeometries()),
-                server.createSearchHandler(args.getQueryTimeout()),
-                formatter));
+        if (!dbProperties.getReverseOnly()) {
+           photonServer.get("/api", new GenericSearchHandler<>(
+                    new SimpleSearchRequestFactory(
+                            dbProperties.getLanguages(),
+                            args.getDefaultLanguage(),
+                            args.getMaxResults(),
+                            dbProperties.getSupportGeometries()),
+                    server.createSearchHandler(args.getQueryTimeout()),
+                    formatter));
 
-        photonServer.get("/structured", new GenericSearchHandler<>(
-                new StructuredSearchRequestFactory(
-                        dbProperties.getLanguages(),
-                        args.getDefaultLanguage(),
-                        args.getMaxResults(),
-                        dbProperties.getSupportGeometries()),
-                server.createStructuredSearchHandler(args.getQueryTimeout()),
-                formatter));
+            photonServer.get("/structured", new GenericSearchHandler<>(
+                    new StructuredSearchRequestFactory(
+                            dbProperties.getLanguages(),
+                            args.getDefaultLanguage(),
+                            args.getMaxResults(),
+                            dbProperties.getSupportGeometries()),
+                    server.createStructuredSearchHandler(args.getQueryTimeout()),
+                    formatter));
+        }
 
         photonServer.get("/reverse", new GenericSearchHandler<>(
                 new ReverseRequestFactory(

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -25,6 +25,7 @@ public class DatabaseProperties {
     private boolean supportGeometries = false;
     private boolean synonymsInstalled = false;
     private ConfigExtraTags extraTags = new ConfigExtraTags();
+    private boolean reverseOnly = false;
 
     @SuppressWarnings("unused")
     public void setDatabaseVersion(String version) {
@@ -120,5 +121,13 @@ public class DatabaseProperties {
                 ", synonymsInstalled=" + synonymsInstalled +
                 ", extraTags=" + extraTags +
                 '}';
+    }
+
+    public void setReverseOnly(boolean reverseOnly) {
+        this.reverseOnly = reverseOnly;
+    }
+
+    public boolean getReverseOnly() {
+        return reverseOnly;
     }
 }

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -140,7 +140,7 @@ public class Server {
 
         new IndexSettingBuilder().setShards(5).createIndex(client, PhotonIndex.NAME);
 
-        new IndexMapping().putMapping(client, PhotonIndex.NAME);
+        new IndexMapping(dbProperties.getReverseOnly()).putMapping(client, PhotonIndex.NAME);
 
         saveToDatabase(dbProperties);
     }

--- a/src/main/java/de/komoot/photon/config/ImportFilterConfig.java
+++ b/src/main/java/de/komoot/photon/config/ImportFilterConfig.java
@@ -38,6 +38,10 @@ public class ImportFilterConfig {
             """)
     private boolean importGeometryColumn = false;
 
+    @Parameter(names = "-reverse-only", category = GROUP, description = """
+            Set up database for reverse geocoding only""")
+    private boolean reverseOnly = false;
+
     public Set<String> getLanguages() {
         return new HashSet<>(languages);
     }
@@ -62,6 +66,7 @@ public class ImportFilterConfig {
             dbProps.setLanguages(getLanguages());
         }
         dbProps.setSupportGeometries(importGeometryColumn);
+        dbProps.setReverseOnly(reverseOnly);
 
         if (extraTags != null) {
             dbProps.setExtraTags(extraTags);

--- a/src/test/java/de/komoot/photon/api/ApiBaseTester.java
+++ b/src/test/java/de/komoot/photon/api/ApiBaseTester.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThatIOException;
+import static org.assertj.core.api.Assertions.*;
 
 public class ApiBaseTester extends ESBaseTester {
     private static final int LISTEN_PORT = 30234;
@@ -49,10 +49,12 @@ public class ApiBaseTester extends ESBaseTester {
                 .lines().collect(Collectors.joining("\n"));
     }
 
-    protected void assertHttpError(String url, int expectedCode) {
-        assertThatIOException()
-                .isThrownBy(() -> readURL(url))
-                .withMessageContaining("response code: " + expectedCode);
-
+    protected void assertHttpResponseCode(String url, int expectedCode) {
+        try {
+            assertThat(connect(url))
+                    .hasFieldOrPropertyWithValue("responseCode", expectedCode);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -17,7 +17,6 @@ import java.util.Date;
 import java.util.List;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * API tests that check queries against an already running ES instance and
@@ -77,7 +76,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @FieldSource("BASE_URLS")
     void testBogus(String baseUrl) {
-        assertHttpError(baseUrl + "&bogus=thing", 400);
+        assertHttpResponseCode(baseUrl + "&bogus=thing", 400);
     }
 
     @ParameterizedTest
@@ -167,7 +166,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @FieldSource("BASE_URLS")
     void testBadLimitParameter(String baseUrl) {
-        assertHttpError(baseUrl + "&limit=NaN", 400);
+        assertHttpResponseCode(baseUrl + "&limit=NaN", 400);
     }
 
     @ParameterizedTest
@@ -198,7 +197,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @FieldSource("BASE_URLS")
     void testBadLayerParameter(String baseUrl) {
-        assertHttpError(baseUrl + "&layer=locality&layer=suburb", 400);
+        assertHttpResponseCode(baseUrl + "&layer=locality&layer=suburb", 400);
     }
 
     @ParameterizedTest
@@ -265,7 +264,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @FieldSource("BASE_URLS")
     void testBadOsmTagParameter(String baseUrl) {
-        assertHttpError(baseUrl + "&osm_tag=bad:bad:bad", 400);
+        assertHttpResponseCode(baseUrl + "&osm_tag=bad:bad:bad", 400);
     }
 
     @ParameterizedTest
@@ -291,7 +290,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @ValueSource(strings = {"4+5.6", "abc", "ab..23", "a.b,c", "a.b,!c.d"})
     void testCategoryBadValues(String paramValue) {
-        assertHttpError("/api?q=berlin&include=" + paramValue, 400);
+        assertHttpResponseCode("/api?q=berlin&include=" + paramValue, 400);
     }
 
     @ParameterizedTest
@@ -306,18 +305,18 @@ class ApiIntegrationTest extends ApiBaseTester {
             "lat=52.54714&lon=-180.01", "lat=-90.01&lon=13.39026"
     })
     void testReverseBadLocation(String param) {
-        assertHttpError("/reverse?" + param, 400);
+        assertHttpResponseCode("/reverse?" + param, 400);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"bad", "NaN", "0.0", "-10.0"})
     void testReverseBadRadius(String param) {
-        assertHttpError("/reverse?lat=52.54714&lon=13.39026&radius=" + param, 400);
+        assertHttpResponseCode("/reverse?lat=52.54714&lon=13.39026&radius=" + param, 400);
     }
 
     @Test
     void testSearchMissingQuery() {
-        assertHttpError("/api?debug=1", 400);
+        assertHttpResponseCode("/api?debug=1", 400);
     }
 
     @Test
@@ -341,7 +340,7 @@ class ApiIntegrationTest extends ApiBaseTester {
             "lat=52.54714&lon=-180.01", "lat=-90.01&lon=13.39026"
     })
     void testSearchBadLocation(String param) {
-        assertHttpError("/api?q=berlin&" + param, 400);
+        assertHttpResponseCode("/api?q=berlin&" + param, 400);
     }
 
     @ParameterizedTest
@@ -352,18 +351,18 @@ class ApiIntegrationTest extends ApiBaseTester {
             "-181, 9, 4, 12", "12, 9, 181, 12"
     })
     void testSearchBadBbox(String param) {
-        assertHttpError("/api?q=berlin&bbox=" + param, 400);
+        assertHttpResponseCode("/api?q=berlin&bbox=" + param, 400);
     }
 
 
     @ParameterizedTest
     @ValueSource(strings = {"bad", "NaN"})
     void testSearchBadLocationBiasScale(String param) {
-        assertHttpError("/api?q=berlin&lat=52.54714&lon=13.39026&location_bias_scale=" + param, 400);
+        assertHttpResponseCode("/api?q=berlin&lat=52.54714&lon=13.39026&location_bias_scale=" + param, 400);
     }
 
     @Test
-    void testMetricsEndpoint() throws IOException {
-        assertEquals(200, connect("/metrics").getResponseCode());
+    void testMetricsEndpoint() {
+        assertHttpResponseCode("/metrics", 200);
     }
 }

--- a/src/test/java/de/komoot/photon/api/ApiLanguageSelectionTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiLanguageSelectionTest.java
@@ -116,7 +116,7 @@ class ApiLanguageSelectionTest extends ApiBaseTester {
     @FieldSource("BASE_URLS")
     void testLanguageByParameterUnsupported(String baseUrl) throws Exception {
         startAPI();
-        assertHttpError(baseUrl + "&lang=fr", 400);
+        assertHttpResponseCode(baseUrl + "&lang=fr", 400);
     }
 
     @ParameterizedTest

--- a/src/test/java/de/komoot/photon/api/ApiReverseOnlyTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiReverseOnlyTest.java
@@ -1,0 +1,98 @@
+package de.komoot.photon.api;
+
+import de.komoot.photon.App;
+import de.komoot.photon.Importer;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.nominatim.model.AddressType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiReverseOnlyTest extends ApiBaseTester {
+
+    @BeforeAll
+    void setUp(@TempDir Path dataDirectory) throws Exception {
+        getProperties().setImportDate(new Date());
+        getProperties().setReverseOnly(true);
+        setUpES(dataDirectory);
+        Importer instance = makeImporter();
+        instance.add(List.of(new PhotonDoc()
+                .placeId("1000").osmType("N").osmId(1000).tagKey("place").tagValue("city")
+                .categories(List.of("osm.place.city"))
+                .importance(0.6).addressType(AddressType.CITY)
+                .centroid(makePoint(13.38886, 52.51704))
+                .names(makeDocNames("name", "berlin"))
+        ));
+        instance.add(List.of(new PhotonDoc()
+                .placeId("1001").osmType("R").osmId(1001).tagKey("place").tagValue("suburb")
+                .categories(List.of("osm.place.suburb"))
+                .importance(0.3).addressType(AddressType.DISTRICT)
+                .centroid(makePoint(13.39026, 52.54714))
+                .names(makeDocNames("name", "berlin"))
+        ));
+        instance.add(List.of(new PhotonDoc()
+                .placeId("1002").osmType("W").osmId(1002).tagKey("place").tagValue("hamlet")
+                .categories(List.of("osm.place.hamlet"))
+                .importance(0.3).addressType(AddressType.LOCALITY)
+                .centroid(makePoint(13.390261, 52.54714))
+                .names(makeDocNames("name", "berlin"))
+        ));
+
+        instance.finish();
+        refresh();
+        startAPI();
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        App.shutdown();
+        shutdownES();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api?q=berlin", "/structured?city=berlin", "/metrics"})
+    void testSearchDisabled(String queryUrl) {
+        assertHttpResponseCode(queryUrl, 404);
+    }
+
+    @Test
+    void testApi() throws IOException {
+        assertThatJson(readURL("/reverse?lat=52.54714&lon=13.39026")).isObject()
+                .node("features").isArray().hasSize(1)
+                .element(0).isObject()
+                .node("properties").isObject()
+                .containsEntry("osm_key", "place")
+                .containsEntry("osm_value", "suburb")
+                .containsEntry("name", "berlin");
+    }
+
+    @Test
+    void testLimitParam() throws IOException {
+        assertThatJson(readURL("/reverse?lat=52.54714&lon=13.39026&limit=20")).isObject()
+                .node("features").isArray()
+                .hasSizeGreaterThan(1);
+    }
+
+    @Test
+    void testExcludeParam() throws IOException {
+        assertThatJson(readURL("/reverse?lat=52.54714&lon=13.39026&exclude=osm.place.suburb")).isObject()
+                .node("features").isArray().hasSize(1)
+                .element(0).isObject()
+                .node("properties").isObject()
+                .containsEntry("osm_key", "place")
+                .containsEntry("osm_value", "hamlet");
+    }
+}


### PR DESCRIPTION
Adds a new import parameter `-reverse-only`, which creates a database without any of the indexes for forward search. When running Photon on such a database then the `/api` and `/structured` endpoints are disabled.

A planet database imported as reverse-only comes to about 35GB.

Closes #904.