### PR TITLE
Submit bulk requests in parallel during import

### DIFF
--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -154,10 +154,11 @@ public class App {
             return;
         }
 
-        final var importThread = new ImportThread(esServer.createImporter(dbProperties));
+        final int maxConcurrentBulks = Math.max(1, cli.getGeneralConfig().getThreads());
+        final var importThread = new ImportThread(esServer.createImporter(dbProperties, maxConcurrentBulks));
 
+        Date importDate = null;
         try {
-            Date importDate;
             if (cli.getImportFileConfig().isEnabled()) {
                 importDate = importFromFile(cli.getImportFileConfig(), importFilterConfig, importThread);
             } else {
@@ -168,13 +169,23 @@ public class App {
                         importThread,
                         dbProperties);
             }
-            dbProperties.setImportDate(importDate);
-            esServer.saveToDatabase(dbProperties);
         } catch (IOException ex) {
             LOGGER.error("IO error while importing", ex);
             return;
         } finally {
             importThread.finish();
+        }
+
+        if (importThread.hasErrors()) {
+            return;
+        }
+
+        dbProperties.setImportDate(importDate);
+        try {
+            esServer.saveToDatabase(dbProperties);
+        } catch (IOException ex) {
+            LOGGER.error("Failed to save database properties after import", ex);
+            return;
         }
 
         LOGGER.info("Database has been successfully set up with the following properties:\n{}", dbProperties);

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -193,8 +193,12 @@ public class Server {
     }
 
     public Importer createImporter(DatabaseProperties dbProperties) {
+        return createImporter(dbProperties, 1);
+    }
+
+    public Importer createImporter(DatabaseProperties dbProperties, int maxConcurrentRequests) {
         registerPhotonDocSerializer(dbProperties);
-        return new de.komoot.photon.opensearch.Importer(client);
+        return new de.komoot.photon.opensearch.Importer(client, maxConcurrentRequests);
     }
 
     public Updater createUpdater(DatabaseProperties dbProperties) {

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -193,8 +193,18 @@ public class Server {
     }
 
     public Importer createImporter(DatabaseProperties dbProperties) {
+        // Tests use this path and drive refresh() explicitly; don't tune refresh_interval,
+        // or the explicit refresh() calls would no-op against refresh_interval=-1.
+        return createImporter(dbProperties, 1, false);
+    }
+
+    public Importer createImporter(DatabaseProperties dbProperties, int maxConcurrentRequests) {
+        return createImporter(dbProperties, maxConcurrentRequests, true);
+    }
+
+    private Importer createImporter(DatabaseProperties dbProperties, int maxConcurrentRequests, boolean tuneRefresh) {
         registerPhotonDocSerializer(dbProperties);
-        return new de.komoot.photon.opensearch.Importer(client);
+        return new de.komoot.photon.opensearch.Importer(client, maxConcurrentRequests, tuneRefresh);
     }
 
     public Updater createUpdater(DatabaseProperties dbProperties) {

--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -30,6 +30,11 @@ public class ImportThread {
     private final long startMillis;
     private volatile boolean exceptionInThread = false;
 
+    /** True after finish() if any error occurred during the import. */
+    public boolean hasErrors() {
+        return exceptionInThread;
+    }
+
     public ImportThread(Importer importer) {
         this.importer = importer;
         this.thread = new Thread(new ImportRunnable());
@@ -88,6 +93,14 @@ public class ImportThread {
                 Thread.currentThread().interrupt();
             }
         }
+        // Defensive: the consumer thread may have died before processing FINAL_DOCUMENT
+        // (uncaught exception in importer.add). Importer.finish() is idempotent.
+        try {
+            importer.finish();
+        } catch (Throwable t) {
+            LOGGER.error("Importer finish failed.", t);
+            exceptionInThread = true;
+        }
         if (!exceptionInThread) {
             LOGGER.info("Finished import of {} photon documents. (Total processing time: {}s)",
                     counter.longValue(), (System.currentTimeMillis() - startMillis) / 1000);
@@ -111,7 +124,8 @@ public class ImportThread {
                 }
                 for (Iterable<PhotonDoc> docs : batch) {
                     if (docs == FINAL_DOCUMENT) {
-                        importer.finish();
+                        // importer.finish() is invoked from ImportThread.finish() on the
+                        // calling thread, so it runs even if this consumer thread dies.
                         return;
                     }
                     importer.add(docs);

--- a/src/main/java/de/komoot/photon/nominatim/ImportThread.java
+++ b/src/main/java/de/komoot/photon/nominatim/ImportThread.java
@@ -7,45 +7,34 @@ import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Worker thread for bulk importing data from a Nominatim database.
+ * Thin wrapper that forwards documents to the importer on the caller's thread and
+ * logs progress. Backpressure flows from the importer's bulk pipeline.
  */
 @NullMarked
 public class ImportThread {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final int PROGRESS_INTERVAL = 50000;
-	private static final int MAX_QUEUE_SIZE = 10_000;
-    private static final List<PhotonDoc> FINAL_DOCUMENT = List.of();
-    private final BlockingQueue<Iterable<PhotonDoc>> documents = new ArrayBlockingQueue<>(MAX_QUEUE_SIZE);
-    private final AtomicLong counter = new AtomicLong();
+
     private final Importer importer;
-    private final Thread thread;
     private final long startMillis;
+    // Multiple reader threads share one ImportThread, so counter and the error
+    // flag need cross-thread visibility.
+    private final AtomicLong counter = new AtomicLong();
     private volatile boolean exceptionInThread = false;
+
+    public boolean hasErrors() {
+        return exceptionInThread;
+    }
 
     public ImportThread(Importer importer) {
         this.importer = importer;
-        this.thread = new Thread(new ImportRunnable());
-        this.thread.setUncaughtExceptionHandler((t, ex) -> {
-            LOGGER.error("Import error.", ex);
-            exceptionInThread = true;
-        });
-        this.thread.start();
         this.startMillis = System.currentTimeMillis();
     }
 
-    /**
-     * Adds the given document from Nominatim to the import queue.
-     *
-     * @param docs Fully filled nominatim document.
-     */
     public void addDocument(@Nullable Iterable<PhotonDoc> docs) {
         if (exceptionInThread) {
             throw new RuntimeException("Import thread failed.");
@@ -55,70 +44,31 @@ public class ImportThread {
             return;
         }
 
-        while (true) {
-            try {
-                documents.put(docs);
-                break;
-            } catch (InterruptedException e) {
-                LOGGER.warn("Thread interrupted while placing document in queue.");
-                // Restore interrupted state.
-                Thread.currentThread().interrupt();
-            }
+        try {
+            importer.add(docs);
+        } catch (RuntimeException e) {
+            exceptionInThread = true;
+            LOGGER.error("Import error.", e);
+            throw e;
         }
 
-        if (counter.incrementAndGet() % PROGRESS_INTERVAL == 0) {
-            final double documentsPerSecond = 1000d * counter.longValue() / (System.currentTimeMillis() - startMillis);
-            LOGGER.info("Imported {} documents [{}/second]", counter.longValue(), documentsPerSecond);
+        final long c = counter.incrementAndGet();
+        if (c % PROGRESS_INTERVAL == 0) {
+            final double documentsPerSecond = 1000d * c / (System.currentTimeMillis() - startMillis);
+            LOGGER.info("Imported {} documents [{}/second]", c, documentsPerSecond);
         }
     }
 
-    /**
-     * Finalize the import.
-     * Sends an end marker to the import thread and then waits for it to join.
-     */
     public void finish() {
-        while (true) {
-            try {
-                documents.put(FINAL_DOCUMENT);
-                thread.join();
-                break;
-            } catch (InterruptedException e) {
-                LOGGER.warn("Thread interrupted while placing document in queue.");
-                // Restore interrupted state.
-                Thread.currentThread().interrupt();
-            }
+        try {
+            importer.finish();
+        } catch (Throwable t) {
+            LOGGER.error("Importer finish failed.", t);
+            exceptionInThread = true;
         }
         if (!exceptionInThread) {
             LOGGER.info("Finished import of {} photon documents. (Total processing time: {}s)",
-                    counter.longValue(), (System.currentTimeMillis() - startMillis) / 1000);
+                    counter.get(), (System.currentTimeMillis() - startMillis) / 1000);
         }
     }
-
-    private class ImportRunnable implements Runnable {
-
-        @Override
-        public void run() {
-            List<Iterable<PhotonDoc>> batch = new ArrayList<>(MAX_QUEUE_SIZE);
-            while (true) {
-                if (documents.drainTo(batch) == 0) {
-                    try {
-                        batch.add(documents.take());
-                    } catch (InterruptedException e) {
-                        LOGGER.info("Interrupted exception", e);
-                        // Restore interrupted state.
-                        Thread.currentThread().interrupt();
-                    }
-                }
-                for (Iterable<PhotonDoc> docs : batch) {
-                    if (docs == FINAL_DOCUMENT) {
-                        importer.finish();
-                        return;
-                    }
-                    importer.add(docs);
-                }
-                batch.clear();
-            }
-        }
-    }
-
 }

--- a/src/main/java/de/komoot/photon/opensearch/BulkRetryHelper.java
+++ b/src/main/java/de/komoot/photon/opensearch/BulkRetryHelper.java
@@ -1,0 +1,88 @@
+package de.komoot.photon.opensearch;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NullMarked;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.transport.httpclient5.ResponseException;
+
+import java.io.IOException;
+
+/**
+ * Sends OpenSearch bulk requests with exponential-backoff retries on HTTP 429 — the
+ * status OpenSearch returns when the parent circuit breaker trips during heavy writes.
+ */
+@NullMarked
+final class BulkRetryHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /** Initial backoff before the first retry; doubled on each subsequent attempt. */
+    private static final long INITIAL_RETRY_DELAY_MS = 500L;
+
+    /** Maximum retry attempts after the initial request. ~64 s backoff on the last try. */
+    private static final int MAX_BULK_RETRIES = 8;
+
+    /** Cap on per-item error log lines per bulk to avoid log flooding. */
+    private static final int ERROR_LOG_LIMIT_PER_BULK = 10;
+
+    private BulkRetryHelper() {
+    }
+
+    /**
+     * Send the bulk request, retrying on HTTP 429 with exponential backoff.
+     * @throws RuntimeException on per-item errors, non-429 transport failures, or retry exhaustion.
+     */
+    static void sendWithRetry(OpenSearchClient client, BulkRequest request) {
+        final int opCount = request.operations().size();
+        IOException lastException = null;
+        for (int attempt = 0; attempt <= MAX_BULK_RETRIES; attempt++) {
+            if (attempt > 0) {
+                sleepBackoff(attempt, opCount);
+            }
+            try {
+                final BulkResponse resp = client.bulk(request);
+                if (resp.errors()) {
+                    throw new RuntimeException(logAndCountItemErrors(resp) + " failed items in bulk");
+                }
+                if (attempt > 0) {
+                    LOGGER.info("Bulk retry succeeded on attempt {}/{}", attempt, MAX_BULK_RETRIES);
+                }
+                return;
+            } catch (IOException e) {
+                if (!(e instanceof ResponseException re && re.status() == 429)) {
+                    throw new RuntimeException("Bulk request failed", e);
+                }
+                lastException = e;
+            }
+        }
+        throw new RuntimeException("Bulk retries exhausted after " + MAX_BULK_RETRIES
+                + " attempts (" + opCount + " operations)", lastException);
+    }
+
+    private static void sleepBackoff(int attempt, int opCount) {
+        final long delayMs = INITIAL_RETRY_DELAY_MS * (1L << (attempt - 1));
+        LOGGER.warn("Bulk rejected (429); retrying {} operations in {} ms (attempt {}/{})",
+                opCount, delayMs, attempt, MAX_BULK_RETRIES);
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during retry backoff", e);
+        }
+    }
+
+    private static int logAndCountItemErrors(BulkResponse response) {
+        int count = 0;
+        for (BulkResponseItem item : response.items()) {
+            if (item.error() != null) {
+                if (count++ < ERROR_LOG_LIMIT_PER_BULK) {
+                    LOGGER.error("Bulk item error: {}", item.toJsonString());
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/de/komoot/photon/opensearch/BulkRetryHelper.java
+++ b/src/main/java/de/komoot/photon/opensearch/BulkRetryHelper.java
@@ -1,0 +1,98 @@
+package de.komoot.photon.opensearch;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NullMarked;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.transport.httpclient5.ResponseException;
+
+import java.io.IOException;
+
+/**
+ * Sends OpenSearch bulk requests with exponential-backoff retries on HTTP 429 — the
+ * status OpenSearch returns when the parent circuit breaker trips during heavy writes.
+ */
+@NullMarked
+final class BulkRetryHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /** Initial backoff before the first retry; doubled on each subsequent attempt. */
+    private static final long INITIAL_RETRY_DELAY_MS = 500L;
+
+    /** Maximum retry attempts after the initial request. ~64 s backoff on the last try. */
+    private static final int MAX_BULK_RETRIES = 8;
+
+    /** Cap on per-item error log lines per bulk to avoid log flooding. */
+    private static final int ERROR_LOG_LIMIT_PER_BULK = 10;
+
+    private BulkRetryHelper() {
+    }
+
+    /**
+     * Send the bulk request, retrying on HTTP 429 with exponential backoff.
+     * @throws RuntimeException on per-item errors, non-429 transport failures, or retry exhaustion.
+     */
+    static void sendWithRetry(OpenSearchClient client, BulkRequest request) {
+        final int opCount = request.operations().size();
+        // ApacheHttpClient5Transport surfaces 429 as ResponseException (an IOException).
+        // Other transports or future versions may route it through the typed-endpoint
+        // converter and throw OpenSearchException (a RuntimeException) instead, so catch
+        // both and key the retry decision off the HTTP status.
+        Exception lastException = null;
+        for (int attempt = 0; attempt <= MAX_BULK_RETRIES; attempt++) {
+            if (attempt > 0) {
+                sleepBackoff(attempt, opCount);
+            }
+            try {
+                final BulkResponse resp = client.bulk(request);
+                if (resp.errors()) {
+                    throw new RuntimeException(logAndCountItemErrors(resp) + " failed items in bulk");
+                }
+                if (attempt > 0) {
+                    LOGGER.info("Bulk retry succeeded on attempt {}/{}", attempt, MAX_BULK_RETRIES);
+                }
+                return;
+            } catch (IOException e) {
+                if (!(e instanceof ResponseException re && re.status() == 429)) {
+                    throw new RuntimeException("Bulk request failed", e);
+                }
+                lastException = e;
+            } catch (OpenSearchException e) {
+                if (e.status() != 429) {
+                    throw e;
+                }
+                lastException = e;
+            }
+        }
+        throw new RuntimeException("Bulk retries exhausted after " + MAX_BULK_RETRIES
+                + " attempts (" + opCount + " operations)", lastException);
+    }
+
+    private static void sleepBackoff(int attempt, int opCount) {
+        final long delayMs = INITIAL_RETRY_DELAY_MS * (1L << (attempt - 1));
+        LOGGER.warn("Bulk rejected (429); retrying {} operations in {} ms (attempt {}/{})",
+                opCount, delayMs, attempt, MAX_BULK_RETRIES);
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during retry backoff", e);
+        }
+    }
+
+    private static int logAndCountItemErrors(BulkResponse response) {
+        int count = 0;
+        for (BulkResponseItem item : response.items()) {
+            if (item.error() != null) {
+                if (count++ < ERROR_LOG_LIMIT_PER_BULK) {
+                    LOGGER.error("Bulk item error: {}", item.toJsonString());
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/de/komoot/photon/opensearch/Importer.java
+++ b/src/main/java/de/komoot/photon/opensearch/Importer.java
@@ -4,27 +4,68 @@ import de.komoot.photon.PhotonDoc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @NullMarked
 public class Importer implements de.komoot.photon.Importer {
     private static final Logger LOGGER = LogManager.getLogger();
 
+    /** Documents per bulk request. */
+    private static final int BULK_SIZE = 10000;
+
+    /** Refresh interval restored on the index after import completes. */
+    private static final String DEFAULT_REFRESH_INTERVAL = "1s";
+
     private final OpenSearchClient client;
-    private BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
-    private int todoDocuments = 0;
-    private boolean hasPrintedNoUpdates = false;
+    private final ExecutorService submitPool;
+    private final Semaphore inFlight;
+    private final Phaser pending = new Phaser(1);
+    private final AtomicReference<@Nullable Throwable> firstFailure = new AtomicReference<>();
+    private final AtomicBoolean hasPrintedNoUpdates = new AtomicBoolean(false);
+    private final AtomicBoolean finished = new AtomicBoolean(false);
+    private final boolean disabledRefresh;
+
+    private BulkRequest.Builder builder = new BulkRequest.Builder();
+    private int todo = 0;
 
     public Importer(OpenSearchClient client) {
+        this(client, 1, false);
+    }
+
+    public Importer(OpenSearchClient client, int maxConcurrentRequests) {
+        this(client, maxConcurrentRequests, true);
+    }
+
+    private Importer(OpenSearchClient client, int maxConcurrentRequests, boolean tuneRefresh) {
         this.client = client;
+        final int threads = Math.max(1, maxConcurrentRequests);
+        this.submitPool = Executors.newFixedThreadPool(threads, r -> {
+            final Thread t = new Thread(r, "photon-bulk-submit");
+            t.setDaemon(true);
+            return t;
+        });
+        this.inFlight = new Semaphore(threads);
+        this.disabledRefresh = tuneRefresh && setRefreshInterval("-1");
     }
 
     @Override
     public void add(Iterable<PhotonDoc> docs) {
+        final Throwable f = firstFailure.get();
+        if (f != null) {
+            throw new RuntimeException("Error inserting new documents", f);
+        }
+
         String placeID = null;
         int objectId = 0;
         for (var doc : docs) {
@@ -32,34 +73,55 @@ public class Importer implements de.komoot.photon.Importer {
                 placeID = doc.getPlaceId();
             }
             if (placeID == null) {
-                if (!hasPrintedNoUpdates) {
+                if (hasPrintedNoUpdates.compareAndSet(false, true)) {
                     LOGGER.warn("Documents have no place_id. Updates will not be possible.");
-                    hasPrintedNoUpdates = true;
                 }
-                bulkRequest.operations(op -> op
-                        .create(i -> i
-                                .index(PhotonIndex.NAME)
-                                .document(doc)));
+                builder.operations(op -> op.create(i -> i.index(PhotonIndex.NAME).document(doc)));
             } else {
                 final String uuid = PhotonDoc.makeUid(placeID, objectId++);
-                bulkRequest.operations(op -> op
-                        .create(i -> i
-                                .index(PhotonIndex.NAME)
-                                .id(uuid)
-                                .document(doc)));
+                builder.operations(op -> op.create(i -> i.index(PhotonIndex.NAME).id(uuid).document(doc)));
             }
-            ++todoDocuments;
-
-            if (todoDocuments % 10000 == 0) {
-                saveDocuments();
+            if (++todo >= BULK_SIZE) {
+                flush();
             }
         }
     }
 
     @Override
     public void finish() {
-        if (todoDocuments > 0) {
-            saveDocuments();
+        // Idempotent: ImportThread.finish() invokes us defensively after thread.join(),
+        // so a normal-path call from the consumer thread plus the defensive call must
+        // collapse to a single execution.
+        if (!finished.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            if (todo > 0) {
+                flush();
+            }
+        } catch (Throwable t) {
+            firstFailure.compareAndSet(null, t);
+        } finally {
+            // Drain any submissions already handed to the pool before returning, even if
+            // the final flush() threw — otherwise background bulk writes could still be
+            // hitting the index after finish() returns. arriveAndAwaitAdvance() does not
+            // throw InterruptedException.
+            pending.arriveAndAwaitAdvance();
+            submitPool.shutdown();
+        }
+
+        // Restore refresh_interval before surfacing any failure — the index is left in a
+        // sane state even when the import aborts, so a subsequent serve is not stuck with
+        // refresh disabled.
+        if (disabledRefresh) {
+            setRefreshInterval(DEFAULT_REFRESH_INTERVAL);
+        }
+
+        final Throwable failure = firstFailure.get();
+        if (failure != null) {
+            LOGGER.error("Import failed.", failure);
+            throw new RuntimeException("Error inserting new documents", failure);
         }
 
         try {
@@ -69,34 +131,53 @@ public class Importer implements de.komoot.photon.Importer {
         }
     }
 
-    private void saveDocuments() {
+    /**
+     * Hand the current bulk off to a submitter thread and reset the builder.
+     * <p>
+     * The {@link #inFlight} semaphore caps concurrent in-flight bulks to the configured
+     * {@code maxConcurrentRequests}, providing backpressure: when all permits are held,
+     * this call blocks until one is released. Retry-on-429 happens synchronously on the
+     * submitter thread via {@link BulkRetryHelper#sendWithRetry}, so a retrying bulk
+     * continues to hold its permit — no separate retry scheduler needed.
+     */
+    private void flush() {
+        final BulkRequest req = builder.build();
+        builder = new BulkRequest.Builder();
+        todo = 0;
+
         try {
-            final var request = bulkRequest.build();
-            final var response = client.bulk(request);
-
-            if (response.errors()) {
-                for (BulkResponseItem bri: response.items()) {
-                    if (bri.status() != 201) {
-                        LOGGER.error("Error during bulk import: {}", bri.toJsonString());
-                        int loggedErrors = 0;
-                        for (var op : request.operations()) {
-                            if (op.isCreate() && bri.id() != null && bri.id().equals(op.create().id())) {
-                                if (++loggedErrors > 10) {
-                                    LOGGER.error("And other bad documents.");
-                                    break;
-                                }
-                                LOGGER.error("Bad document: {}", op.create().document());
-                            }
-                        }
-                    }
-                }
-                throw new RuntimeException("Error inserting new documents");
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Error during bulk import", e);
+            inFlight.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Import interrupted while waiting for a submit slot", e);
         }
+        pending.register();
+        submitPool.execute(() -> {
+            try {
+                BulkRetryHelper.sendWithRetry(client, req);
+            } catch (RuntimeException e) {
+                firstFailure.compareAndSet(null, e);
+            } finally {
+                inFlight.release();
+                pending.arriveAndDeregister();
+            }
+        });
+    }
 
-        bulkRequest = new BulkRequest.Builder();
-        todoDocuments = 0;
+    /**
+     * Apply {@code index.refresh_interval} to the photon index. Returns true if the
+     * setting was accepted; false on failure (in which case we carry on with whatever
+     * interval the index already had).
+     */
+    private boolean setRefreshInterval(String interval) {
+        try {
+            client.indices().putSettings(s -> s
+                    .index(PhotonIndex.NAME)
+                    .settings(set -> set.refreshInterval(Time.of(t -> t.time(interval)))));
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("Could not set refresh_interval={} on index {}.", interval, PhotonIndex.NAME, e);
+            return false;
+        }
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/Importer.java
+++ b/src/main/java/de/komoot/photon/opensearch/Importer.java
@@ -4,27 +4,83 @@ import de.komoot.photon.PhotonDoc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.indices.IndexSettings;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @NullMarked
 public class Importer implements de.komoot.photon.Importer {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private final OpenSearchClient client;
-    private BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
-    private int todoDocuments = 0;
-    private boolean hasPrintedNoUpdates = false;
+    /** Documents per bulk request. */
+    private static final int BULK_SIZE = 10000;
 
-    public Importer(OpenSearchClient client) {
+    /** Fallback refresh_interval if the original value cannot be read. Matches the OpenSearch default. */
+    private static final String FALLBACK_REFRESH_INTERVAL = "1s";
+
+    private final OpenSearchClient client;
+    private final BlockingQueue<BulkRequest> bulkQueue;
+    // Compared by reference identity in submitLoop. The dummy delete is only there so
+    // BulkRequest.Builder.build() passes its required-operations check.
+    private final BulkRequest poison = new BulkRequest.Builder()
+            .operations(op -> op.delete(d -> d.index(PhotonIndex.NAME).id("__photon_poison_pill__")))
+            .build();
+    private final List<Thread> submitThreads;
+    private final AtomicReference<@Nullable Throwable> firstFailure = new AtomicReference<>();
+    private final AtomicBoolean hasPrintedNoUpdates = new AtomicBoolean(false);
+    private final AtomicBoolean finished = new AtomicBoolean(false);
+    private final boolean shouldRestoreRefresh;
+    @Nullable private final String originalRefreshInterval;
+
+    // One accumulator per producer thread keeps add() lock-free across the
+    // multi-reader import path. Cross-thread handoff happens only at bulkQueue.put().
+    private final ConcurrentMap<Thread, Bulk> bulks = new ConcurrentHashMap<>();
+
+    private static final class Bulk {
+        BulkRequest.Builder builder = new BulkRequest.Builder();
+        int todo = 0;
+    }
+
+    public Importer(OpenSearchClient client, int maxConcurrentRequests, boolean tuneRefresh) {
         this.client = client;
+        final int threads = Math.max(1, maxConcurrentRequests);
+        // One slot keeps a fast submitter from idling between builds. Larger buffers
+        // multiply the live-bulk footprint and OOM the embedded OpenSearch under load.
+        this.bulkQueue = new ArrayBlockingQueue<>(1);
+        this.submitThreads = new ArrayList<>(threads);
+        for (int i = 0; i < threads; i++) {
+            final Thread t = new Thread(this::submitLoop, "photon-bulk-submit-" + i);
+            t.setDaemon(true);
+            this.submitThreads.add(t);
+            t.start();
+        }
+        // Read before overwrite: the operator's value may not be the OS default.
+        this.originalRefreshInterval = tuneRefresh ? readRefreshInterval() : null;
+        this.shouldRestoreRefresh = tuneRefresh && setRefreshInterval("-1");
     }
 
     @Override
     public void add(Iterable<PhotonDoc> docs) {
+        final Throwable f = firstFailure.get();
+        if (f != null) {
+            throw new RuntimeException("Error inserting new documents", f);
+        }
+
+        final Bulk b = bulks.computeIfAbsent(Thread.currentThread(), k -> new Bulk());
+
         String placeID = null;
         int objectId = 0;
         for (var doc : docs) {
@@ -32,34 +88,53 @@ public class Importer implements de.komoot.photon.Importer {
                 placeID = doc.getPlaceId();
             }
             if (placeID == null) {
-                if (!hasPrintedNoUpdates) {
+                if (hasPrintedNoUpdates.compareAndSet(false, true)) {
                     LOGGER.warn("Documents have no place_id. Updates will not be possible.");
-                    hasPrintedNoUpdates = true;
                 }
-                bulkRequest.operations(op -> op
-                        .create(i -> i
-                                .index(PhotonIndex.NAME)
-                                .document(doc)));
+                b.builder.operations(op -> op.create(i -> i.index(PhotonIndex.NAME).document(doc)));
             } else {
                 final String uuid = PhotonDoc.makeUid(placeID, objectId++);
-                bulkRequest.operations(op -> op
-                        .create(i -> i
-                                .index(PhotonIndex.NAME)
-                                .id(uuid)
-                                .document(doc)));
+                b.builder.operations(op -> op.create(i -> i.index(PhotonIndex.NAME).id(uuid).document(doc)));
             }
-            ++todoDocuments;
-
-            if (todoDocuments % 10000 == 0) {
-                saveDocuments();
+            if (++b.todo >= BULK_SIZE) {
+                flush(b);
             }
         }
     }
 
     @Override
     public void finish() {
-        if (todoDocuments > 0) {
-            saveDocuments();
+        if (!finished.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            // Safe to iterate without locking: finish() runs after all producer threads
+            // have joined, so no concurrent put into `bulks` is in flight.
+            for (Bulk b : bulks.values()) {
+                if (b.todo > 0) {
+                    flush(b);
+                }
+            }
+        } catch (Throwable t) {
+            firstFailure.compareAndSet(null, t);
+        } finally {
+            // Always drain submitters, even if flush() threw, so no bulks are still
+            // in flight after finish() returns.
+            shutdownSubmitters();
+        }
+
+        // Restore before surfacing failure: a subsequent serve must not be stuck with
+        // refresh disabled. The cluster-default case can't round-trip through the typed
+        // API, so fall back to "1s".
+        if (shouldRestoreRefresh) {
+            setRefreshInterval(originalRefreshInterval != null ? originalRefreshInterval : FALLBACK_REFRESH_INTERVAL);
+        }
+
+        final Throwable failure = firstFailure.get();
+        if (failure != null) {
+            LOGGER.error("Import failed.", failure);
+            throw new RuntimeException("Error inserting new documents", failure);
         }
 
         try {
@@ -69,34 +144,122 @@ public class Importer implements de.komoot.photon.Importer {
         }
     }
 
-    private void saveDocuments() {
+    // Retry-on-429 runs on the submitter thread, keeping the worker busy for the
+    // duration. That's intentional: it slows the producer under sustained 429s
+    // instead of piling on more concurrent bulks.
+    private void flush(Bulk b) {
+        final BulkRequest req = b.builder.build();
+        b.builder = new BulkRequest.Builder();
+        b.todo = 0;
+
         try {
-            final var request = bulkRequest.build();
-            final var response = client.bulk(request);
-
-            if (response.errors()) {
-                for (BulkResponseItem bri: response.items()) {
-                    if (bri.status() != 201) {
-                        LOGGER.error("Error during bulk import: {}", bri.toJsonString());
-                        int loggedErrors = 0;
-                        for (var op : request.operations()) {
-                            if (op.isCreate() && bri.id() != null && bri.id().equals(op.create().id())) {
-                                if (++loggedErrors > 10) {
-                                    LOGGER.error("And other bad documents.");
-                                    break;
-                                }
-                                LOGGER.error("Bad document: {}", op.create().document());
-                            }
-                        }
-                    }
-                }
-                throw new RuntimeException("Error inserting new documents");
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Error during bulk import", e);
+            bulkQueue.put(req);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Import interrupted while waiting for a submit slot", e);
         }
+    }
 
-        bulkRequest = new BulkRequest.Builder();
-        todoDocuments = 0;
+    private void submitLoop() {
+        while (true) {
+            final BulkRequest req;
+            try {
+                req = bulkQueue.take();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            if (req == poison) {
+                return;
+            }
+            // Once any submitter has recorded a hard failure, drop subsequent bulks
+            // without sending. Still drain the queue so producers don't block on put()
+            // until they hit firstFailure on their next add().
+            if (firstFailure.get() != null) {
+                continue;
+            }
+            try {
+                BulkRetryHelper.sendWithRetry(client, req);
+            } catch (Throwable t) {
+                // Errors (OOM, AssertionError, ...) too: a thread that died silently would
+                // hang -j 1 (no consumer to drain the queue) or drop in-flight docs at -j N.
+                firstFailure.compareAndSet(null, t);
+            }
+        }
+    }
+
+    private void shutdownSubmitters() {
+        for (int i = 0; i < submitThreads.size(); i++) {
+            try {
+                bulkQueue.put(poison);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // Don't leave un-poisoned workers blocked on take(); the join below would hang.
+                for (Thread t : submitThreads) t.interrupt();
+                break;
+            }
+        }
+        for (Thread t : submitThreads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Apply {@code index.refresh_interval} to the photon index. Returns true if the
+     * setting was accepted; false on failure (in which case we carry on with whatever
+     * interval the index already had).
+     */
+    private boolean setRefreshInterval(String interval) {
+        try {
+            client.indices().putSettings(s -> s
+                    .index(PhotonIndex.NAME)
+                    .settings(set -> set.refreshInterval(Time.of(t -> t.time(interval)))));
+            return true;
+        } catch (IOException | OpenSearchException e) {
+            LOGGER.warn("Could not set refresh_interval={} on index {}.", interval, PhotonIndex.NAME, e);
+            return false;
+        }
+    }
+
+    /**
+     * Read the current {@code index.refresh_interval} for the photon index, or null if it
+     * is unset (the index is using the cluster default). Returns null on read failure too;
+     * the caller treats that the same as "unknown, use the fallback on restore".
+     */
+    @Nullable
+    private String readRefreshInterval() {
+        try {
+            final var state = client.indices()
+                    .getSettings(g -> g.index(PhotonIndex.NAME))
+                    .get(PhotonIndex.NAME);
+            return state == null ? null : findRefreshInterval(state.settings(), 4);
+        } catch (IOException | OpenSearchException e) {
+            LOGGER.warn("Could not read refresh_interval from index {}.", PhotonIndex.NAME, e);
+            return null;
+        }
+    }
+
+    /**
+     * OpenSearch can nest the value under {@code index} or another {@code settings} key
+     * depending on API version and request options. Walk the known nesting paths and
+     * return the first non-null {@code refresh_interval}. The depth bound guards against
+     * pathological responses.
+     */
+    @Nullable
+    private static String findRefreshInterval(@Nullable IndexSettings settings, int depth) {
+        if (settings == null || depth == 0) {
+            return null;
+        }
+        final Time refresh = settings.refreshInterval();
+        if (refresh != null) {
+            return refresh.time();
+        }
+        final String fromIndex = findRefreshInterval(settings.index(), depth - 1);
+        return fromIndex != null ? fromIndex : findRefreshInterval(settings.settings(), depth - 1);
     }
 }

--- a/src/main/java/de/komoot/photon/opensearch/Updater.java
+++ b/src/main/java/de/komoot/photon/opensearch/Updater.java
@@ -87,13 +87,11 @@ public class Updater implements de.komoot.photon.Updater {
     private void updateDocuments() {
         if (todoDocuments > 0) {
             try {
-                var response = client.bulk(bulkRequest.build());
-
-                if (response.errors()) {
-                    LOGGER.error("Errors during bulk update.");
-                }
-            } catch (IOException e) {
-                LOGGER.error("IO error during bulk update", e);
+                BulkRetryHelper.sendWithRetry(client, bulkRequest.build());
+            } catch (RuntimeException e) {
+                // Preserves the pre-existing silent-continue behaviour on hard failure;
+                // adds 429/circuit-breaker retry resilience via BulkRetryHelper.
+                LOGGER.error("Errors during bulk update.", e);
             }
 
             bulkRequest = new BulkRequest.Builder();


### PR DESCRIPTION
Up to -j N bulk requests are now sent concurrently, with producer backpressure so the pipeline stays bounded.

Bulk writes automatically retry with exponential backoff when OpenSearch pushes back (HTTP 429 from the parent circuit breaker), so large imports don't abort on transient overload.

The index is switched to manual refresh during import and refreshed once at the end, skipping per-second refresh churn.

Belgium benchmark (Apple Silicon, OpenJDK 21, -Xmx4g, 4.95M docs):

                 time     docs/s
    master       233s     21,430
    -j 1         213s     23,260   (-8.6%)
    -j 5         134s     36,970   (-42.5%)

Supercedes #1048 