### PR TITLE
Add optional -street-housenumber-full import switch

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,6 +149,19 @@ When available, photon can also import full geometries instead of just a
 centroid and bounding box. These geometries will then be returned with the
 response. To enable this, use the **-full-geometries** switch.
 
+In some countries a building carries two numbers: a conscription (descriptive)
+number and a street (orientation) number, which Nominatim exposes together as a
+combined house number such as `2531/80` (for example in Czechia and Slovakia).
+By default photon indexes street-based addresses with the plain street number
+only. Use the **-street-housenumber-full** switch to index them with the full
+combined house number instead. The house number analyzer splits the combined
+form on the delimiter, so the address can still be found by the street number,
+the conscription number or the full combined form. This only affects addresses
+that carry a separate street number; the place-based address variant continues
+to use the conscription number regardless of this setting. The switch is stored
+in the database properties so that follow-up updates keep using the same
+behaviour.
+
 _Hint: if these filtering options are not sufficient, it is always possible
 to preprocess the json dump before feeding it to photon. Have a look at the
 [dump spec](json-dump-format-0.1.0.md) to learn about the format of this

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -269,6 +269,7 @@ public class App {
         reader.setExtraTags(args.getExtraTags());
         reader.setCountryFilter(args.getCountryCodes());
         reader.setLanguages(args.getLanguages());
+        reader.setStreetHousenumberFull(args.getStreetHousenumberFull());
 
         reader.readHeader();
         final var importDate = reader.getImportDate();

--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -26,6 +26,7 @@ public class DatabaseProperties {
     private boolean synonymsInstalled = false;
     private ConfigExtraTags extraTags = new ConfigExtraTags();
     private boolean reverseOnly = false;
+    private boolean streetHousenumberFull = false;
 
     @SuppressWarnings("unused")
     public void setDatabaseVersion(String version) {
@@ -120,6 +121,7 @@ public class DatabaseProperties {
                 ", supportGeometries=" + supportGeometries +
                 ", synonymsInstalled=" + synonymsInstalled +
                 ", extraTags=" + extraTags +
+                ", streetHousenumberFull=" + streetHousenumberFull +
                 '}';
     }
 
@@ -129,5 +131,20 @@ public class DatabaseProperties {
 
     public boolean getReverseOnly() {
         return reverseOnly;
+    }
+
+    /**
+     * Whether street-based addresses that carry a separate street number should be indexed with
+     * the full combined house number (the {@code housenumber} value, e.g. the Czech/Slovak
+     * conscription/orientation form {@code 2531/80}) instead of the plain street number.
+     *
+     * @return {@code true} if the full combined house number is used, {@code false} otherwise.
+     */
+    public boolean getStreetHousenumberFull() {
+        return streetHousenumberFull;
+    }
+
+    public void setStreetHousenumberFull(boolean streetHousenumberFull) {
+        this.streetHousenumberFull = streetHousenumberFull;
     }
 }

--- a/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
+++ b/src/main/java/de/komoot/photon/PhotonDocAddressSet.java
@@ -14,8 +14,27 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
     private final List<PhotonDoc> docs = new ArrayList<>();
 
     public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address) {
+        this(base, address, false);
+    }
+
+    /**
+     * Build the set of address documents for a place.
+     *
+     * @param base                  The document the addresses are derived from.
+     * @param address               The address key/value pairs of the place.
+     * @param streetHousenumberFull When {@code true}, street-based addresses that carry a
+     *                              separate street number (i.e. the conscription/orientation
+     *                              split used in countries such as Czechia and Slovakia) are
+     *                              indexed with the full combined house number (the
+     *                              {@code housenumber} key, e.g. {@code 2531/80}) instead of the
+     *                              plain street number. The house number analyzer still splits
+     *                              the combined form, so the street number and the conscription
+     *                              number stay searchable on their own. When {@code false} (the
+     *                              default) the plain street number is used.
+     */
+    public PhotonDocAddressSet(PhotonDoc base, Map<String, String> address, boolean streetHousenumberFull) {
         addPlaceAddress(base, address, "conscriptionnumber");
-        addStreetAddress(base, address, "streetnumber");
+        addStreetAddress(base, address, streetHousenumberFull);
 
         if (docs.isEmpty()) {
             addGenericAddress(base, address, "housenumber");
@@ -46,11 +65,22 @@ public class PhotonDocAddressSet implements Iterable<PhotonDoc> {
         }
     }
 
-    private void addStreetAddress(PhotonDoc base, Map<String, String> address, @SuppressWarnings("SameParameterValue") String key) {
-        if (address.containsKey("street")) {
-            for (String hnr : splitHousenumber(address, key)) {
-                docs.add(new PhotonDoc(base).houseNumber(hnr));
-            }
+    private void addStreetAddress(PhotonDoc base, Map<String, String> address, boolean streetHousenumberFull) {
+        if (!address.containsKey("street")) {
+            return;
+        }
+
+        // Addresses that split the house number into a street (orientation) number and a
+        // conscription number (e.g. in Czechia and Slovakia) also carry the two joined as a
+        // combined house number such as "2531/80". When requested, index that combined form
+        // instead of the plain street number. The house number analyzer splits it on the
+        // delimiter, so the street number and the conscription number remain searchable on
+        // their own. Ordinary addresses without a separate street number are left untouched.
+        final String key = streetHousenumberFull && address.containsKey("streetnumber")
+                ? "housenumber" : "streetnumber";
+
+        for (String hnr : splitHousenumber(address, key)) {
+            docs.add(new PhotonDoc(base).houseNumber(hnr));
         }
     }
 

--- a/src/main/java/de/komoot/photon/config/ImportFilterConfig.java
+++ b/src/main/java/de/komoot/photon/config/ImportFilterConfig.java
@@ -42,6 +42,14 @@ public class ImportFilterConfig {
             Set up database for reverse geocoding only""")
     private boolean reverseOnly = false;
 
+    @Parameter(names = "-street-housenumber-full", category = GROUP, description = """
+            Index street-based addresses with the full combined house number (the 'housenumber'
+            value, e.g. the Czech/Slovak conscription/orientation form '2531/80') instead of the
+            plain street number. Only affects addresses that carry a separate street number.
+            Disabled by default.
+            """)
+    private boolean streetHousenumberFull = false;
+
     public Set<String> getLanguages() {
         return new HashSet<>(languages);
     }
@@ -60,6 +68,10 @@ public class ImportFilterConfig {
         return importGeometryColumn;
     }
 
+    public boolean getStreetHousenumberFull() {
+        return streetHousenumberFull;
+    }
+
     public DatabaseProperties getDatabaseProperties() {
         final var dbProps = new DatabaseProperties();
         if (!languages.isEmpty()) {
@@ -67,6 +79,7 @@ public class ImportFilterConfig {
         }
         dbProps.setSupportGeometries(importGeometryColumn);
         dbProps.setReverseOnly(reverseOnly);
+        dbProps.setStreetHousenumberFull(streetHousenumberFull);
 
         if (extraTags != null) {
             dbProps.setExtraTags(extraTags);

--- a/src/main/java/de/komoot/photon/json/JsonReader.java
+++ b/src/main/java/de/komoot/photon/json/JsonReader.java
@@ -33,6 +33,7 @@ public class JsonReader {
     private ConfigExtraTags extraTags = new ConfigExtraTags();
     private String @Nullable [] countryFilter = null;
     private Set<String> languages = Set.of();
+    private boolean streetHousenumberFull = false;
 
     public JsonReader(File inputFile) throws IOException {
         parser = configureObjectMapper().createParser(inputFile);
@@ -73,6 +74,10 @@ public class JsonReader {
         this.languages = languages;
     }
 
+    public void setStreetHousenumberFull(boolean enable) {
+        streetHousenumberFull = enable;
+    }
+
     public void readHeader() throws IOException {
         final String docType = readStartDocument();
 
@@ -106,7 +111,7 @@ public class JsonReader {
                 Iterable<PhotonDoc> docs;
                 if (parser.isExpectedStartObjectToken()) {
                     parseDoc = parsePlaceDocument();
-                    docs = parseDoc.asMultiAddressDocs(countryFilter, languages);
+                    docs = parseDoc.asMultiAddressDocs(countryFilter, languages, streetHousenumberFull);
                 } else if (parser.isExpectedStartArrayToken()) {
                     List<PhotonDoc> docList = new ArrayList<>();
                     while (parser.nextToken() != JsonToken.END_ARRAY) {

--- a/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
+++ b/src/main/java/de/komoot/photon/json/NominatimPlaceDocument.java
@@ -43,7 +43,7 @@ public class NominatimPlaceDocument {
         return doc;
     }
 
-    public Iterable<PhotonDoc> asMultiAddressDocs(String @Nullable [] countryFilter, Set<String> languages) {
+    public Iterable<PhotonDoc> asMultiAddressDocs(String @Nullable [] countryFilter, Set<String> languages, boolean streetHousenumberFull) {
         if (!names.isEmpty()) {
             doc.names(NameMap.makeForPlace(names, languages));
         }
@@ -57,7 +57,7 @@ public class NominatimPlaceDocument {
             doc.addAddresses(address.get(), languages);
         }
 
-        return new PhotonDocAddressSet(doc, address == null ? Map.of() : address.getMainAddress());
+        return new PhotonDocAddressSet(doc, address == null ? Map.of() : address.getMainAddress(), streetHousenumberFull);
     }
 
     @Nullable

--- a/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
@@ -75,7 +75,7 @@ public class NominatimImporter extends NominatimConnector {
                     doc.addAddresses(address, dbProperties.getLanguages()); // take precedence over computed address
                     doc.setCountry(cnames);
 
-                    importThread.addDocument(new PhotonDocAddressSet(doc, address));
+                    importThread.addDocument(new PhotonDocAddressSet(doc, address, dbProperties.getStreetHousenumberFull()));
                 });
 
         // Next get all POIs/housenumbers.
@@ -103,7 +103,7 @@ public class NominatimImporter extends NominatimConnector {
                     doc.addAddresses(address, dbProperties.getLanguages()); // take precedence over computed address
                     doc.setCountry(cnames);
 
-                    importThread.addDocument(new PhotonDocAddressSet(doc, address));
+                    importThread.addDocument(new PhotonDocAddressSet(doc, address, dbProperties.getStreetHousenumberFull()));
                 });
 
         // Interpolation table

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -123,7 +123,7 @@ public class NominatimUpdater extends NominatimConnector {
             assert countryNames != null;
             doc.setCountry(countryNames.get(rs.getString("country_code")));
 
-            return new PhotonDocAddressSet(doc, address);
+            return new PhotonDocAddressSet(doc, address, dbProperties.getStreetHousenumberFull());
         };
 
         // Setup handling of interpolation table.

--- a/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
+++ b/src/test/java/de/komoot/photon/PhotonDocAddressSetTest.java
@@ -120,6 +120,30 @@ class PhotonDocAddressSetTest {
     }
 
     @Test
+    void testConscriptionAddressWithFullStreetHousenumber() {
+        assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
+                "housenumber", "34/50",
+                "conscriptionnumber", "50",
+                "streetnumber", "34",
+                "place", "Nowhere",
+                "street", "Chaussee"), true))
+                .satisfiesExactly(
+                        d -> assertDocWithHnrAndStreet(d, "50", "Nowhere"),
+                        d2 -> assertDocWithHnrAndStreet(d2, "34/50", "Chaussee"));
+    }
+
+    @Test
+    void testFullStreetHousenumberIgnoredWithoutStreetNumber() {
+        // Ordinary address without a separate street number stays on the generic path,
+        // so enabling the switch must not change its behaviour.
+        assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
+                "housenumber", "34",
+                "street", "Chaussee"), true))
+                .satisfiesExactly(
+                        d -> assertDocWithHnrAndStreet(d, "34", "Chaussee"));
+    }
+
+    @Test
     void testBlockAddress() {
         assertThat(new PhotonDocAddressSet(baseDoc, Map.of(
                 "housenumber", "1",


### PR DESCRIPTION
## What this does

Adds an opt-in import switch **`-street-housenumber-full`** that indexes street-based
addresses with the full combined house number (e.g. `2531/80`) instead of the plain
street number.

Disabled by default — existing behaviour is unchanged for everyone who does not set it.

## Why

In countries that split a building's address into a **conscription (descriptive) number**
and a **street (orientation) number**, Nominatim exposes the two joined as a combined house
number such as `2531/80` (e.g. Czechia and Slovakia).

Before the multi-address rework in #884 (released in 0.7.0), that combined form was indexed
and therefore searchable. Since then, street addresses are indexed with the plain street
number only, so the combined form is no longer found. For CZ/SK data this is a regression:
users routinely search by the full `2531/80` form.

## Why opt-in rather than changing the default

The 0.7.0 rework deliberately assigns the conscription number to the place context and the
street number to the street context. This PR does **not** revert that decision — it only adds
an alternative, off-by-default indexing for the street number, so:

- no behaviour changes for anyone unless they explicitly enable the switch;
- other countries are unaffected — the switch only kicks in for addresses that actually carry
  a separate street number (the conscription/orientation split);
- it composes cleanly with the current place/street/generic split.

## How it works

When enabled, an address that has a separate `streetnumber` is indexed with its `housenumber`
value (`2531/80`) on the street instead of the bare `streetnumber`. The house number analyzer
(`index_housenumber`) splits the combined form on the delimiter, so the address is still found
by the street number, the conscription number **or** the full combined form — no extra
documents needed.

Ordinary addresses without a separate street number are left on the existing generic path
untouched.

The switch is threaded through all three import paths (Nominatim import, Nominatim update,
JSON dump import) and persisted in the database properties, so incremental updates keep the
same behaviour.

## Testing

- Existing `testConscriptionAddress` kept unchanged (verifies the default is untouched).
- Added `testConscriptionAddressWithFullStreetHousenumber` (switch on → `34/50` on the street).
- Added `testFullStreetHousenumberIgnoredWithoutStreetNumber` (switch on must not change
  ordinary addresses).
- Docs updated in `docs/usage.md`.
- `./gradlew build` passes.

## AI assistance disclosure

Per the contribution guidelines: this PR was prepared with AI assistance. The implementation,
the tests and this PR description were drafted with an AI coding assistant and then reviewed and
verified by me. All AI-assisted parts are the code and text of this PR in full.

## Verification on a live installation

Verified end-to-end on a running photon server (embedded OpenSearch), not only in unit tests.
A small JSON dump with one Czech conscription address was imported twice — once with the
default settings and once with `-street-housenumber-full` — and the running server was queried
over HTTP.

Test address (`address` part of the dump): `street=Kaprova, city=Praha, conscriptionnumber=2531,
streetnumber=80, housenumber=2531/80`.

```
java -jar photon.jar import -import-file cz.jsonl -data-dir default   -languages en
java -jar photon.jar import -import-file cz.jsonl -data-dir with-full -languages en -street-housenumber-full
# (each then started with: java -jar photon.jar serve -data-dir <dir>)
```

| query | default (switch off) | `-street-housenumber-full` |
|-------|----------------------|----------------------------|
| `Kaprova 2531/80` | returns house number `80` | returns **`2531/80`** |
| `Kaprova 80`      | returns `80`               | returns `2531/80` |
| `Kaprova 2531` (conscription no.) | **no result** | returns **`2531/80`** |

So with the default the conscription number `2531` is not searchable at all and the combined
form is never returned; with the switch enabled the address is found by the street number, the
conscription number or the full combined form, and the canonical `2531/80` is returned. The
combined value is indexed once — the house number analyzer splits it, so no duplicate documents
are created.

`DatabaseProperties` after import confirms the persisted setting: `streetHousenumberFull=true`
(and `false` for the default import), so incremental updates keep the same behaviour.

## Related

- Behaviour changed in #884 (multi-address rework, 0.7.0).
- #1098 proposes the same fix but unconditionally (changes the default for everyone). This PR
  keeps it opt-in and gated on the presence of a street number, so it is additive and safe for
  all other data. Happy to consolidate with #1098 whichever direction the maintainers prefer.
