### PR TITLE
Fix dumping of alternative names

### DIFF
--- a/src/main/java/de/komoot/photon/json/JsonDumper.java
+++ b/src/main/java/de/komoot/photon/json/JsonDumper.java
@@ -226,6 +226,14 @@ public class JsonDumper implements Importer {
             return base;
         }
 
-        return String.format("%s:%s", base, inKey);
+        if ("housename".equals(inKey)) {
+            return "addr:housename";
+        }
+
+        if (dbProperties.getLanguages().contains(inKey)) {
+            return base + ":" + inKey;
+        }
+
+        return inKey + "_" + base;
     }
 }

--- a/src/test/java/de/komoot/photon/json/JsonDumperTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonDumperTest.java
@@ -114,6 +114,8 @@ class JsonDumperTest {
                 .name("name:fi", "Spott")
                 .name("name:de", "Sport")
                 .name("odd_name", "Dot")
+                .name("old_name", "Past Spott")
+                .name("addr:housename", "House")
                 .add(jdbc);
 
         var results = readEntireDatabase();
@@ -133,7 +135,9 @@ class JsonDumperTest {
                 .doesNotContainKeys("parent_place_id", "postcode", "extra")
                 .containsEntry("name", Map.of(
                         "name", "Spot",
-                        "name:de", "Sport"));
+                        "name:de", "Sport",
+                        "old_name", "Past Spott",
+                        "addr:housename", "House"));
     }
 
     @Test


### PR DESCRIPTION
This fixes an issue with the json dumper which would dump alternative names in a colon notation, e.g. `name:old` instead of the expected `old_name`.