### PR TITLE
Use housenumber instead of streetnumber for street addresses

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
+++ b/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
@@ -16,9 +16,6 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
    
     public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address) {
         addPlaceAddress(base, address, "conscriptionnumber");
-        // addStreetAddress(base, address, "streetnumber");
-
-        // nově: plný tvar 2531/80 na ulici
         addStreetAddress(base, address, "housenumber");
 
 

--- a/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
+++ b/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
@@ -13,16 +13,20 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
 
     private final List<PhotonDoc> docs = new ArrayList<>();
 
+   
     public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address) {
         addPlaceAddress(base, address, "conscriptionnumber");
-        addStreetAddress(base, address, "streetnumber");
+        // addStreetAddress(base, address, "streetnumber");
+
+        // nově: plný tvar 2531/80 na ulici
+        addStreetAddress(base, address, "housenumber");
+
 
         if (docs.isEmpty()) {
             addGenericAddress(base, address, "housenumber");
         }
 
         if (docs.isEmpty() && base.isUsefulForIndex()) {
-            // Doesn't have housenumbers, so add the original document as the single document
             docs.add(base);
         }
     }

--- a/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
+++ b/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
@@ -15,10 +15,7 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
 
     public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address) {
         addPlaceAddress(base, address, "conscriptionnumber");
-        // Where the house number is split into a conscription and a street number (CZ, SK),
-        // 'housenumber' holds the combined form (e.g. '100/9'). Index that on the street: the
-        // house number analyzer splits it again, so both parts remain searchable on their own.
-        addStreetAddress(base, address, "housenumber");
+        addStreetAddress(base, address);
 
         if (docs.isEmpty()) {
             addGenericAddress(base, address, "housenumber");
@@ -49,11 +46,24 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
         }
     }
 
-    private void addStreetAddress(PhotonDoc base, Map<String, String> address, @SuppressWarnings("SameParameterValue") String key) {
-        if (address.containsKey("street")) {
-            for (String hnr : splitHousenumber(address, key)) {
-                docs.add(new PhotonDoc(base).houseNumber(hnr));
-            }
+    private void addStreetAddress(PhotonDoc base, Map<String, String> address) {
+        if (!address.containsKey("street")) {
+            return;
+        }
+
+        // Where the house number is split into a conscription and a street number (CZ, SK),
+        // 'housenumber' holds the combined form (e.g. '100/9'). The house number analyzer splits
+        // it again, so both parts remain searchable on their own.
+        String[] housenumbers = splitHousenumber(address, "housenumber");
+
+        if (housenumbers.length == 0) {
+            // Be forgiving about addresses that only carry a street number. That is a tagging
+            // error, but a few hundred of them exist, mostly in Slovakia.
+            housenumbers = splitHousenumber(address, "streetnumber");
+        }
+
+        for (String hnr : housenumbers) {
+            docs.add(new PhotonDoc(base).houseNumber(hnr));
         }
     }
 

--- a/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
+++ b/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
@@ -13,17 +13,19 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
 
     private final List<PhotonDoc> docs = new ArrayList<>();
 
-   
     public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address) {
         addPlaceAddress(base, address, "conscriptionnumber");
+        // Where the house number is split into a conscription and a street number (CZ, SK),
+        // 'housenumber' holds the combined form (e.g. '100/9'). Index that on the street: the
+        // house number analyzer splits it again, so both parts remain searchable on their own.
         addStreetAddress(base, address, "housenumber");
-
 
         if (docs.isEmpty()) {
             addGenericAddress(base, address, "housenumber");
         }
 
         if (docs.isEmpty() && base.isUsefulForIndex()) {
+            // Doesn't have housenumbers, so add the original document as the single document
             docs.add(base);
         }
     }

--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -109,15 +109,15 @@ class PhotonDocAddressSetTest {
     @Test
     void testConscriptionAddress() {
         assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
-                "housenumber", "34/50",
-                "conscriptionnumber", "50",
-                "streetnumber", "34",
-                "place", "Nowhere",
-                "street", "Chaussee")))
-                .satisfiesExactly(
-                        d -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
-                        d2 -> assertDocWithHnrAndStreet(d2, "34", "Chaussee"));
-    }
+            "housenumber", "34/50",
+            "conscriptionnumber", "50",
+            "streetnumber", "34",
+            "place", "Nowhere",
+            "street", "Chaussee")))
+            .satisfiesExactly(
+                    d  -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
+                    d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
+}
 
     @Test
     void testBlockAddress() {

--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -109,14 +109,14 @@ class PhotonDocAddressSetTest {
     @Test
     void testConscriptionAddress() {
         assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
-            "housenumber", "34/50",
-            "conscriptionnumber", "50",
-            "streetnumber", "34",
-            "place", "Nowhere",
-            "street", "Chaussee")))
-            .satisfiesExactly(
-                    d  -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
-                    d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
+                "housenumber", "34/50",
+                "conscriptionnumber", "50",
+                "streetnumber", "34",
+                "place", "Nowhere",
+                "street", "Chaussee")))
+                .satisfiesExactly(
+                        d  -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
+                        d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
 }
 
     @Test

