### PR TITLE
match interior words exactly in short query

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/SearchQueryBuilder.java
@@ -50,6 +50,18 @@ public class SearchQueryBuilder extends BaseQueryBuilder {
                     .prefixLength(qlen <= 6 ? 1 : 2)
             ));
 
+            // Exact per-word ngram match against .name, to catch interior-word matches
+            // that .name.prefix misses (it concatenates words before n-gramming). Gated
+            // on qlen >= 5 because name_edge_ngram uses minGram=5 and nothing shorter
+            // can match there. Operator.And so multi-word queries require all tokens.
+            if (qlen >= 5) {
+                b.should(nameExact -> nameExact.match(nmb -> nmb
+                        .query(queryField)
+                        .field(DocFields.COLLECTOR + ".name")
+                        .operator(Operator.And)
+                        .boost(0.5f)));
+            }
+
             if (lenient) {
                 b.should(iq2 -> iq2.match(nmb -> nmb
                         .query(queryField)

--- a/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
+++ b/src/test/java/de/komoot/photon/query/QueryRelevanceTest.java
@@ -115,6 +115,18 @@ class QueryRelevanceTest extends ESBaseTester {
     }
 
     @Test
+    void testShortNameInteriorWordMatch() {
+        // Regression: a short query that equals an interior word of a multi-word name
+        // must surface the doc even when another doc is a 1-edit fuzzy match — the
+        // fuzzy hit would otherwise suppress the lenient retry and hide the answer.
+        setupDocs(
+                createDoc("place", "suburb", 1000, "name", "Sky River"),
+                createDoc("place", "village", 1001, "name", "Riven"));
+
+        assertSearchOsmIds("river", 1000, 1001);
+    }
+
+    @Test
     void testPartialNameWithImportanceOverFullName() {
         setupDocs(
                 createDoc("place", "hamlet", 1000, "name", "Ham")


### PR DESCRIPTION
For a doc "Marikoven Pøylo", the query "pøylo" returned nothing - instead finding a 1-edit-away "Pøyso" at another location. That fuzzy hit kept the first query non-empty, so the lenient retry that would have found "pøylo" via the interior-word index never ran.

Add a should-clause that exact-matches the interior-word index for queries of 5 chars or more. Boost 0.5 keeps it below the regular prefix match but above the lenient fuzzy fallback.