### PR TITLE
Tweak query rematching to put larger weight on name match

### DIFF
--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -6,9 +6,9 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 @NullMarked
 public class QueryReranker implements Consumer<PhotonResult> {
@@ -35,47 +35,85 @@ public class QueryReranker implements Consumer<PhotonResult> {
     }
 
     private double rescore(PhotonResult result) {
-        var localeName = result.getLocalisedWithFallback("name", language, fallbackLanguage, GeoJsonFormatter.NAME_PRECEDENCE);
-        if (!isMultiTermQuery && localeName != null) {
+        var localeName = result.getLocalisedWithFallback(DocFields.NAME, language, fallbackLanguage, GeoJsonFormatter.NAME_PRECEDENCE);
+        if (localeName != null) {
             localeName = normalize(localeName);
-            if (query.equals(localeName)) {
-                return 1.0;
-            }
-            if (localeName.startsWith(query)) {
-                if (localeName.charAt(query.length()) == ' ') {
-                    return 0.9;
+            if (!isMultiTermQuery) {
+                if (query.equals(localeName)) {
+                    return 1.0;
                 }
-                if (!isFullQuery) {
-                    return 0.8;
+                if (localeName.startsWith(query)) {
+                    if (localeName.charAt(query.length()) == ' ') {
+                        return 0.9;
+                    }
+                    if (!isFullQuery) {
+                        return 0.8;
+                    }
                 }
             }
         }
 
-        // address parts, we want to rematch in the query
-        var resultTerms = Stream.of(
-                        localeName,
-                        (String) result.get(DocFields.HOUSENUMBER),
-                        result.getLocalised(DocFields.STREET, language),
-                        result.getLocalised(DocFields.CITY, language),
-                        (String) result.get(DocFields.COUNTRYCODE),
-                        (String) result.get(DocFields.POSTCODE),
-                        result.getLocalised(DocFields.COUNTRY, language),
-                        result.getLocalised(DocFields.STATE, language),
-                        result.getLocalised(DocFields.COUNTY, language),
-                        result.getLocalised(DocFields.DISTRICT, language),
-                        result.getLocalised(DocFields.NAME, "default"),
-                        result.getLocalised(DocFields.NAME, "alt"))
-                .mapMulti(this::mapNames)
-                .toList();
-
         double matches = 0.0;
         var todo = new StringBuilder(" " + query + " ");
+        var resultTerms = new ArrayList<String>();
+
+        var ccMatch = matchCountry(todo, (String) result.get(DocFields.COUNTRYCODE));
+        if (ccMatch <= 0.0) {
+            ccMatch = matchCountry(todo, result.getLocalised(DocFields.COUNTRY, language));
+            if (ccMatch <= 0.0) {
+                ccMatch = matchCountry(todo, result.getLocalised(DocFields.COUNTRY, "default"));
+            }
+        }
+        matches += 0.85 * ccMatch;
+
+
+        var hnrMatchScore = matchHousenumber(todo, result);
+        var streetName = result.getLocalised(DocFields.STREET, language);
+        if (streetName != null) {
+            streetName = normalize(streetName);
+        }
+
+        if (hnrMatchScore > 0.0) {
+            matches += hnrMatchScore;
+            matches += matchMainTerm(todo, streetName);
+            if (localeName != null) {
+                resultTerms.add(localeName);
+            }
+            resultTerms.addAll(secondaryNames(result));
+        } else {
+            var mainMatch = matchMainTerm(todo, localeName);
+            for (var name: secondaryNames(result)) {
+                if (mainMatch > 0.0) {
+                    break;  // only one of the names can be a match
+                }
+                mainMatch = matchMainTerm(todo, name) * 0.9;
+            }
+            matches += mainMatch;
+            if (streetName != null) {
+                resultTerms.add(streetName);
+            }
+        }
+
+        if (todo.toString().isBlank()) {
+            return 0.8 * matches / query.length();
+        }
+
+        // address parts, we want to rematch in the query
+        mapNames(result.getLocalised(DocFields.CITY, language), resultTerms);
+        mapNames(result.getLocalised(DocFields.STATE, language), resultTerms);
+        mapNames(result.getLocalised(DocFields.COUNTY, language), resultTerms);
+        mapNames(result.getLocalised(DocFields.DISTRICT, language), resultTerms);
+        mapNames((String) result.get(DocFields.POSTCODE), resultTerms);
+        mapNames(result.getLocalised(DocFields.CITY, "default"), resultTerms);
+        mapNames(result.getLocalised(DocFields.STATE, "default"), resultTerms);
+        mapNames(result.getLocalised(DocFields.COUNTY, "default"), resultTerms);
+
         var rematchWords = new ArrayList<String>();
         // first try to match the full words, keep address parts that do not match
         for (var term : resultTerms) {
             var idx = todo.indexOf(" " + term + " ");
             if (idx >= 0) {
-                matches += term.length();
+                matches += 0.8 * term.length();
                 todo.delete(idx + 1, idx + term.length() + 2);
                 if (todo.toString().isBlank()) {
                     return 0.8 * matches / query.length();
@@ -89,7 +127,7 @@ public class QueryReranker implements Consumer<PhotonResult> {
         for (var w : todo.toString().strip().split(" +")) {
             for (var term : rematchWords) {
                 if (term.startsWith(w)) {
-                    matches += 0.7 * w.length();
+                    matches += 0.4 * w.length();
                     break;
                 }
             }
@@ -103,18 +141,100 @@ public class QueryReranker implements Consumer<PhotonResult> {
         return 0.8 * matches / query.length();
     }
 
+    private double matchMainTerm(StringBuilder todo, @Nullable String name) {
+        if (name == null) {
+            return 0.0;
+        }
+
+        var idx = todo.indexOf(" " + name + " ");
+        if (idx >= 0) {
+            todo.delete(idx + 1, idx + name.length() + 2);
+            return name.length();
+        }
+
+        var rematchWords = name.split(" +");
+
+        double matches = 0.0;
+
+        if (rematchWords.length > 1) {
+            for (var term : rematchWords) {
+                idx = todo.indexOf(" " + term + " ");
+                if (idx >= 0) {
+                    todo.delete(idx + 1, idx + term.length() + 2);
+                    matches += term.length();
+                }
+            }
+        }
+
+        return matches * 0.6;
+    }
+
+    private double matchHousenumber(StringBuilder todo, PhotonResult result) {
+        var hnr = (String) result.get(DocFields.HOUSENUMBER);
+
+        if (hnr != null) {
+            var norm = normalize(hnr);
+            var idx = todo.indexOf(" " + norm + " ");
+            if (idx >= 0) {
+                todo.delete(idx + 1, idx + norm.length() + 2);
+                return norm.length();
+            }
+
+            var spaceIdx = norm.indexOf(' ');
+            if (spaceIdx > 0) {
+                idx = todo.indexOf(" " + norm.substring(0, spaceIdx + 1));
+                if (idx > 0) {
+                    todo.delete(idx + 1, idx + spaceIdx + 1);
+                    return 0.5 * spaceIdx;
+                }
+            }
+        }
+
+        return 0.0;
+    }
+
+    private double matchCountry(StringBuilder todo, @Nullable String name) {
+        if (name != null) {
+            var norm = " " + normalize(name) + " ";
+
+            if (norm.length() < todo.length()) {
+                var todoAsString = todo.toString();
+                if (todoAsString.startsWith(norm)) {
+                    todo.delete(0, norm.length() - 1);
+                    return norm.length() - 2;
+                }
+                if (todoAsString.endsWith(norm)) {
+                    todo.delete(todo.length() - norm.length() + 1, todo.length());
+                    return norm.length() - 2;
+                }
+            }
+        }
+
+        return 0.0;
+    }
+
     private String normalize(String in) {
         return WORD_BREAK_PATTERN.matcher(in.toLowerCase()).replaceAll(" ").strip();
     }
 
-    private void mapNames(@Nullable String in, Consumer<String> consumer) {
+    private List<String> secondaryNames(PhotonResult result) {
+        var out = new ArrayList<String>();
+
+        mapNames(result.getLocalised(DocFields.NAME, "default"), out);
+        mapNames(result.getLocalised(DocFields.NAME, "alt"), out);
+
+        return out;
+    }
+
+    private void mapNames(@Nullable String in, ArrayList<String> list) {
         if (in != null) {
             for (var s : in.split(";")) {
                 var finname = normalize(s);
                 if (!finname.isEmpty()) {
-                    consumer.accept(finname);
+                    list.add(finname);
                 }
             }
         }
     }
+
 }

--- a/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
+++ b/src/test/java/de/komoot/photon/searcher/MockPhotonResult.java
@@ -2,6 +2,7 @@ package de.komoot.photon.searcher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.komoot.photon.opensearch.DocFields;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -15,9 +16,16 @@ public class MockPhotonResult implements PhotonResult {
     final double[] coordinates = new double[]{42, 21};
     final double[] extent = new double[]{0, 1, 2, 3};
     final Map<String, String> localized = new HashMap<>();
+    double importance = 0.5;
     double score = 0.0;
 
     ObjectMapper mapper = new ObjectMapper();
+
+    public MockPhotonResult() {}
+
+    public MockPhotonResult(double importance) {
+        this.importance = importance;
+    }
 
     @Override
     public double getScore() {
@@ -37,7 +45,7 @@ public class MockPhotonResult implements PhotonResult {
 
     @Override
     public double getImportance() {
-        return 0.5;
+        return importance;
     }
 
     @Override
@@ -92,6 +100,11 @@ public class MockPhotonResult implements PhotonResult {
         return this;
     }
 
+    public MockPhotonResult putName(String lang, String value) {
+        putLocalized(DocFields.NAME, lang, value);
+        return this;
+    }
+
     public MockPhotonResult putLocalized(String key, String lang, String value) {
         localized.put(key + "||" + lang, value);
         return this;
@@ -105,4 +118,5 @@ public class MockPhotonResult implements PhotonResult {
         }
         return this;
     }
+
 }

--- a/src/test/java/de/komoot/photon/searcher/QueryRankerTest.java
+++ b/src/test/java/de/komoot/photon/searcher/QueryRankerTest.java
@@ -1,0 +1,143 @@
+package de.komoot.photon.searcher;
+
+import de.komoot.photon.opensearch.DocFields;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class QueryRankerTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Munich Main Station", "munich main station", "munich  main station"})
+    void testSimpleNameFullMatch(String query) {
+        QueryReRankerAssert.assertThat(query, "en")
+                .scoresResultEqualTo(1.0,
+                        new MockPhotonResult()
+                                .putName("default", "München Hbf")
+                                .putName("en", "Munich Main Station"));
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en", "default", "alt"})
+    void testPartialNameMatchIsLessThanFullMatch(String lang) {
+        QueryReRankerAssert.assertThat("munich main", "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult().putName(lang, "Munich Main"),
+                        new MockPhotonResult().putName(lang, "Munich Main Station")
+                );
+
+        QueryReRankerAssert.assertThat("munich main", "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult().putName(lang, "Munich Main"),
+                        new MockPhotonResult().putName(lang, "Munich Main S"),
+                        new MockPhotonResult().putName(lang, "Munich Mains")
+                );
+
+        QueryReRankerAssert.assertThat("munich main station", "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult().putName(lang, "Munich Main Station"),
+                        new MockPhotonResult().putName(lang, "Main Station Munich"),
+                        new MockPhotonResult().putName(lang, "Munich Station")
+                );
+    }
+
+    @Test
+    void testLocalizedPreferred() {
+        QueryReRankerAssert.assertThat("foobar", "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult()
+                                .putName("en", "foobar")
+                                .putName("default", "fuubaz"),
+                        new MockPhotonResult()
+                                .putName("default", "foobar")
+                                .putName("en", "foobar street"),
+                        new MockPhotonResult()
+                                .putName("default", "foobar")
+                                .putName("en", "fuubaz")
+                );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Oslo, Norge", "Oslo Norway", "Oslo, no",
+                            "Norge Oslo", "Norway Oslo", "no, oslo"})
+    void testScoreCountryBetterThanAddress(String query) {
+        QueryReRankerAssert.assertThat(query, "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult()
+                                .putName("default", "Oslo")
+                                .putLocalized(DocFields.COUNTRY, "default", "Norge")
+                                .putLocalized(DocFields.COUNTRY, "en", "Norway")
+                                .put(DocFields.COUNTRYCODE, "no"),
+                        new MockPhotonResult()
+                                .putName("default", "Oslo")
+                                .putLocalized(DocFields.CITY, "default", "Norge")
+                                .putLocalized(DocFields.CITY, "en", "Norway")
+                                .putLocalized(DocFields.DISTRICT, "default", "no")
+                );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Oslo, Norge, foo", "Oslo Norway foo", "Oslo, no 3",
+            "i Norge Oslo", "in Norway Oslo", "23 no, oslo"})
+    void testScoreCountryWorseThanAddressInMiddleOfQuery(String query) {
+        QueryReRankerAssert.assertThat(query, "en")
+                .ranksResultsInOrder(
+                        new MockPhotonResult()
+                                .putName("default", "Oslo")
+                                .putLocalized(DocFields.CITY, "default", "Norge")
+                                .putLocalized(DocFields.CITY, "en", "Norway")
+                                .putLocalized(DocFields.DISTRICT, "default", "no"),
+                        new MockPhotonResult()
+                                .putName("default", "Oslo")
+                                .putLocalized(DocFields.COUNTRY, "default", "Norge")
+                                .putLocalized(DocFields.COUNTRY, "en", "Norway")
+                                .put(DocFields.COUNTRYCODE, "no")
+                );
+    }
+
+    @Test
+    void testDoNotMatchCountryOnFullQuery() {
+        QueryReRankerAssert.assertThat("liechtenstein", "de")
+                .scoresResultEqualTo(0.0,
+                        new MockPhotonResult(0.0).putLocalized(DocFields.COUNTRY, "de", "liechtenstein"));
+    }
+
+    @Test
+    void testDoNotMatchCountryCodeOnFullQuery() {
+        QueryReRankerAssert.assertThat("li", "de")
+                .scoresResultEqualTo(0.0,
+                        new MockPhotonResult(0.0).put(DocFields.COUNTRYCODE, "li"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en", "default"})
+    void testHousenumberRankingPreferStreetMatch(String lang) {
+        QueryReRankerAssert.assertThat("12 main", lang)
+                .ranksResultsInOrder(
+                        new MockPhotonResult()
+                                .put(DocFields.HOUSENUMBER, "12")
+                                .putLocalized(DocFields.STREET, "default", "Main"),
+                        new MockPhotonResult()
+                                .put(DocFields.HOUSENUMBER, "12")
+                                .putLocalized(DocFields.STREET, "default", "Chruch Street")
+                                .putName("default", "Main")
+                );
+
+    }
+
+    @Test
+    void testHousenumberFullMatchPrefered() {
+        QueryReRankerAssert.assertThat("12 main", "default")
+                .ranksResultsInOrder(
+                        new MockPhotonResult()
+                                .put(DocFields.HOUSENUMBER, "12")
+                                .putLocalized(DocFields.STREET, "default", "Main"),
+                        new MockPhotonResult()
+                                .put(DocFields.HOUSENUMBER, "12 A")
+                                .putLocalized(DocFields.STREET, "default", "Main")
+                        );
+    }
+}

--- a/src/test/java/de/komoot/photon/searcher/QueryReRankerAssert.java
+++ b/src/test/java/de/komoot/photon/searcher/QueryReRankerAssert.java
@@ -1,0 +1,42 @@
+package de.komoot.photon.searcher;
+
+import org.assertj.core.api.AbstractAssert;
+
+public class QueryReRankerAssert extends AbstractAssert<QueryReRankerAssert, QueryReranker> {
+    public QueryReRankerAssert(QueryReranker actual) {
+        super(actual, QueryReRankerAssert.class);
+    }
+
+    public static QueryReRankerAssert assertThat(String query, String language) {
+        return new QueryReRankerAssert(new QueryReranker(query, language, null));
+    }
+
+    public QueryReRankerAssert ranksResultsInOrder(PhotonResult... results) {
+        isNotNull();
+
+        Double prevScore = null;
+        for (int i = 0; i < results.length; ++i) {
+                actual.accept(results[i]);
+                double newScore = results[i].getScore();
+                if (prevScore != null && newScore >= prevScore) {
+                    failWithMessage("Result %s unexpectedly has larger score (%s) than result %s (%s)",
+                            i, newScore, i - 1, prevScore);
+                }
+                prevScore = newScore;
+        }
+
+        return this;
+    }
+
+    public QueryReRankerAssert scoresResultEqualTo(double score, PhotonResult result) {
+        isNotNull();
+
+        actual.accept(result);
+
+        if (Math.abs(result.getScore() - score) > 0.00001) {
+            failWithActualExpectedAndMessage(result.getScore(), score, "Bad score");
+        }
+
+        return this;
+    }
+}


### PR DESCRIPTION
This tweaks the rematching algorithm to put more weight on full name matches. In detail, it changes the following:

* Name matching is done before address matching and gets a larger weight than a matching address.
* Generally reduce match score for partial matches.
* When a housenumber is present, then the primary matching is against the street name rather than the name of the object.
* Country code and country name matches are only considered if they match completely and appear at the beginning or end of the query.

@henrik242 Could you give this a try to see if there are any regressions?