### PR TITLE
Add audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ sure you have a JDK installed. Then run:
 
 This will build and test photon. The final jar can be found in the `target` directory.
 
+## Audit Logging
+
+By default incoming requests are not logged. To enable logging of all incoming requests via
+the API, use the parameter `-enable-audit-log`.
+Requests used for (reverse)geocoding will not contain the actual query, unless the additional parameter `-audit-log-no-privacy` is set.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'de.komoot.photon'
-version = '1.0.0'
+version = '1.0.1.r1'
 description = "Geocoder for OSM data (OpenSearch-based version)"
 
 distZip.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'de.komoot.photon'
-version = '1.0.1.r1'
+version = '1.0.0'
 description = "Geocoder for OSM data (OpenSearch-based version)"
 
 distZip.enabled = false

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -39,19 +39,20 @@ public class App {
     private static final AtomicReference<@Nullable Server> esServer = new AtomicReference<>();
     @Nullable private static Javalin photonServer;
 
-    private static String buildAccessLogQuery(Context ctx) {
+    private static String buildAccessLogQuery(Context ctx, ApiServerConfig args) {
         final String path = ctx.path();
         String params = ctx.queryString();
-
+        
         if (path.startsWith("/structured") || path.startsWith("/api") || path.startsWith("/reverse") ) {
-            // do not log any parameters when performing (reverse)geocoding
+            if (args.isDisabledAuditLogPrivacy() == false) {
+                // do not log any parameters when performing (reverse)geocoding
+                params = "";
+            }
+        }
+        if ( params == null || params.isBlank() ) {
             params = "";
         } else {
-            if ( params == null || params.isBlank() || params == "" ) {
-                params = "";
-            } else {
-                params = "?" + params;
-            }
+            params = "?" + params;
         }
         return params;
     }
@@ -344,23 +345,27 @@ public class App {
                          Languages: {}
                          Import Date: {}
                          Support Structured Queries: true
-                         Support Geometries: {}""",
-                dbProperties.getLanguages(), dbProperties.getImportDate(), dbProperties.getSupportGeometries());
+                         Support Geometries: {}
+                         Audit Logging: {},
+                         Audit Logging Privacy Disabled: {}""",
+                dbProperties.getLanguages(), dbProperties.getImportDate(), dbProperties.getSupportGeometries(), args.isEnabledAuditLog(), args.isDisabledAuditLogPrivacy());
 
         MetricsConfig metrics = setupMetrics(args.getMetrics(), server.getClient());
         final var formatter = new GeoJsonFormatter();
 
         photonServer = Javalin.create(config -> {
-            config.requestLogger.http((ctx, ms) -> {
-                ACCESS_LOG.info(
-                    "{} {}{} status={} tookMs={}",
-                    ctx.method(),
-                    ctx.path(),
-                    buildAccessLogQuery(ctx),
-                    ctx.status(),
-                    ms
-                );
-            });
+            if (args.isEnabledAuditLog()) {
+                config.requestLogger.http((ctx, ms) -> {
+                    ACCESS_LOG.info(
+                        "{} {}{} status={} tookMs={}",
+                        ctx.method(),
+                        ctx.path(),
+                        buildAccessLogQuery(ctx, args),
+                        ctx.status(),
+                        ms
+                    );
+                });
+            }
 
             config.router.ignoreTrailingSlashes = true;
             config.http.defaultContentType = ContentType.APPLICATION_JSON.toString();

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -1,5 +1,6 @@
 package de.komoot.photon;
 
+import io.javalin.http.Context;
 import de.komoot.photon.cli.Commands;
 import de.komoot.photon.cli.PhotonCli;
 import de.komoot.photon.config.*;
@@ -34,8 +35,26 @@ import static de.komoot.photon.metrics.MetricsConfig.setupMetrics;
 @NullMarked
 public class App {
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger ACCESS_LOG = LogManager.getLogger("de.komoot.photon.access");
     private static final AtomicReference<@Nullable Server> esServer = new AtomicReference<>();
     @Nullable private static Javalin photonServer;
+
+    private static String buildAccessLogQuery(Context ctx) {
+        final String path = ctx.path();
+        String params = ctx.queryString();
+
+        if (path.startsWith("/structured") || path.startsWith("/api") || path.startsWith("/reverse") ) {
+            // do not log any parameters when performing (reverse)geocoding
+            params = "";
+        } else {
+            if ( params == null || params.isBlank() || params == "" ) {
+                params = "";
+            } else {
+                params = "?" + params;
+            }
+        }
+        return params;
+    }
 
     public static void main(String[] rawArgs) throws Exception {
         PhotonCli cli = new PhotonCli();
@@ -332,6 +351,17 @@ public class App {
         final var formatter = new GeoJsonFormatter();
 
         photonServer = Javalin.create(config -> {
+            config.requestLogger.http((ctx, ms) -> {
+                ACCESS_LOG.info(
+                    "{} {}{} status={} tookMs={}",
+                    ctx.method(),
+                    ctx.path(),
+                    buildAccessLogQuery(ctx),
+                    ctx.status(),
+                    ms
+                );
+            });
+
             config.router.ignoreTrailingSlashes = true;
             config.http.defaultContentType = ContentType.APPLICATION_JSON.toString();
             if (metrics.isEnabled()) {

--- a/src/main/java/de/komoot/photon/config/ApiServerConfig.java
+++ b/src/main/java/de/komoot/photon/config/ApiServerConfig.java
@@ -39,6 +39,18 @@ public class ApiServerConfig {
             """)
     private boolean enableUpdateApi = false;
 
+    @Parameter(names = "-enable-audit-log", category = GROUP, description = """
+            Enable logging of incoming requests. No query parameters are logged
+            for coding requests.
+            """)
+    private boolean enableAuditLog = false;
+
+    @Parameter(names = "-audit-log-no-privacy", category = GROUP, description = """
+            When enabled, all request parameters are logged, even for coding requests.
+            Be cautious, this can contain personal information.
+            """)
+    private boolean disableAuditLogPrivacy = false;
+
     @Parameter(names = "-max-results", category = GROUP, placeholder = "NUM", description = """
             Maximum possible value for the 'limit' parameter for forward geocoding searches
             """)
@@ -91,6 +103,14 @@ public class ApiServerConfig {
         return this.enableUpdateApi;
     }
 
+    public boolean isEnabledAuditLog() {
+        return this.enableAuditLog;
+    }
+
+    public boolean isDisabledAuditLogPrivacy() {
+        return this.disableAuditLogPrivacy;
+    }
+    
     public int getMaxReverseResults() {
         return maxReverseResults;
     }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,17 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="error">
-    <Appenders>
-        <Console name="stderr" target="SYSTEM_ERR">
-            <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
-        </Console>
-        <Async name="ASYNC" bufferSize="500">
-            <AppenderRef ref="stderr"/>
-        </Async>
-    </Appenders>
-    <Loggers>
-        <Logger name="de.komoot.photon" level="info"/>
-        <Root level="warn">
-            <AppenderRef ref="ASYNC" />
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
+      <LevelRangeFilter minLevel="TRACE" maxLevel="INFO"
+                        onMatch="ACCEPT" onMismatch="DENY"/>
+    </Console>
+
+    <Console name="stderr" target="SYSTEM_ERR">
+      <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
+      <ThresholdFilter level="WARN"
+                       onMatch="ACCEPT" onMismatch="DENY"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="de.komoot.photon.access" level="info" additivity="false">
+      <AppenderRef ref="stdout"/>
+    </Logger>
+
+    <Logger name="de.komoot.photon" level="info" additivity="false">
+      <AppenderRef ref="stdout"/>
+      <AppenderRef ref="stderr"/>
+    </Logger>
+
+    <Root level="warn">
+      <AppenderRef ref="stderr"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,31 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="error">
   <Appenders>
+
     <Console name="stdout" target="SYSTEM_OUT">
       <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
-      <LevelRangeFilter minLevel="TRACE" maxLevel="INFO"
-                        onMatch="ACCEPT" onMismatch="DENY"/>
+      <LevelRangeFilter minLevel="TRACE" maxLevel="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
     </Console>
+    <Async name="ASYNC_stdout" bufferSize="500">
+      <AppenderRef ref="stdout" />
+    </Async>
 
     <Console name="stderr" target="SYSTEM_ERR">
       <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
-      <ThresholdFilter level="WARN"
-                       onMatch="ACCEPT" onMismatch="DENY"/>
+      <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
     </Console>
+    <Async name="ASYNC_stderr" bufferSize="500">
+      <AppenderRef ref="stderr" />
+    </Async>
+
   </Appenders>
 
   <Loggers>
+
     <Logger name="de.komoot.photon.access" level="info" additivity="false">
-      <AppenderRef ref="stdout"/>
+      <AppenderRef ref="ASYNC_stdout"/>
     </Logger>
 
     <Logger name="de.komoot.photon" level="info" additivity="false">
-      <AppenderRef ref="stdout"/>
-      <AppenderRef ref="stderr"/>
+      <AppenderRef ref="ASYNC_stdout"/>
+      <AppenderRef ref="ASYNC_stderr"/>
     </Logger>
 
     <Root level="warn">
-      <AppenderRef ref="stderr"/>
+      <AppenderRef ref="ASYNC_stderr"/>
     </Root>
+
   </Loggers>
 </Configuration>


### PR DESCRIPTION
This pull request adds audit logging capabilities. This means, that every incoming request is logged to stdout.
To enable this feature, the parameter `-enable-audit-log` has to be set.

By default, no query content is stored to ensure privacy. To also log the content of each query, the parameter `-audit-log-no-privacy` can be set.
