### PR TITLE
fix "Oslo S" matching possessive POIs

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -275,6 +275,12 @@ public class IndexSettingBuilder {
                         .catenateAll(true))
         ));
 
+        settings.charFilter("expand_possessive", f -> f.definition(d -> d
+                .patternReplace(p -> p
+                        .pattern("(\\p{L}+)'s\\b")
+                        .replacement("$1 $1s"))
+        ));
+
         settings.filter("delimiter_alphanum", f -> f.definition(d -> d
                 .wordDelimiterGraph(w -> w
                         .preserveOriginal(false)
@@ -306,7 +312,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_name_ngram", f -> f.custom(d -> d
-                .charFilter("normalize_apostrophes")
+                .charFilter("normalize_apostrophes", "expand_possessive")
                 .tokenizer("collection_split")
                 .filter("delimited_term_freq",
                         "delimiter_whitespace",

--- a/src/test/java/de/komoot/photon/TestServer.java
+++ b/src/test/java/de/komoot/photon/TestServer.java
@@ -6,6 +6,7 @@ import de.komoot.photon.opensearch.PhotonIndex;
 import de.komoot.photon.searcher.PhotonResult;
 import org.codelibs.opensearch.runner.OpenSearchRunner;
 import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.indices.analyze.AnalyzeToken;
 
 import java.io.IOException;
 import java.util.List;
@@ -99,6 +100,18 @@ public class TestServer {
         }
 
         return null;
+    }
+
+    public List<String> analyze(String analyzer, String text) {
+        try {
+            var response = testServer.getClient().indices().analyze(a -> a
+                    .index(PhotonIndex.NAME)
+                    .analyzer(analyzer)
+                    .text(text));
+            return response.tokens().stream().map(AnalyzeToken::token).collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<PhotonResult> getAll() {

--- a/src/test/java/de/komoot/photon/opensearch/PossessiveTokenizationTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/PossessiveTokenizationTest.java
@@ -1,0 +1,96 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.query.SimpleSearchRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PossessiveTokenizationTest extends ESBaseTester {
+
+    @BeforeAll
+    void setUp(@TempDir Path dataDirectory) throws IOException {
+        setUpES(dataDirectory);
+        var importer = makeImporter();
+        importer.add(List.of(
+                doc(1, "Tiffany's"),
+                doc(2, "Lio's Cafe Bar"),
+                doc(3, "O'Connor"),
+                doc(4, "L'Etoile"),
+                doc(5, "Oslo S")
+        ));
+        importer.finish();
+        refresh();
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    private PhotonDoc doc(long id, String name) {
+        return new PhotonDoc(String.valueOf(id), "N", id, "amenity", "cafe")
+                .names(makeDocNames("name", name))
+                .countryCode("NO")
+                .importance(0.05);
+    }
+
+    private List<String> hitNames(String query) {
+        var request = new SimpleSearchRequest();
+        request.setQuery(query);
+        return getServer().createSearchHandler(20).search(request).toList()
+                .stream()
+                .map(r -> r.getLocalised("name", "en"))
+                .toList();
+    }
+
+    @Test
+    void indexNameNgramAnalyzerOutput() {
+        assertThat(getTestServer().analyze("index_name_ngram", "lio's")).contains("lio", "lios").doesNotContain("s");
+    }
+
+    @Test
+    void osloSDoesNotPullInPossessivePois() {
+        var hits = hitNames("Oslo S");
+        assertThat(hits).contains("Oslo S");
+        assertThat(hits).doesNotContain("Tiffany's", "Lio's Cafe Bar");
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @CsvSource({
+            "'Tiffany',    'Tiffany''s'",
+            "'Lio',        'Lio''s Cafe Bar'",
+            "'O''Connor',  'O''Connor'",
+            "'Connor',     'O''Connor'",
+            "'O Connor',   'O''Connor'",
+            "'L''Etoile',  'L''Etoile'",
+            "'Etoile',     'L''Etoile'"
+    })
+    void queryFindsExpectedHit(String query, String expectedName) {
+        assertThat(hitNames(query)).contains(expectedName);
+    }
+
+    @ParameterizedTest(name = "{0} must NOT surface {1}")
+    @CsvSource({
+            "'Tiffany',  'Lio''s Cafe Bar'",
+            "'Tiffany',  'O''Connor'",
+            "'Connor',   'Tiffany''s'",
+            "'Connor',   'Lio''s Cafe Bar'"
+    })
+    void queryDoesNotReturnUnrelatedHit(String query, String forbiddenName) {
+        assertThat(hitNames(query)).doesNotContain(forbiddenName);
+    }
+}


### PR DESCRIPTION
Strip "'s" only in the index_name_ngram path via a new delimiter_name_ngram filter. delimiter_terms (term collector) stays unchanged so "Lio's" still hits a perfect match.