--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -117,7 +117,7 @@ class PhotonDocAddressSetTest {
                 .satisfiesExactly(
                         d  -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
                         d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
-}
+    }
 
     @Test
     void testBlockAddress() {

--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -115,7 +115,7 @@ class PhotonDocAddressSetTest {
                 "place", "Nowhere",
                 "street", "Chaussee")))
                 .satisfiesExactly(
-                        d  -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
+                        d -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
                         d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
     }
 

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -386,6 +386,46 @@ class NominatimConnectorDBTest {
                                 AddressType.COUNTRY, COUNTRY_NAMES
                         )));
     }
+
+    /**
+     * When the combined housenumber is tagged as well, then the street address uses the
+     * combined form while the place address keeps the conscription number.
+     */
+    @Test
+    void testObjectWithConscriptionNumberAndHousenumber() {
+        PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
+        PlacexTestRow place = new PlacexTestRow("building", "yes")
+                .addr("housenumber", "99521/34")
+                .addr("streetnumber", "34")
+                .addr("conscriptionnumber", "99521")
+                .addr("place", "Village")
+                .addr("street", "Main St")
+                .parent(parent).add(jdbc);
+
+        place.addAddresslines(jdbc,
+                parent,
+                new PlacexTestRow("place", "city").name("Grand Central").ranks(16).add(jdbc));
+
+        readEntireDatabase();
+
+        importer.assertThatAllByRow(place)
+                .hasSize(2)
+                .anySatisfy(d -> assertThat(d)
+                        .hasFieldOrPropertyWithValue("houseNumber", "99521/34")
+                        .hasFieldOrPropertyWithValue("addressParts", Map.of(
+                                AddressType.STREET, Map.of("default", "Main St"),
+                                AddressType.CITY, Map.of("default", "Grand Central"),
+                                AddressType.COUNTRY, COUNTRY_NAMES
+                        )))
+                .anySatisfy(d -> assertThat(d)
+                        .hasFieldOrPropertyWithValue("houseNumber", "99521")
+                        .hasFieldOrPropertyWithValue("addressParts", Map.of(
+                                AddressType.STREET, Map.of("default", "Village"),
+                                AddressType.CITY, Map.of("default", "Grand Central"),
+                                AddressType.COUNTRY, COUNTRY_NAMES
+                        )));
+    }
+
     /**
      * Unnamed objects are ignored when they do not have a housenumber.
      */


### PR DESCRIPTION
In Czechia, house numbers are commonly represented as a combination of conscription number and street number (e.g. 2531/80). Both parts are used when referring to an address on a street.
Previously, Photon indexed only the street number for street-based addresses. As a result, searches using the conscription number could fail.
This change indexes the full housenumber value instead. OpenSearch tokenizes values such as 2531/80, making it possible to find the address by:

street number (80)
conscription number (2531)
full house number (2531/80)

This approach avoids creating multiple documents for the same address while improving support for Czech address numbering.

## AI assistance disclosure

Per the contribution guidelines: the code change, the added tests and parts of the discussion in this PR were drafted with AI assistance and reviewed by me.

## Verification on a live installation

Verified on a running photon server with the embedded OpenSearch, not only in unit tests. A JSON dump with three addresses was imported twice, once with the current master behaviour and once with this change, and each running server was queried over HTTP.

Test addresses (the `address` part of each dump entry):

| # | tags |
| --- | --- |
| 1 | `street=Kaprova`, `city=Praha`, `conscriptionnumber=2531`, `streetnumber=80`, `housenumber=2531/80` |
| 2 | `place=Lhota`, `city=Lhota`, `conscriptionnumber=100`, `housenumber=100` |
| 3 | `street=Hlavna`, `city=Bratislava`, `streetnumber=34` (no `housenumber`) |

    java -jar photon.jar import -import-file cz-sk-test.jsonl -data-dir <dir> -languages en,cs
    java -jar photon.jar serve -data-dir <dir>

House number returned per query:

| query | before | after |
| --- | --- | --- |
| `Kaprova 2531/80` | `80` | `2531/80` |
| `Kaprova 80` | `80` | `2531/80` |
| `Kaprova 2531` | no result | `2531/80` |
| `Lhota 100` | `100` | `100` |
| `Hlavna 34` | `34` | `34` |

Both imports produce three documents, so no duplicate documents are created: the combined value is indexed once and the house number analyzer splits it. The conscription number becomes searchable and the canonical `2531/80` is returned. The place-based address is unchanged, and address 3, which only carries `addr:streetnumber`, still resolves thanks to the fallback.