### PR TITLE
fold apostrophe variants to ASCII

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -20,6 +20,17 @@ import java.util.stream.Collectors;
 public class IndexSettingBuilder {
     private static final String SYNONYM_FILTER = "extra_synonyms";
     private static final String CLASSIFICATION_FILTER = "classification_synonyms";
+
+    /** Apostrophe variants we fold to ASCII ' before any tokenization or
+     *  word-delimiter filter runs, so curly apostrophes in input data tokenize
+     *  the same way as ASCII ones. */
+    private static final String[] APOSTROPHE_VARIANTS = {
+            "’",   // U+2019 RIGHT SINGLE QUOTATION MARK
+            "‘",   // U+2018 LEFT SINGLE QUOTATION MARK
+            "ʼ",   // U+02BC MODIFIER LETTER APOSTROPHE
+            "ʻ"    // U+02BB MODIFIER LETTER TURNED COMMA
+    };
+
     private final IndexSettingsAnalysis.Builder settings = new IndexSettingsAnalysis.Builder();
     private int numShards = 1;
     private boolean hasSynonymFilter = false;
@@ -121,7 +132,7 @@ public class IndexSettingBuilder {
                         .preserveOriginal(false))
         ));
 
-        builder.charFilter("punctuationgreedy");
+        builder.charFilter("normalize_apostrophes");
         builder.tokenizer("search_tokenizer");
         builder.filter(normFilters);
 
@@ -159,6 +170,7 @@ public class IndexSettingBuilder {
                 )
         ));
 
+        builder.charFilter("normalize_apostrophes");
         builder.tokenizer("collection_split");
         builder.filter("delimited_term_freq", "multiplexer_" + name, "drop_empty_tokens", "unique");
 
@@ -211,7 +223,15 @@ public class IndexSettingBuilder {
                 .length(l -> l.min(1).max(500))
         ));
 
-        // Search analyzers
+        // Apostrophe folding: applied to both the index and the search side so that
+        // typographic and modifier apostrophe variants tokenize identically to ASCII '.
+        final var apostropheMappings = Arrays.stream(APOSTROPHE_VARIANTS)
+                .map(v -> v + " => '")
+                .toList();
+        settings.charFilter("normalize_apostrophes", f -> f.definition(d -> d
+                .mapping(m -> m.mappings(apostropheMappings))
+        ));
+
         settings.charFilter("punctuationgreedy", f -> f.definition(d -> d
                 .patternReplace(p -> p.pattern("'").replacement(" "))
         ));
@@ -226,6 +246,7 @@ public class IndexSettingBuilder {
         settings.analyzer("search", f -> f.custom(buildSearchAnalyzer(NORMALIZATION_FILTERS)));
 
         settings.analyzer("search_prefix", f -> f.custom(d -> d
+                .charFilter("normalize_apostrophes")
                 .tokenizer("keyword")
                 .filter("keep_alphanum")
                 .filter(NORMALIZATION_FILTERS)
@@ -285,6 +306,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_name_ngram", f -> f.custom(d -> d
+                .charFilter("normalize_apostrophes")
                 .tokenizer("collection_split")
                 .filter("delimited_term_freq",
                         "delimiter_whitespace",
@@ -295,6 +317,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_name_prefix", f -> f.custom(d -> d
+                .charFilter("normalize_apostrophes")
                 .tokenizer("collection_split")
                 .filter("delimited_term_freq",
                         "keep_alphanum")
@@ -303,6 +326,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_name_full", f -> f.custom(d -> d
+                .charFilter("normalize_apostrophes")
                 .tokenizer("keyword")
                 .filter("keep_alphanum")
                 .filter(NORMALIZATION_FILTERS)
@@ -321,7 +345,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_raw", f -> f.custom(d -> d
-                .charFilter("punctuationgreedy")
+                .charFilter("normalize_apostrophes", "punctuationgreedy")
                 .tokenizer("standard")
                 .filter(NORMALIZATION_FILTERS)
         ));

--- a/src/test/java/de/komoot/photon/opensearch/ApostropheNormalizationTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/ApostropheNormalizationTest.java
@@ -1,0 +1,69 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.query.SimpleSearchRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApostropheNormalizationTest extends ESBaseTester {
+
+    @BeforeAll
+    void setUp(@TempDir Path dataDirectory) throws IOException {
+        setUpES(dataDirectory);
+        var importer = makeImporter();
+        importer.add(List.of(
+                doc(1, "Tiffany’s"),   // RIGHT SINGLE QUOTATION MARK
+                doc(2, "Hawaiʻi"),     // MODIFIER LETTER TURNED COMMA
+                doc(3, "O'Connor")     // ASCII baseline
+        ));
+        importer.finish();
+        refresh();
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    private PhotonDoc doc(long id, String name) {
+        return new PhotonDoc(String.valueOf(id), "N", id, "amenity", "cafe")
+                .names(makeDocNames("name", name))
+                .countryCode("NO")
+                .importance(0.05);
+    }
+
+    private List<String> hitNames(String query) {
+        var request = new SimpleSearchRequest();
+        request.setQuery(query);
+        return getServer().createSearchHandler(20).search(request).toList()
+                .stream()
+                .map(r -> r.getLocalised("name", "en"))
+                .toList();
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @CsvSource({
+            // Indexed with curly, queried with ASCII
+            "'Tiffany''s',  'Tiffany’s'",
+            // Indexed with ASCII, queried with curly
+            "'O’Connor', 'O''Connor'",
+            // Modifier letter folds the same way
+            "'Hawai''i',    'Hawaiʻi'"
+    })
+    void curlyAndAsciiApostrophesMatchEachOther(String query, String expectedName) {
+        assertThat(hitNames(query)).contains(expectedName);
+    }
+}


### PR DESCRIPTION
Add a normalize_apostrophes char filter that maps U+2019, U+2018, U+02BC, U+02BB to U+0027 and wire it into the search analyzer, the classification analyzer, search_prefix, index_name_{ngram,prefix,full}, and index_raw, so typographic apostrophes tokenize identically to ASCII. User-supplied synonyms get the same fold via foldApostrophes.