### PR TITLE
broaden apostrophe-contraction handling

### DIFF
--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -277,8 +277,14 @@ public class IndexSettingBuilder {
 
         settings.charFilter("expand_possessive", f -> f.definition(d -> d
                 .patternReplace(p -> p
-                        .pattern("(\\p{L}+)'s\\b")
-                        .replacement("$1 $1s"))
+                        .pattern("(?U)(\\p{L}{2,})'(\\p{L}{1,2})\\b|(\\p{L})'(\\p{L})\\b")
+                        .replacement("$1$3 $1$2$3$4"))
+        ));
+
+        settings.charFilter("expand_prefix_contraction", f -> f.definition(d -> d
+                .patternReplace(p -> p
+                        .pattern("(?U)\\b(\\p{L})'(\\p{L}{2,})\\b")
+                        .replacement("$1$2 $2"))
         ));
 
         settings.filter("delimiter_alphanum", f -> f.definition(d -> d
@@ -312,7 +318,7 @@ public class IndexSettingBuilder {
         ));
 
         settings.analyzer("index_name_ngram", f -> f.custom(d -> d
-                .charFilter("normalize_apostrophes", "expand_possessive")
+                .charFilter("normalize_apostrophes", "expand_possessive", "expand_prefix_contraction")
                 .tokenizer("collection_split")
                 .filter("delimited_term_freq",
                         "delimiter_whitespace",

--- a/src/test/java/de/komoot/photon/TestServer.java
+++ b/src/test/java/de/komoot/photon/TestServer.java
@@ -92,14 +92,10 @@ public class TestServer {
                     .index(PhotonIndex.NAME)
                     .id(id), OpenSearchResult.class);
 
-            if (response.found()) {
-                return response.source();
-            }
+            return response.found() ? response.source() : null;
         } catch (IOException e) {
-            // ignore
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public List<String> analyze(String analyzer, String text) {
@@ -122,9 +118,7 @@ public class TestServer {
                     .stream().map(Hit::source)
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            //ignore
+            throw new RuntimeException(e);
         }
-
-        return List.of();
     }
 }

--- a/src/test/java/de/komoot/photon/opensearch/PossessiveTokenizationTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/PossessiveTokenizationTest.java
@@ -29,7 +29,11 @@ class PossessiveTokenizationTest extends ESBaseTester {
                 doc(2, "Lio's Cafe Bar"),
                 doc(3, "O'Connor"),
                 doc(4, "L'Etoile"),
-                doc(5, "Oslo S")
+                doc(5, "Oslo S"),
+                doc(6, "L'Eglise"),
+                doc(7, "O'Reillys"),
+                doc(8, "Saint-Jean d'Acre"),
+                doc(9, "O' Sole Mio")
         ));
         importer.finish();
         refresh();
@@ -60,6 +64,17 @@ class PossessiveTokenizationTest extends ESBaseTester {
     @Test
     void indexNameNgramAnalyzerOutput() {
         assertThat(getTestServer().analyze("index_name_ngram", "lio's")).contains("lio", "lios").doesNotContain("s");
+        assertThat(getTestServer().analyze("index_name_ngram", "o's")).contains("o", "os").doesNotContain("s");
+        assertThat(getTestServer().analyze("index_name_ngram", "Côte d'Or")).contains("cote", "or", "dor");
+        assertThat(getTestServer().analyze("index_name_ngram", "L'Étoile")).contains("letoile", "etoile").doesNotContain("l");
+        assertThat(getTestServer().analyze("index_name_ngram", "L'Église")).contains("leglise", "eglise").doesNotContain("l");
+        assertThat(getTestServer().analyze("index_name_ngram", "L'Été Bar")).contains("lete", "ete", "bar").doesNotContain("l");
+        assertThat(getTestServer().analyze("index_name_ngram", "l'eglise")).contains("eglise", "leglise").doesNotContain("l");
+        assertThat(getTestServer().analyze("index_name_ngram", "o'reillys")).contains("reillys", "oreillys").doesNotContain("o");
+        assertThat(getTestServer().analyze("index_name_ngram", "MainStreet")).contains("main", "street", "mainstreet");
+        assertThat(getTestServer().analyze("index_name_ngram", "d'acre")).contains("dacre", "acre").doesNotContain("d");
+        assertThat(getTestServer().analyze("index_name_ngram", "d'Acre")).contains("acre", "dacre");
+        assertThat(getTestServer().analyze("index_name_ngram", "Saint-Jean d'Acre")).contains("acre", "dacre");
     }
 
     @Test
@@ -77,7 +92,14 @@ class PossessiveTokenizationTest extends ESBaseTester {
             "'Connor',     'O''Connor'",
             "'O Connor',   'O''Connor'",
             "'L''Etoile',  'L''Etoile'",
-            "'Etoile',     'L''Etoile'"
+            "'Etoile',     'L''Etoile'",
+            "'Acre',       'Saint-Jean d''Acre'",
+            "'Saint-Jean', 'Saint-Jean d''Acre'",
+            "'d''Acre',    'Saint-Jean d''Acre'",
+            "'o''so',      'O'' Sole Mio'",
+            "'o''sol',     'O'' Sole Mio'",
+            "'o'' sol',    'O'' Sole Mio'",
+            "'o''sole',    'O'' Sole Mio'"
     })
     void queryFindsExpectedHit(String query, String expectedName) {
         assertThat(hitNames(query)).contains(expectedName);


### PR DESCRIPTION
- expand_possessive now matches 1-2 letter postfixes ('s, 'd, 'll, 've, 're, 'em), covering "Don't Tell Mama", "You're Gorgeous", "Grill'd".
- expand_prefix_contraction handles leading apostrophe contractions ("L'Etoile", "O'Reillys") by emitting both the catenated and suffix forms, so "Oslo L" / "Oslo O" no longer match these POIs.