### PR TITLE
Optionally use parallel consumers for bulk import indexing

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -183,6 +183,13 @@ public class App {
             importThread.finish();
         }
 
+        try {
+            esServer.refreshIndexes();
+        } catch (IOException ex) {
+            LOGGER.error("Failed to refresh index after import", ex);
+            return;
+        }
+
         LOGGER.info("Database has been successfully set up with the following properties:\n{}", dbProperties);
     }
 

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -154,8 +154,8 @@ public class App {
             return;
         }
 
-        // One consumer thread per shard for optimal bulk indexing throughput.
-        final int numConsumers = Server.NUM_SHARDS;
+        // numConsumers == Server.NUM_SHARDS yields optimal bulk indexing throughput.
+        final int numConsumers = Math.max(1, cli.getGeneralConfig().getThreads());
         List<Importer> importers = new ArrayList<>(numConsumers);
         for (int i = 0; i < numConsumers; i++) {
             importers.add(esServer.createImporter(dbProperties));

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -154,7 +154,13 @@ public class App {
             return;
         }
 
-        final var importThread = new ImportThread(esServer.createImporter(dbProperties));
+        // One consumer thread per shard for optimal bulk indexing throughput.
+        final int numConsumers = Server.NUM_SHARDS;
+        List<Importer> importers = new ArrayList<>(numConsumers);
+        for (int i = 0; i < numConsumers; i++) {
+            importers.add(esServer.createImporter(dbProperties));
+        }
+        final var importThread = new ImportThread(importers);
 
         try {
             Date importDate;

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -41,6 +41,8 @@ public class Server {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    /** Number of shards for the photon index. */
+    public static final int NUM_SHARDS = 5;
     protected OpenSearchClient client;
     @Nullable private OpenSearchRunner runner = null;
 
@@ -136,7 +138,7 @@ public class Server {
             client.indices().delete(d -> d.index(PhotonIndex.NAME));
         }
 
-        new IndexSettingBuilder().setShards(5).createIndex(client, PhotonIndex.NAME);
+        new IndexSettingBuilder().setShards(NUM_SHARDS).createIndex(client, PhotonIndex.NAME);
 
         new IndexMapping(dbProperties.getReverseOnly()).putMapping(client, PhotonIndex.NAME);
 

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -45,6 +45,7 @@ public class Server {
     public static final int NUM_SHARDS = 5;
     protected OpenSearchClient client;
     @Nullable private OpenSearchRunner runner = null;
+    private volatile boolean serializerRegistered = false;
 
     public Server(PhotonDBConfig config, boolean create) throws IOException {
         final File dataDirectory = new File(config.getDataDirectory(), "photon_data");
@@ -221,10 +222,14 @@ public class Server {
     }
 
     private void registerPhotonDocSerializer(DatabaseProperties dbProperties) {
+        if (serializerRegistered) {
+            return;
+        }
         final var module = new SimpleModule("PhotonDocSerializer",
                 new Version(1, 0, 0, null, null, null));
         module.addSerializer(PhotonDoc.class, new PhotonDocSerializer(dbProperties));
 
         ((JacksonJsonpMapper) client._transport().jsonpMapper()).objectMapper().registerModule(module);
+        serializerRegistered = true;
     }
 }

--- a/src/main/java/de/komoot/photon/config/GeneralConfig.java
+++ b/src/main/java/de/komoot/photon/config/GeneralConfig.java
@@ -1,15 +1,16 @@
 package de.komoot.photon.config;
 
 import com.beust.jcommander.Parameter;
+import de.komoot.photon.Server;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class GeneralConfig {
     public static final String GROUP="General options";
 
-    @Parameter(names = "-j", category = GROUP, description = """
-            Use given number of threads in parallel where possible
-            """)
+    @Parameter(names = "-j", category = GROUP, description =
+            "Use given number of threads in parallel where possible. " +
+            "Set to " + Server.NUM_SHARDS + " to match the number of shards for optimal import performance.")
     private int threads = 1;
 
     @Parameter(names = "-h", category = GROUP, description = "Show help/usage")

--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -9,12 +9,11 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Worker thread for bulk importing data from a Nominatim database.
+ * Worker thread(s) for bulk importing data into a Photon database.
  */
 @NullMarked
 public class ImportThread {
@@ -22,22 +21,22 @@ public class ImportThread {
 
     private static final int PROGRESS_INTERVAL = 50000;
 	private static final int MAX_QUEUE_SIZE = 10_000;
-    private static final List<PhotonDoc> FINAL_DOCUMENT = List.of();
     private final BlockingQueue<Iterable<PhotonDoc>> documents = new ArrayBlockingQueue<>(MAX_QUEUE_SIZE);
     private final AtomicLong counter = new AtomicLong();
-    private final Importer importer;
-    private final Thread thread;
+    private final ExecutorService executor;
     private final long startMillis;
+    private volatile boolean producerDone = false;
     private volatile boolean exceptionInThread = false;
 
     public ImportThread(Importer importer) {
-        this.importer = importer;
-        this.thread = new Thread(new ImportRunnable());
-        this.thread.setUncaughtExceptionHandler((t, ex) -> {
-            LOGGER.error("Import error.", ex);
-            exceptionInThread = true;
-        });
-        this.thread.start();
+        this(List.of(importer));
+    }
+
+    public ImportThread(List<Importer> importers) {
+        this.executor = Executors.newFixedThreadPool(importers.size());
+        for (var imp : importers) {
+            executor.execute(new ImportRunnable(imp));
+        }
         this.startMillis = System.currentTimeMillis();
     }
 
@@ -66,28 +65,20 @@ public class ImportThread {
             }
         }
 
-        if (counter.incrementAndGet() % PROGRESS_INTERVAL == 0) {
-            final double documentsPerSecond = 1000d * counter.longValue() / (System.currentTimeMillis() - startMillis);
-            LOGGER.info("Imported {} documents [{}/second]", counter.longValue(), documentsPerSecond);
+        final long count = counter.incrementAndGet();
+        if (count % PROGRESS_INTERVAL == 0) {
+            final double documentsPerSecond = 1000d * count / (System.currentTimeMillis() - startMillis);
+            LOGGER.info("Imported {} documents [{}/second]", count, documentsPerSecond);
         }
     }
 
     /**
      * Finalize the import.
-     * Sends an end marker to the import thread and then waits for it to join.
+     * Signals consumer threads to stop and waits for them to complete.
      */
     public void finish() {
-        while (true) {
-            try {
-                documents.put(FINAL_DOCUMENT);
-                thread.join();
-                break;
-            } catch (InterruptedException e) {
-                LOGGER.warn("Thread interrupted while placing document in queue.");
-                // Restore interrupted state.
-                Thread.currentThread().interrupt();
-            }
-        }
+        producerDone = true;
+        executor.close();
         if (!exceptionInThread) {
             LOGGER.info("Finished import of {} photon documents. (Total processing time: {}s)",
                     counter.longValue(), (System.currentTimeMillis() - startMillis) / 1000);
@@ -95,29 +86,49 @@ public class ImportThread {
     }
 
     private class ImportRunnable implements Runnable {
+        private final Importer importer;
+
+        ImportRunnable(Importer importer) {
+            this.importer = importer;
+        }
 
         @Override
         public void run() {
+            try {
+                runImport();
+            } catch (Exception e) {
+                LOGGER.error("Import error.", e);
+                exceptionInThread = true;
+            }
+        }
+
+        private void runImport() {
             List<Iterable<PhotonDoc>> batch = new ArrayList<>(MAX_QUEUE_SIZE);
             while (true) {
                 if (documents.drainTo(batch) == 0) {
+                    if (producerDone && documents.isEmpty()) {
+                        break;
+                    }
                     try {
-                        batch.add(documents.take());
+                        var item = documents.poll(500, TimeUnit.MILLISECONDS);
+                        if (item != null) {
+                            batch.add(item);
+                        } else {
+                            continue;
+                        }
                     } catch (InterruptedException e) {
                         LOGGER.info("Interrupted exception", e);
                         // Restore interrupted state.
                         Thread.currentThread().interrupt();
+                        break;
                     }
                 }
                 for (Iterable<PhotonDoc> docs : batch) {
-                    if (docs == FINAL_DOCUMENT) {
-                        importer.finish();
-                        return;
-                    }
                     importer.add(docs);
                 }
                 batch.clear();
             }
+            importer.finish();
         }
     }
 

--- a/src/main/java/de/komoot/photon/opensearch/Importer.java
+++ b/src/main/java/de/komoot/photon/opensearch/Importer.java
@@ -61,12 +61,6 @@ public class Importer implements de.komoot.photon.Importer {
         if (todoDocuments > 0) {
             saveDocuments();
         }
-
-        try {
-            client.indices().refresh(r -> r.index(PhotonIndex.NAME));
-        } catch (IOException e) {
-            LOGGER.warn("Refresh of database failed", e);
-        }
     }
 
     private void saveDocuments() {

--- a/src/test/java/de/komoot/photon/TestServer.java
+++ b/src/test/java/de/komoot/photon/TestServer.java
@@ -52,7 +52,17 @@ public class TestServer {
     }
 
     public Importer createImporter(DatabaseProperties dbProperties) {
-        return testServer.createImporter(dbProperties);
+        var inner = testServer.createImporter(dbProperties);
+        return new Importer() {
+            @Override
+            public void add(Iterable<PhotonDoc> docs) { inner.add(docs); }
+
+            @Override
+            public void finish() {
+                inner.finish();
+                refreshTestServer();
+            }
+        };
     }
 
     public Updater createUpdater(DatabaseProperties dbProperties) {


### PR DESCRIPTION
Use a specified number of parallel consumer threads for OpenSearch bulk indexing, optimally one per shard (=5). Each thread has its own Importer instance with an independent BulkRequest buffer, sharing the thread-safe OpenSearchClient.

Replaces the sentinel-based single-thread shutdown with a volatile flag + poll timeout for clean multi-thread termination.

Benchmark (Belgium 11GB, 4.9M docs): 221s -> 166s (25% faster).