### PR TITLE
Enable creation of backwards-compatible extracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,62 @@ jobs:
 
       - name: Update Photon
         run: java -jar "target/photon-$PHOTON_VERSION.jar" update -database nominatim -user runner -password foobar
+
+
+  backwards-compatibility:
+    name: Check backwards compatibility against Photon 1.0.1
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Java 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'gradle'
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq expect
+        shell: bash
+
+      - name: Compile Photon with older OpenSearch version
+        run: ./gradlew assemble -PosVersion=3.5.0.0
+
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # 5.0.3
+        with:
+            path: |
+               andorra.jsonl.zst
+               photon-1.0.1.jar
+            key: old-photon-download
+
+      - name: Download json dump and baseline Photon
+        run: |
+            if [ ! -f andorra.jsonl.zst ]; then
+              wget --no-verbose -O andorra.jsonl.zst https://download1.graphhopper.com/public/europe/andorra/photon-dump-andorra-1.0-latest.jsonl.zst
+            fi
+            if [ ! -f photon-1.0.1.jar ]; then
+              wget --no-verbose -O photon-1.0.1.jar https://github.com/komoot/photon/releases/download/1.0.1/photon-1.0.1.jar
+            fi
+        shell: bash
+
+      - name: Get Photon version
+        run: echo "PHOTON_VERSION=$(./gradlew -q properties --property version | grep '^version:' | awk '{print $2}')" >> "$GITHUB_ENV"
+
+      - name: Import json dump
+        run: zstdcat andorra.jsonl.zst | java -jar "target/photon-$PHOTON_VERSION.jar" import -import-file -
+        shell: bash
+
+      - name: Run serve with baseline version
+        run: expect -c "spawn java -jar photon-1.0.1.jar serve; expect \"You are running Javalin\" { close } eof {exit 2} timeout {exit 2}"
+        shell: bash
+
+      - name: Compile Photon with current OpenSearch version
+        run: ./gradlew assemble
+
+      - name: Run serve with master version
+        run: expect -c "spawn java -jar target/photon-$PHOTON_VERSION.jar serve; expect \"You are running Javalin\" { close } eof {exit 2} timeout {exit 2}"
+        shell: bash

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 }
 
 dependencies {
+    def opensearchVersion = project.properties['osVersion'] ?: '3.6.0.0'
     constraints {
         implementation('commons-io:commons-io') {
             version { require('[2.20.0,)') }
@@ -42,7 +43,7 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:3.8.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.6'
 
-    implementation('org.codelibs.opensearch:opensearch-runner:3.6.0.0') {
+    implementation('org.codelibs.opensearch:opensearch-runner:' + opensearchVersion) {
         exclude(module: 'repository-url')
         exclude(module: 'reindex-client')
         exclude(module: 'rank-eval-client')


### PR DESCRIPTION
As already mentioned in https://github.com/komoot/photon/pull/1029#issuecomment-4003834628, there is an issue with OpenSearch (OS) where OS databases are forward-compatible but not backwards. You can use a database created on an older version of the 3.x series with a newer minor version but not vise versa.

The database extracts on the download server are supposed to work for all releases in a major series of Photon. There simply is no bandwidth to create separate extracts for each minor release. So, in order to make that work, the extracts need to be created against the smallest used OS version in the major Photon release series.

To make that work and still get the newest available minor OS version with each Photon release, I've come up with the following plan: a) always keep the master branch on the latest OS 3.x version and also include these in releases. b) When making a release build a special version of Photon with the lower OS version (currently 3.5) and deploy that on the extract server. This gives us OS 3.5-compatible database extracts while everybody can run a Photon version with the latest and greatest (and securest) OS.

This PR adds two things to make that happen:

1. The OpenSearch version to build into Photon is now configurable on the command line: `./gradlew assemble -PosVersion=3.5.0.0`.
2. A CI tasks checks that OpenSearch doesn't sneak in other incompatibilities that need to be taken care of. The tasks builds a database with a downgraded Photon from master and then runs serve against Photon 1.0.1 (currently the lowest version in the 1.x series that needs to be compatible) and Photon master with latest OS.