### PR TITLE
Scale down importance according to search rank of the object

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -74,7 +74,23 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
         }
 
         double importance = rs.getDouble("importance");
-        doc.importance(rs.wasNull() ? (0.40001 - rs.getInt("rank_search") / 75d) : importance);
+        if (rs.wasNull()) {
+            int rank = rs.getInt("rank_search");
+            doc.importance(0.40001 - rank / 75d);
+        } else if (importance < 0.4) {
+            doc.importance(importance);
+        } else {
+            // Nominatim has relatively large importances for POIs of
+            // headquarters of organisations. This scales the importance
+            // by search rank to reduce the influence.
+            int rank = rs.getInt("rank_search");
+            double limit = 0.4 + 0.6 * (1 - rank / 30d);
+            if (importance > limit) {
+                doc.importance(limit + (importance - limit) / 2);
+            } else {
+                doc.importance(importance);
+            }
+        }
 
         return doc;
     }


### PR DESCRIPTION
The [wikipedia-based importances](https://github.com/osm-search/wikipedia-wikidata/) can yield rather high values, when a wikipedia link of an OSM object refers to an organisation rather than to the actual location, for example when the head quarter of a company is tagged. This is not much of an issue for Nominatim because the objects in question usually have rather long names. With its strong bias on full names and preference of objects with higher rank, Nominatim will rarely have them float up. In Photon these importance create serious issues because the basic search is based on single-word tokens rather than on full names.

This PR scales importances down, once they go over a per-rank threshold. The threshold is the lower, the higher the rank is. So organisations, which are usually at POI level (rank 30), will be most affected.

This won't make the false positive results go away but at least it will push them down a bit for ranking.