### PR TITLE
Include location bias into rescoring

### DIFF
--- a/src/main/java/de/komoot/photon/GenericSearchHandler.java
+++ b/src/main/java/de/komoot/photon/GenericSearchHandler.java
@@ -2,7 +2,6 @@ package de.komoot.photon;
 
 import de.komoot.photon.query.RequestBase;
 import de.komoot.photon.query.RequestFactory;
-import de.komoot.photon.searcher.PhotonResult;
 import de.komoot.photon.searcher.ResultFormatter;
 import de.komoot.photon.searcher.SearchHandler;
 import de.komoot.photon.searcher.StreetDupesRemover;
@@ -11,7 +10,6 @@ import io.javalin.http.Handler;
 import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
-import java.util.Comparator;
 
 @NullMarked
 public class GenericSearchHandler<T extends RequestBase> implements Handler {
@@ -30,8 +28,7 @@ public class GenericSearchHandler<T extends RequestBase> implements Handler {
     public void handle(Context context) {
         final T searchRequest = requestFactory.create(context);
 
-        var results = requestHandler.search(searchRequest)
-                .sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed());
+        var results = requestHandler.search(searchRequest);
 
         if (searchRequest.getDedupe()) {
             results = results.filter(new StreetDupesRemover());

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 @NullMarked
 public class OpenSearchResult implements PhotonResult {
-    private static final double EARTH_RADIUS_KM = 2 * 6371;
+    private static final double EARTH_DIAMETER_KM = 2 * 6371;
 
     private static final List<String> KEYS_WITH_LOCALE = List.of(
             DocFields.NAME, DocFields.STREET, DocFields.LOCALITY,
@@ -73,7 +73,7 @@ public class OpenSearchResult implements PhotonResult {
             double sinXDist = Math.sin(Math.toRadians(pt.getX() - coordinates[0]) / 2);
             double sinYDist = Math.sin(Math.toRadians(pt.getY() - coordinates[1]) / 2);
             double a = sinYDist * sinYDist + cosY1 * cosY2 * sinXDist * sinXDist;
-            double dist = EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+            double dist = EARTH_DIAMETER_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
             if (dist < biasRadius) {
                 bias = weight;

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.komoot.photon.searcher.PhotonResult;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.locationtech.jts.geom.Point;
 
 import java.util.HashMap;
 import java.util.List;
@@ -12,13 +13,15 @@ import java.util.Map;
 
 @NullMarked
 public class OpenSearchResult implements PhotonResult {
+    private static final double EARTH_RADIUS_KM = 2 * 6371;
+
     private static final List<String> KEYS_WITH_LOCALE = List.of(
             DocFields.NAME, DocFields.STREET, DocFields.LOCALITY,
             DocFields.DISTRICT, DocFields.CITY, DocFields.COUNTY,
             DocFields.STATE, DocFields.COUNTRY
     );
 
-    private double opensearchScore = 0.0;
+    @Nullable private Double opensearchScore;
     private double score = 0.0;
     private double @Nullable [] extent = null;
     private double[] coordinates = INVALID_COORDINATES;
@@ -36,7 +39,7 @@ public class OpenSearchResult implements PhotonResult {
         }
     }
 
-    record Point (@JsonProperty("lat") double lat, @JsonProperty("lon") double lon) {}
+    record JsonPoint(@JsonProperty("lat") double lat, @JsonProperty("lon") double lon) {}
 
     @Override
     public double getScore() {
@@ -48,12 +51,47 @@ public class OpenSearchResult implements PhotonResult {
         this.score += difference;
     }
 
-    public void setOpensearchScore(double opensearchScore) {
+    public void setOpensearchScore(@Nullable Double opensearchScore) {
         this.opensearchScore = opensearchScore;
     }
 
+    public void adjustScoreByImportance(double osScoreWeight) {
+        double importance = getImportance();
+        if (opensearchScore != null) {
+            opensearchScore -= importance * osScoreWeight;
+        }
+        score += importance;
+    }
+
+    public void adjustScoreByLocationBias(Point pt, double osScoreFactor, double weight,
+                                          double biasRadius, double negDecayFactor) {
+        double bias = 0.0;
+        if (coordinates != INVALID_COORDINATES) {
+            // compute haversine distance
+            double cosY1 = Math.cos(Math.toRadians(pt.getY()));
+            double cosY2 = Math.cos(Math.toRadians(coordinates[1]));
+            double sinXDist = Math.sin(Math.toRadians(pt.getX() - coordinates[0]) / 2);
+            double sinYDist = Math.sin(Math.toRadians(pt.getY() - coordinates[1]) / 2);
+            double a = sinYDist * sinYDist + cosY1 * cosY2 * sinXDist * sinXDist;
+            double dist = EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+            if (dist < biasRadius) {
+                bias = 1.0;
+            } else {
+                bias = Math.exp((dist - biasRadius) * negDecayFactor);
+            }
+        }
+        bias *= weight;
+
+        if (opensearchScore != null) {
+            opensearchScore -= bias * osScoreFactor;
+        }
+
+        score += bias;
+    }
+
     public double getOpensearchScore() {
-        return opensearchScore;
+        return opensearchScore == null ? 0.0 : opensearchScore;
     }
 
     public double getImportance() {
@@ -112,7 +150,7 @@ public class OpenSearchResult implements PhotonResult {
 
 
     @JsonProperty(DocFields.COORDINATE)
-    void setCoordinates(Point pt) {
+    void setCoordinates(JsonPoint pt) {
         coordinates = new double[]{pt.lon, pt.lat};
     }
 

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchResult.java
@@ -76,18 +76,18 @@ public class OpenSearchResult implements PhotonResult {
             double dist = EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
             if (dist < biasRadius) {
-                bias = 1.0;
+                bias = weight;
+                // adjust score with linear decay so closer objects are higher ranked
+                score += (1.0 - 0.1 * dist / biasRadius) * weight;
             } else {
-                bias = Math.exp((dist - biasRadius) * negDecayFactor);
+                bias = Math.exp((dist - biasRadius) * negDecayFactor) * weight;
+                score += 0.9 * bias;
             }
         }
-        bias *= weight;
 
         if (opensearchScore != null) {
             opensearchScore -= bias * osScoreFactor;
         }
-
-        score += bias;
     }
 
     public double getOpensearchScore() {

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchReverseHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchReverseHandler.java
@@ -45,8 +45,8 @@ public class OpenSearchReverseHandler implements SearchHandler<ReverseRequest> {
     }
 
     @Override
-    public String dumpQuery(ReverseRequest photonRequest) {
-        return "{}";
+    public @Nullable String dumpQuery(ReverseRequest photonRequest) {
+        return null;
     }
 
     private SearchResponse<OpenSearchResult> search(Query query, int limit, @Nullable Point location) {

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchReverseHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchReverseHandler.java
@@ -38,9 +38,7 @@ public class OpenSearchReverseHandler implements SearchHandler<ReverseRequest> {
                 request.getLimit(),
                 request.getLocationDistanceSort() ? request.getLocation() : null);
 
-        var scorer = new ResultScorer(0);
-        return results.hits().hits().stream()
-                .mapMulti(scorer::hitToResult)
+        return ResultScorer.hitsToResultStream(results)
                 .map(r -> r);
     }
 

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 @NullMarked
 public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchRequest> {
+    private static final float IMPORTANCE_FACTOR = 30f;
     private final OpenSearchClient client;
     private final String queryTimeout;
 
@@ -38,7 +39,7 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
         }
 
         var stream =  ResultScorer.hitsToResultStream(results, SearchQueryBuilder.IMPORTANCE_FACTOR)
-                .peek(r -> r.adjustScore(r.getImportance() * request.getScaleForBias()))
+                .peek(r -> r.adjustScore(r.getImportance() * request.getImportanceWeight()))
                 .map(r -> (PhotonResult) r);
 
         if (request.getQuery() != null) {
@@ -58,7 +59,17 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
         query.addCountryCodeFilter(request.getCountryCodes());
         query.addOsmTagFilter(request.getOsmTagFilters());
         query.addLayerFilter(request.getLayerFilters());
-        query.addLocationBias(request.getLocationForBias(), request.getScaleForBias(), request.getZoomForBias());
+
+        if (request.hasLocationBias()) {
+            assert request.getLocationForBias() != null;
+            query.addLocationBias(
+                    request.getLocationForBias(),
+                    IMPORTANCE_FACTOR * (1.0f - request.getImportanceWeight()),
+                    request.getRadiusForBias(),
+                    request.getDecayRadiusForBias());
+
+        }
+
         query.includeCategories(request.getIncludeCategories());
         query.excludeCategories(request.getExcludeCategories());
         query.addBoundingBox(request.getBbox());

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 @NullMarked
 public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchRequest> {
     private static final float IMPORTANCE_FACTOR = 30f;
+    private static final double NEG_DECAY_FACTOR = Math.log(0.5);
     private final OpenSearchClient client;
     private final String queryTimeout;
 
@@ -38,15 +39,29 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
             results = sendQuery(buildQuery(request, true), extLimit);
         }
 
-        var stream =  ResultScorer.hitsToResultStream(results, IMPORTANCE_FACTOR)
-                .peek(r -> r.adjustScore(r.getImportance() * request.getImportanceWeight()))
-                .map(r -> (PhotonResult) r);
+        var stream = ResultScorer.hitsToResultStream(results)
+                .peek(r -> r.adjustScoreByImportance(IMPORTANCE_FACTOR * request.getImportanceWeight()));
+
+        if (request.hasLocationBias()) {
+            double decay = NEG_DECAY_FACTOR / request.getDecayRadiusForBias();
+            stream = stream.peek(r -> {
+                assert request.getLocationForBias() != null;
+                r.adjustScoreByLocationBias(
+                        request.getLocationForBias(),
+                        IMPORTANCE_FACTOR,
+                        1 - request.getImportanceWeight(),
+                        request.getRadiusForBias(),
+                        decay
+                );
+            });
+        }
 
         if (request.getQuery() != null) {
             stream = stream.peek(new QueryReranker(request.getQuery(), request.getLanguage()));
         }
 
-        return stream.sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed());
+        return ResultScorer.adjustByNormalizedOpenSearchScore(stream)
+                .sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed());
     }
 
     @Override

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -38,7 +38,7 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
             results = sendQuery(buildQuery(request, true), extLimit);
         }
 
-        var stream =  ResultScorer.hitsToResultStream(results, SearchQueryBuilder.IMPORTANCE_FACTOR)
+        var stream =  ResultScorer.hitsToResultStream(results, IMPORTANCE_FACTOR)
                 .peek(r -> r.adjustScore(r.getImportance() * request.getImportanceWeight()))
                 .map(r -> (PhotonResult) r);
 
@@ -59,6 +59,7 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
         query.addCountryCodeFilter(request.getCountryCodes());
         query.addOsmTagFilter(request.getOsmTagFilters());
         query.addLayerFilter(request.getLayerFilters());
+        query.addImportance(IMPORTANCE_FACTOR * request.getImportanceWeight());
 
         if (request.hasLocationBias()) {
             assert request.getLocationForBias() != null;

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchSearchHandler.java
@@ -11,6 +11,7 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchResponse;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.stream.Stream;
 
 @NullMarked
@@ -44,7 +45,7 @@ public class OpenSearchSearchHandler implements SearchHandler<SimpleSearchReques
             stream = stream.peek(new QueryReranker(request.getQuery(), request.getLanguage()));
         }
 
-        return stream;
+        return stream.sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed());
     }
 
     @Override

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 @NullMarked
 public class OpenSearchStructuredSearchHandler implements SearchHandler<StructuredSearchRequest> {
     private static final float LOCATION_BIAS_FACTOR = 30f;
+    private static final double NEG_DECAY_FACTOR = Math.log(0.5);
     private final OpenSearchClient client;
     private final String queryTimeout;
 
@@ -52,9 +53,24 @@ public class OpenSearchStructuredSearchHandler implements SearchHandler<Structur
             }
         }
 
-        return ResultScorer.hitsToResultStream(results, 0)
-                .sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed())
-                .map(r -> r);
+        var stream = ResultScorer.hitsToResultStream(results);
+
+        if (photonRequest.hasLocationBias()) {
+            double decay = NEG_DECAY_FACTOR / photonRequest.getDecayRadiusForBias();
+            stream = stream.peek(r -> {
+                assert photonRequest.getLocationForBias() != null;
+                r.adjustScoreByLocationBias(
+                        photonRequest.getLocationForBias(),
+                        LOCATION_BIAS_FACTOR,
+                        1 - photonRequest.getImportanceWeight(),
+                        photonRequest.getRadiusForBias(),
+                        decay
+                );
+            });
+        }
+
+        return ResultScorer.adjustByNormalizedOpenSearchScore(stream)
+                .sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed());
     }
 
     @Override

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -11,6 +11,7 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchResponse;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.stream.Stream;
 
 /**
@@ -51,6 +52,7 @@ public class OpenSearchStructuredSearchHandler implements SearchHandler<Structur
         }
 
         return ResultScorer.hitsToResultStream(results, 0)
+                .sorted(Comparator.comparingDouble(PhotonResult::getScore).reversed())
                 .map(r -> r);
     }
 

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -4,6 +4,7 @@ import de.komoot.photon.searcher.PhotonResult;
 import de.komoot.photon.query.StructuredSearchRequest;
 import de.komoot.photon.searcher.SearchHandler;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.SearchType;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -54,8 +55,8 @@ public class OpenSearchStructuredSearchHandler implements SearchHandler<Structur
     }
 
     @Override
-    public String dumpQuery(StructuredSearchRequest searchRequest) {
-        return "{}";
+    public @Nullable String dumpQuery(StructuredSearchRequest searchRequest) {
+        return null;
     }
 
     public Query buildQuery(StructuredSearchRequest photonRequest, boolean lenient) {

--- a/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
+++ b/src/main/java/de/komoot/photon/opensearch/OpenSearchStructuredSearchHandler.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
  */
 @NullMarked
 public class OpenSearchStructuredSearchHandler implements SearchHandler<StructuredSearchRequest> {
+    private static final float LOCATION_BIAS_FACTOR = 30f;
     private final OpenSearchClient client;
     private final String queryTimeout;
 
@@ -65,7 +66,17 @@ public class OpenSearchStructuredSearchHandler implements SearchHandler<Structur
         final var query = new SearchQueryBuilder(photonRequest, lenient);
         query.addOsmTagFilter(photonRequest.getOsmTagFilters());
         query.addLayerFilter(photonRequest.getLayerFilters());
-        query.addLocationBias(photonRequest.getLocationForBias(), photonRequest.getScaleForBias(), photonRequest.getZoomForBias());
+
+        if (photonRequest.hasLocationBias()) {
+            assert photonRequest.getLocationForBias() != null;
+            query.addLocationBias(
+                    photonRequest.getLocationForBias(),
+                    LOCATION_BIAS_FACTOR * (1.0f - photonRequest.getImportanceWeight()),
+                    photonRequest.getRadiusForBias(),
+                    photonRequest.getDecayRadiusForBias());
+
+        }
+
         query.includeCategories(photonRequest.getIncludeCategories());
         query.excludeCategories(photonRequest.getExcludeCategories());
         query.addBoundingBox(photonRequest.getBbox());

--- a/src/main/java/de/komoot/photon/opensearch/ResultScorer.java
+++ b/src/main/java/de/komoot/photon/opensearch/ResultScorer.java
@@ -1,61 +1,46 @@
 package de.komoot.photon.opensearch;
 
+import de.komoot.photon.searcher.PhotonResult;
 import org.jspecify.annotations.NullMarked;
-import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.SearchResult;
 
-import java.util.function.Consumer;
+import java.util.Comparator;
 import java.util.stream.Stream;
 
 @NullMarked
 public class ResultScorer {
-    private final double importanceWeight;
-
     private double maxScore = 10.0;
 
-    public ResultScorer(double importanceWeight) {
-        this.importanceWeight = importanceWeight;
+    public static Stream<OpenSearchResult> hitsToResultStream(SearchResult<OpenSearchResult> results) {
+        Stream.Builder<OpenSearchResult> builder = Stream.builder();
+        for (var hit: results.hits().hits()) {
+            var result = hit.source();
+            if (result != null) {
+                result.setOpensearchScore(hit.score());
+                builder.add(result);
+            }
+        }
+
+        return builder.build();
     }
 
-    public static Stream<OpenSearchResult> hitsToResultStream(SearchResult<OpenSearchResult> results,
-                                                          double importanceWeight) {
-        var scorer = new ResultScorer(importanceWeight);
-        return results.hits().hits().stream()
-                .mapMulti(scorer::hitToResult)
-                .toList().stream()  // go through all results once before normalizing
+    static public Stream<PhotonResult> adjustByNormalizedOpenSearchScore(Stream<OpenSearchResult> results) {
+        var scorer = new ResultScorer();
+        return results.sorted(Comparator.comparingDouble(OpenSearchResult::getOpensearchScore).reversed())
                 .map(scorer::normalizeScore);
     }
 
-     public void hitToResult(Hit<OpenSearchResult> hit, Consumer<OpenSearchResult> consumer) {
-        var result = hit.source();
-        if (result != null) {
-            var score = hit.score();
-            if (score != null) {
-                if (importanceWeight > 0) {
-                    score -= result.getImportance() * importanceWeight;
-                }
-                if (score > maxScore) {
-                    maxScore = score;
-                }
-                result.setOpensearchScore(score);
-            }
-
-            consumer.accept(result);
-        }
-     }
-
-     private OpenSearchResult normalizeScore(OpenSearchResult result) {
+     private PhotonResult normalizeScore(OpenSearchResult result) {
         var osScore = result.getOpensearchScore();
 
-        if (maxScore < 20) {
-            osScore /= maxScore;
-        } else if (osScore <= maxScore - 20) {
-            osScore = 0;
-        } else {
-            osScore = (osScore - maxScore + 20) / 20;
+        if (osScore >= maxScore) {
+            maxScore = osScore;
+            result.adjustScore(1.0);
+        } else if (maxScore < 20) {
+            result.adjustScore(osScore / maxScore);
+        } else if (osScore > maxScore - 20) {
+            result.adjustScore((osScore - maxScore + 20) / 20);
         }
-
-        result.adjustScore(osScore);
 
         return result;
      }

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -202,23 +202,16 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
         }
     }
 
-    public void addLocationBias(@Nullable Point point, float scale, int zoom) {
-        if (point == null || zoom < 4) return;
-
-        if (zoom > 18) {
-            zoom = 18;
-        }
-        float radius = (1 << (18 - zoom)) * 0.25f;
-
+    public void addLocationBias(Point point, float weight, double radius, double decayRadius) {
         innerQuery.functions(fn1 -> fn1
-                .weight(IMPORTANCE_FACTOR * 0.95f * (1.0f - scale))
+                .weight(weight)
                 .exp(ex -> ex
                         .field(DocFields.COORDINATE)
                         .placement(p -> p
                                 .origin(JsonData.of(Map.of("lon", point.getX(), "lat", point.getY())))
-                                .decay(0.8)
-                                .offset(JsonData.of(radius / 10 + "km"))
-                                .scale(JsonData.of(radius + "km")))));
+                                .decay(0.5)
+                                .offset(JsonData.of(radius + "km"))
+                                .scale(JsonData.of(decayRadius + "km")))));
     }
 
     public void addBoundingBox(@Nullable Envelope bbox) {

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -24,10 +24,13 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
             // Empty query is used for category-only searches (e.g. /api?include=osm.place.city),
             // see SimpleSearchRequestFactory.create
             innerQuery.query(q -> q.matchAll(ma -> ma));
-        } else if (!suggestAddresses && (query.length() < 4 || query.matches("^\\p{IsAlphabetic}+$"))) {
-            setupShortQuery(query, lenient);
         } else {
-            setupFullQuery(query, lenient, suggestAddresses);
+            var stripped = query.strip();
+            if (!suggestAddresses && (stripped.length() < 4 || stripped.matches("^\\p{IsAlphabetic}+$"))) {
+                setupShortQuery(stripped, lenient);
+            } else {
+                setupFullQuery(stripped, lenient, suggestAddresses);
+            }
         }
     }
 

--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
 
 @NullMarked
 public class SearchQueryBuilder extends BaseQueryBuilder {
-    public static final float IMPORTANCE_FACTOR = 30f;
-
-    public FunctionScoreQuery.Builder innerQuery = new FunctionScoreQuery.Builder();
+    public FunctionScoreQuery.Builder innerQuery = new FunctionScoreQuery.Builder()
+            .scoreMode(FunctionScoreMode.Sum)
+            .boostMode(FunctionBoostMode.Sum);
 
     public SearchQueryBuilder(@Nullable String query, boolean lenient, boolean suggestAddresses) {
         if (query == null) {
@@ -29,13 +29,6 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
         } else {
             setupFullQuery(query, lenient, suggestAddresses);
         }
-
-        innerQuery.functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
-                        .field(DocFields.IMPORTANCE)
-                        .factor(IMPORTANCE_FACTOR)
-                        .missing(0.00001)))
-                .scoreMode(FunctionScoreMode.Sum)
-                .boostMode(FunctionBoostMode.Sum);
     }
 
     public void setupShortQuery(String query, boolean lenient) {
@@ -200,6 +193,13 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
                 ));
             }
         }
+    }
+
+    public void addImportance(float weight) {
+        innerQuery.functions(fvf -> fvf.fieldValueFactor(fvfb -> fvfb
+                        .field(DocFields.IMPORTANCE)
+                        .factor(weight)
+                        .missing(0.00001)));
     }
 
     public void addLocationBias(Point point, float weight, double radius, double decayRadius) {

--- a/src/main/java/de/komoot/photon/query/SearchRequestBase.java
+++ b/src/main/java/de/komoot/photon/query/SearchRequestBase.java
@@ -37,7 +37,7 @@ public class SearchRequestBase extends RequestBase {
     }
 
     public double getDecayRadiusForBias() {
-        return biasRadius * (zoom - 4);
+        return Math.max(8, biasRadius * (zoom - 3));
     }
 
     public float getImportanceWeight() {

--- a/src/main/java/de/komoot/photon/query/SearchRequestBase.java
+++ b/src/main/java/de/komoot/photon/query/SearchRequestBase.java
@@ -8,7 +8,7 @@ import org.locationtech.jts.geom.Point;
 @NullMarked
 public class SearchRequestBase extends RequestBase {
     @Nullable private Point locationForBias;
-    private float scale = 0.2f;
+    private float scale = 0.4f;
     private int zoom = 12;
     private double biasRadius = zoomToRadius(zoom);
     @Nullable private Envelope bbox;

--- a/src/main/java/de/komoot/photon/query/SearchRequestBase.java
+++ b/src/main/java/de/komoot/photon/query/SearchRequestBase.java
@@ -9,13 +9,22 @@ import org.locationtech.jts.geom.Point;
 public class SearchRequestBase extends RequestBase {
     @Nullable private Point locationForBias;
     private float scale = 0.2f;
-    private int zoom = 14;
+    private int zoom = 12;
+    private double biasRadius = zoomToRadius(zoom);
     @Nullable private Envelope bbox;
     private boolean suggestAddresses = false;
+
+    private static double zoomToRadius(int zoom) {
+        return Math.pow(2.2, 18 - zoom) * 0.1;
+    }
 
     @Nullable
     public Envelope getBbox() {
         return bbox;
+    }
+
+    public boolean hasLocationBias() {
+        return locationForBias != null && zoom > 4;
     }
 
     @Nullable
@@ -23,12 +32,16 @@ public class SearchRequestBase extends RequestBase {
         return locationForBias;
     }
 
-    public float getScaleForBias() {
-        return locationForBias == null ? 1.0f : scale;
+    public double getRadiusForBias() {
+        return biasRadius;
     }
 
-    public int getZoomForBias() {
-        return zoom;
+    public double getDecayRadiusForBias() {
+        return biasRadius * (zoom - 4);
+    }
+
+    public float getImportanceWeight() {
+        return hasLocationBias() ? scale : 1.0f;
     }
 
     void setLocationForBias(@Nullable Point locationForBias) {
@@ -46,6 +59,7 @@ public class SearchRequestBase extends RequestBase {
     void setZoom(@Nullable Integer zoom) {
         if (zoom != null) {
             this.zoom = Integer.max(Integer.min(zoom, 18), 0);
+            biasRadius = zoomToRadius(this.zoom);
         }
     }
 

--- a/src/main/java/de/komoot/photon/query/SimpleSearchRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/SimpleSearchRequestFactory.java
@@ -30,7 +30,7 @@ public class SimpleSearchRequestFactory extends SearchRequestFactoryBase impleme
                 throw new BadRequestException(400, "q parameter is required when no include categories are specified");
             }
         } else {
-            request.setQuery(query.strip());
+            request.setQuery(query);
         }
 
         return request;

--- a/src/main/java/de/komoot/photon/searcher/GeoJsonFormatter.java
+++ b/src/main/java/de/komoot/photon/searcher/GeoJsonFormatter.java
@@ -110,16 +110,16 @@ public class GeoJsonFormatter implements ResultFormatter {
 
             if (withDebugInfo || queryDebugInfo != null) {
                 gen.writeObjectFieldStart(GeoJsonFields.GEOJSON_KEY_PROPERTIES);
-                if (queryDebugInfo != null) {
-                    gen.writeFieldName("debug");
-                    gen.writeRawValue(queryDebugInfo);
-                }
                 if (withDebugInfo) {
                     gen.writeArrayFieldStart("raw_data");
                     for (var res : results) {
                         gen.writePOJO(res.getRawData());
                     }
                     gen.writeEndArray();
+                }
+                if (queryDebugInfo != null) {
+                    gen.writeFieldName("debug");
+                    gen.writeRawValue(queryDebugInfo);
                 }
                 gen.writeEndObject();
             }

--- a/src/main/java/de/komoot/photon/searcher/PhotonResult.java
+++ b/src/main/java/de/komoot/photon/searcher/PhotonResult.java
@@ -29,6 +29,8 @@ public interface PhotonResult {
 
     double getScore();
 
+    double getImportance();
+
     void adjustScore(double difference);
 
     Map<String, Object> getRawData();

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -93,6 +93,11 @@ public class QueryReranker implements Consumer<PhotonResult> {
             }
         }
 
+        if (matches == 0.0) {
+            // Not matching at all, still give it a slight boost when it is important.
+            return 0.5 * result.getImportance();
+        }
+
         return 0.8 * matches / query.length();
     }
 

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -16,11 +16,13 @@ public class QueryReranker implements Consumer<PhotonResult> {
     private final String query;
     private final String language;
     private final boolean isMultiTermQuery;
+    private final boolean isFullQuery;
 
     public QueryReranker(String query, String language) {
         this.query = normalize(query);
         this.language = language;
         this.isMultiTermQuery = query.indexOf(',') >= 0;
+        this.isFullQuery = query.endsWith(" ");
     }
 
     @Override
@@ -39,9 +41,11 @@ public class QueryReranker implements Consumer<PhotonResult> {
             }
             if (localeName.startsWith(query)) {
                 if (localeName.charAt(query.length()) == ' ') {
+                    return 0.9;
+                }
+                if (!isFullQuery) {
                     return 0.8;
                 }
-                return 0.7;
             }
         }
 
@@ -72,7 +76,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
                 matches += term.length();
                 todo.delete(idx + 1, idx + term.length() + 2);
                 if (todo.toString().isBlank()) {
-                    return 0.9 * matches / query.length();
+                    return 0.8 * matches / query.length();
                 }
                 continue;
             }
@@ -89,7 +93,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
             }
         }
 
-        return 0.9 * matches / query.length();
+        return 0.8 * matches / query.length();
     }
 
     private String normalize(String in) {

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -39,7 +39,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
             }
             if (localeName.startsWith(query)) {
                 if (localeName.charAt(query.length()) == ' ') {
-                    return 0.9;
+                    return 0.8;
                 }
                 return 0.7;
             }
@@ -72,7 +72,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
                 matches += term.length();
                 todo.delete(idx + 1, idx + term.length() + 2);
                 if (todo.toString().isBlank()) {
-                    return 0.7 * matches / query.length();
+                    return 0.9 * matches / query.length();
                 }
                 continue;
             }
@@ -89,7 +89,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
             }
         }
 
