### PR TITLE
Restore HTTP request-latency histogram buckets in Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+* fix missing HTTP request-latency histogram buckets in Prometheus metrics: the
+  `http.server.requests` timer now publishes percentile histograms, so
+  `http_server_requests_seconds_bucket` and `histogram_quantile()` p95/p99
+  panels work again
+* note: a previous Javalin upgrade renamed the request timer from
+  `jetty.server.requests` to `http.server.requests`; repoint dashboards and
+  alerts from `jetty_server_requests_seconds*` to `http_server_requests_seconds*`
+
 ## [1.2.1] - 2026-06-30
 
 * fix "Request Entity Too Large" error on import with geometry (thanks @henrik242)

--- a/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
+++ b/src/main/java/de/komoot/photon/metrics/MetricsConfig.java
@@ -36,7 +36,10 @@ public class MetricsConfig {
         registry.config().meterFilter(new MeterFilter() {
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-                if (id.getName().equals("jetty.server.requests")) {
+                // Enable percentile histograms for the HTTP request-latency timer only, so we don't
+                // add high-cardinality buckets to unrelated timers (JVM GC pauses, OpenSearch client
+                // timers, etc.).
+                if (id.getName().equals("http.server.requests")) {
                     return DistributionStatisticConfig.builder()
                             .percentilesHistogram(true)
                             .build()

--- a/src/test/java/de/komoot/photon/api/ApiMetricsTest.java
+++ b/src/test/java/de/komoot/photon/api/ApiMetricsTest.java
@@ -68,4 +68,30 @@ class ApiMetricsTest extends ApiBaseTester {
         var conn = connect("/metrics");
         assertThat(conn.getResponseCode()).isEqualTo(404);
     }
+
+    /**
+     * Regression test for the missing HTTP request-latency histogram buckets: Javalin's
+     * MicrometerPlugin records request timings under the "http.server.requests" meter, and the
+     * metrics filter must enable percentile histograms for it. Without the buckets (and their "le"
+     * label) any Grafana panel using histogram_quantile() for p95/p99 latency returns nothing.
+     * A future rename of the emitted meter makes this fail loudly instead of silently dropping
+     * the buckets.
+     */
+    @Test
+    void testMetricsEndpointExposesHttpRequestLatencyHistogram() throws Exception {
+        startAPI("-metrics-enable", "prometheus");
+
+        // Drive real requests so the http.server.requests timer records observations before scraping.
+        readURL("/api?q=berlin");
+        readURL("/reverse?lat=52.54714&lon=13.39026");
+
+        String metrics = readURL("/metrics");
+
+        // A bucket line carrying an "le" label is what histogram_quantile() consumes.
+        assertThat(metrics).containsPattern("http_server_requests_seconds_bucket\\{[^}]*le=\"");
+
+        // The summary series must still be exposed alongside the buckets.
+        assertThat(metrics).contains("http_server_requests_seconds_count");
+        assertThat(metrics).contains("http_server_requests_seconds_sum");
+    }
 }

--- a/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
+++ b/src/test/java/de/komoot/photon/metrics/MetricsConfigTest.java
@@ -1,9 +1,12 @@
 package de.komoot.photon.metrics;
 
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.opensearch.client.opensearch.OpenSearchClient;
+
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,4 +32,51 @@ class MetricsConfigTest {
         assertFalse(metricsConfig.isEnabled());
     }
 
+    /**
+     * The HTTP request-latency timer that Javalin's MicrometerPlugin registers is named
+     * "http.server.requests". The meter filter must enable percentile histograms for it so that
+     * Prometheus gets "_bucket" series with an "le" label, which histogram_quantile() (p95/p99)
+     * depends on. This guards the name the filter matches against accidental edits; the end-to-end
+     * guard against Javalin renaming the emitted meter lives in ApiMetricsTest.
+     */
+    @Test
+    void testHttpServerRequestsTimerExposesHistogramBuckets() {
+        OpenSearchClient openSearchClient = new OpenSearchClient(null) {};
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics("prometheus", openSearchClient);
+        PrometheusMeterRegistry registry = metricsConfig.getRegistry();
+
+        // Mirror the timer emitted by io.javalin.micrometer.MicrometerPlugin for each request.
+        registry.timer("http.server.requests", "method", "GET", "uri", "/api", "status", "200")
+                .record(Duration.ofMillis(5));
+
+        String scrape = registry.scrape();
+
+        assertTrue(scrape.contains("http_server_requests_seconds_bucket"),
+                "expected histogram buckets for http.server.requests, got:\n" + scrape);
+        assertTrue(scrape.contains("le=\""),
+                "expected an 'le' label on the histogram buckets, got:\n" + scrape);
+        assertTrue(scrape.contains("http_server_requests_seconds_count"),
+                "expected _count series to remain present, got:\n" + scrape);
+        assertTrue(scrape.contains("http_server_requests_seconds_sum"),
+                "expected _sum series to remain present, got:\n" + scrape);
+    }
+
+    /**
+     * The histogram must stay scoped to the request timer. Enabling percentile histograms globally
+     * would add high-cardinality buckets to unrelated timers (JVM GC pauses, OpenSearch client
+     * timers, etc.), so an arbitrary timer must not get "_bucket" series.
+     */
+    @Test
+    void testUnrelatedTimerDoesNotExposeHistogramBuckets() {
+        OpenSearchClient openSearchClient = new OpenSearchClient(null) {};
+        MetricsConfig metricsConfig = MetricsConfig.setupMetrics("prometheus", openSearchClient);
+        PrometheusMeterRegistry registry = metricsConfig.getRegistry();
+
+        registry.timer("some.unrelated.timer").record(Duration.ofMillis(5));
+
+        String scrape = registry.scrape();
+
+        assertFalse(scrape.contains("some_unrelated_timer_seconds_bucket"),
+                "unrelated timers must not get histogram buckets, got:\n" + scrape);
+    }
 }


### PR DESCRIPTION
The metric filter still matched the old jetty.server.requests timer, but Javalin renamed it to http.server.requests, so percentile histograms were never enabled and the http_server_requests_seconds_bucket series vanished. Match the current name and add regression tests (filter-level plus an end-to-end scrape).