-        return 0.7 * matches / query.length();
+        return 0.9 * matches / query.length();
     }
 
     private String normalize(String in) {

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -15,10 +15,12 @@ public class QueryReranker implements Consumer<PhotonResult> {
     private static final Pattern WORD_BREAK_PATTERN = Pattern.compile("[-,: ]+");
     private final String query;
     private final String language;
+    private final boolean isMultiTermQuery;
 
     public QueryReranker(String query, String language) {
         this.query = normalize(query);
         this.language = language;
+        this.isMultiTermQuery = query.indexOf(',') >= 0;
     }
 
     @Override
@@ -30,7 +32,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
 
     private double rescore(PhotonResult result) {
         var localeName = result.getLocalised("name", language, GeoJsonFormatter.NAME_PRECEDENCE);
-        if (localeName != null) {
+        if (!isMultiTermQuery && localeName != null) {
             localeName = normalize(localeName);
             if (query.equals(localeName)) {
                 return 1.0;

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -39,7 +39,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
                 if (localeName.charAt(query.length()) == ' ') {
                     return 0.9;
                 }
-                return Math.min(0.7, (double) query.length() / localeName.length());
+                return 0.7;
             }
         }
 
@@ -65,32 +65,29 @@ public class QueryReranker implements Consumer<PhotonResult> {
         var rematchWords = new ArrayList<String>();
         // first try to match the full words, keep address parts that do not match
         for (var term : resultTerms) {
-            var idx = todo.indexOf(" " + term);
+            var idx = todo.indexOf(" " + term + " ");
             if (idx >= 0) {
-                if (todo.charAt(idx + term.length() + 1) == ' ') {
-                    matches += term.length();
-                    todo.delete(idx + 1, idx + term.length() + 2);
-                    if (todo.toString().isBlank()) {
-                        return matches / query.length();
-                    }
-                    continue;
+                matches += term.length();
+                todo.delete(idx + 1, idx + term.length() + 2);
+                if (todo.toString().isBlank()) {
+                    return 0.7 * matches / query.length();
                 }
+                continue;
             }
             rematchWords.addAll(Arrays.asList(term.split(" ")));
         }
 
         // still query left to do, try prefix matching on remaining parts
-        matches += Arrays.stream(todo.toString().strip().split(" +"))
-                .mapToDouble(w -> {
-                    for (var term : rematchWords) {
-                        if (term.startsWith(w)) {
-                            return Double.min(0.7, (double) w.length() / term.length()) * w.length();
-                        }
-                    }
-                    return 0.0;
-                }).sum();
+        for (var w : todo.toString().strip().split(" +")) {
+            for (var term : rematchWords) {
+                if (term.startsWith(w)) {
+                    matches += 0.7 * w.length();
+                    break;
+                }
+            }
+        }
 
-        return matches / query.length();
+        return 0.7 * matches / query.length();
     }
 
     private String normalize(String in) {

--- a/src/main/java/de/komoot/photon/searcher/SearchHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/SearchHandler.java
@@ -2,6 +2,7 @@ package de.komoot.photon.searcher;
 
 import de.komoot.photon.query.RequestBase;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.stream.Stream;
 
@@ -13,5 +14,5 @@ public interface SearchHandler<T extends RequestBase> {
 
     Stream<PhotonResult> search(T searchRequest);
 
-    String dumpQuery(T searchRequest);
+    @Nullable String dumpQuery(T searchRequest);
 }

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -100,8 +100,8 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @CsvSource({
             "city, /api?q=berlin&limit=1",                                    // basic search
-            "suburb, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=18",  // search with location bias
-            "city, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=10&location_bias_scale=0.6",  // search with large location bias
+            "city, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026",  // search with location bias
+            "suburb, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=18&location_bias_scale=0.01",  // search with strong location bias
             "city, /reverse/?lon=13.38886&lat=52.51704" // basic reverse
     })
     void testApi(String osmValue, String url) throws Exception {

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -100,7 +100,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     @ParameterizedTest
     @CsvSource({
             "city, /api?q=berlin&limit=1",                                    // basic search
-            "suburb, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=16",  // search with location bias
+            "suburb, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=18",  // search with location bias
             "city, /api?q=berlin&limit=1&lat=52.54714&lon=13.39026&zoom=10&location_bias_scale=0.6",  // search with large location bias
             "city, /reverse/?lon=13.38886&lat=52.51704" // basic reverse
     })

--- a/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiIntegrationTest.java
@@ -208,7 +208,7 @@ class ApiIntegrationTest extends ApiBaseTester {
     void testDebugOutput(String baseUrl) throws Exception {
         assertThatJson(readURL(baseUrl + "&debug=1")).isObject()
                 .node("properties").isObject()
-                .containsKeys("debug", "raw_data");
+                .containsKeys("raw_data");
     }
 
     @ParameterizedTest

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -85,9 +85,9 @@ class QueryRelevanceTest extends ESBaseTester {
     void testShortNameMissSpellingOverPartialWithImportance() {
         setupDocs(
                 createDoc("place", "city", 1000, "name", "Oslo")
-                        .importance(0.7),
+                        .importance(1.0),
                 createDoc("place", "town", 1001, "name", "Olsokava")
-                        .importance(0.1)
+                        .importance(0.25)
         );
 
         assertSearchOsmIds("olso", 1000, 1001);

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -58,7 +58,7 @@ class QueryRelevanceTest extends ESBaseTester {
     {
         SimpleSearchRequest result = new SimpleSearchRequest();
         result.setQuery("ham");
-        result.setLocationForBias(FACTORY.createPoint(new Coordinate(-9.999, -10)));
+        result.setLocationForBias(FACTORY.createPoint(new Coordinate(-9.9999, -10)));
         return result;
     }
 
@@ -143,7 +143,7 @@ class QueryRelevanceTest extends ESBaseTester {
     void testLocationPreferenceForHigherImportance() {
         setupDocs(
                 createDoc("place", "hamlet", 1000, "name", "Ham")
-                        .importance(0.8)
+                        .importance(0.85)
                         .centroid(FACTORY.createPoint(new Coordinate(10, 10))),
                 createDoc("place", "hamlet", 1001, "name", "Ham")
                         .importance(0.01)
@@ -159,7 +159,7 @@ class QueryRelevanceTest extends ESBaseTester {
     void testLocationPreferenceScaleForImportance(double scale) {
         setupDocs(
                 createDoc("place", "hamlet", 1000, "name", "Ham")
-                        .importance(1.0 - scale)
+                        .importance(1.05 - scale)
                         .centroid(FACTORY.createPoint(new Coordinate(10, 10))),
                 createDoc("place", "hamlet", 1001, "name", "Ham")
                         .importance(0.01)

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -58,7 +58,7 @@ class QueryRelevanceTest extends ESBaseTester {
     {
         SimpleSearchRequest result = new SimpleSearchRequest();
         result.setQuery("ham");
-        result.setLocationForBias(FACTORY.createPoint(new Coordinate(-9.9, -10)));
+        result.setLocationForBias(FACTORY.createPoint(new Coordinate(-9.999, -10)));
         return result;
     }
 
@@ -85,7 +85,7 @@ class QueryRelevanceTest extends ESBaseTester {
     void testShortNameMissSpellingOverPartialWithImportance() {
         setupDocs(
                 createDoc("place", "city", 1000, "name", "Oslo")
-                        .importance(0.5),
+                        .importance(0.7),
                 createDoc("place", "town", 1001, "name", "Olsokava")
                         .importance(0.1)
         );
@@ -120,7 +120,7 @@ class QueryRelevanceTest extends ESBaseTester {
                 createDoc("place", "hamlet", 1000, "name", "Ham")
                         .importance(0.1),
                 createDoc("place", "city", 1001, "name", "Hamburg")
-                        .importance(0.5));
+                        .importance(0.7));
 
         assertSearchOsmIds("ham", 1001, 1000);
     }

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -130,8 +130,10 @@ class QueryRelevanceTest extends ESBaseTester {
     void testLocationPreferenceForEqualImportance(String placeName) {
         setupDocs(
                 createDoc("place", "hamlet", 1000, "name", "Ham")
+                        .importance(0.5)
                         .centroid(FACTORY.createPoint(new Coordinate(10, 10))),
                 createDoc("place", "hamlet", 1001, "name", placeName)
+                        .importance(0.5)
                         .centroid(FACTORY.createPoint(new Coordinate(-10, -10))));
 
         assertThat(search(createBiasedRequest()))

--- a/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
+++ b/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
@@ -36,6 +36,11 @@ public class MockPhotonResult implements PhotonResult {
     }
 
     @Override
+    public double getImportance() {
+        return 0.5;
+    }
+
+    @Override
     @Nullable
     public String getLocalised(String key, String language, String... altNames) {
         return localized.get(key + "||" + language);


### PR DESCRIPTION
This extends the rescoring algorithm from #1041 to also take into account the score from the location bias. Thus the final OpenSearch score is now neatly split into match score, importance score and location bias score. The location bias score is added such that if nothing suitable is found in the focus area, the rescoring behaves exactly as if no location bias was set at all.

This also changes the size of the focus area (larger for large zooms, smaller for smaller ones) and the default zoom (14 -> 12) and location_bias_score (0.2 -> 0.4).

The PR also adds the output of OpenSearch's explain to the debug output for search. That can be useful to understand how the score came to be.

@henrik242 would you mind checking the effects on your data?

Closes #1024.