### PR TITLE
Add admin_level to list of extratags exported by Nominatim

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -35,13 +35,20 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
     public PhotonDoc mapRow(ResultSet rs, int rowNum) throws SQLException {
         String osmKey = rs.getString("class");
         String osmValue = rs.getString("type");
+
+        var extratags = dbutils.getMap(rs, "extratags");
+
+        if ("boundary".equals(osmKey) && "administrative".equals(osmValue)) {
+            extratags = new HashMap<>(extratags); // make a mutable copy
+            extratags.put("admin_level", String.valueOf(rs.getInt("admin_level")));
+        }
+
         if (!CATEGORY_PATTERN.matcher(osmKey).matches()) {
             osmKey = "place";
             osmValue = "yes";
         } else if (!CATEGORY_PATTERN.matcher(osmValue).matches()) {
             osmValue = "yes";
         }
-        var extratags = dbutils.getMap(rs, "extratags");
         String place = extratags.get("place");
         if (place == null) {
             place = extratags.get("linked_place");
@@ -96,9 +103,11 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
     }
 
     public String makeBaseSelect() {
-        var sql = "SELECT p.place_id, p.osm_type, p.osm_id, p.class, p.type, p.name, p.postcode," +
-                "       p.address, p.extratags, ST_Envelope(p.geometry) AS bbox," +
-                "       p.rank_address, p.rank_search, p.importance, p.country_code, p.centroid, " +
+        var sql = """
+                SELECT p.place_id, p.osm_type, p.osm_id, p.class, p.type, p.name, p.postcode,
+                       p.address, p.extratags, p.admin_level, ST_Envelope(p.geometry) AS bbox,
+                       p.rank_address, p.rank_search, p.importance, p.country_code, p.centroid,
+                """ +
                 dbutils.jsonArrayFromSelect(
                         "address_place_id",
                         "FROM place_addressline pa " +

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -536,4 +536,53 @@ class NominatimConnectorDBTest {
                 ));
 
     }
+
+    @Test
+    void testBoundariesHaveAdminLevelInExtraTags() {
+        var place = new PlacexTestRow("boundary", "administrative").name("Rio")
+                .ranks(16)
+                .country("us")
+                .admin_level(8)
+                .add(jdbc);
+
+        readEntireDatabase();
+
+        importer.assertThatByPlaceId(place.getPlaceString())
+                .hasFieldOrPropertyWithValue("extratags", Map.of("admin_level", "8"));
+
+    }
+
+    @Test
+    void testBoundariesHaveAdminLevelInExtraTagsWithExisting() {
+        var place = new PlacexTestRow("boundary", "administrative").name("Rio")
+                .ranks(16)
+                .country("us")
+                .admin_level(8)
+                .extraTag("foo", "bar")
+                .add(jdbc);
+
+        readEntireDatabase();
+
+        importer.assertThatByPlaceId(place.getPlaceString())
+                .hasFieldOrPropertyWithValue("extratags", Map.of(
+                        "admin_level", "8",
+                        "foo", "bar"));
+
+    }
+
+    @Test
+    void testBAdminLevelOfNonBoundariesIsIgnored() {
+        var place = new PlacexTestRow("boundary", "something").name("Rio")
+                .ranks(16)
+                .country("us")
+                .admin_level(8)
+                .extraTag("foo", "bar")
+                .add(jdbc);
+
+        readEntireDatabase();
+
+        importer.assertThatByPlaceId(place.getPlaceString())
+                .hasFieldOrPropertyWithValue("extratags", Map.of("foo", "bar"));
+
+    }
 }

--- a/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
+++ b/src/test/java/de/komoot/photon/nominatim/testdb/PlacexTestRow.java
@@ -29,6 +29,7 @@ public class PlacexTestRow {
     private String geometry;
     private String postcode;
     private String countryCode = "us";
+    private int admin_level = 15;
     private Double importance = null;
 
     public PlacexTestRow(String key, String value) {
@@ -88,6 +89,11 @@ public class PlacexTestRow {
         return this;
     }
 
+    public PlacexTestRow admin_level(int lvl) {
+        this.admin_level = lvl;
+        return this;
+    }
+
     public PlacexTestRow housenumber(int value) {
         addr("housenumber", Integer.toString(value));
         return this;
@@ -137,12 +143,12 @@ public class PlacexTestRow {
     public PlacexTestRow add(JdbcTemplate jdbc) {
         jdbc.update(
                 "INSERT INTO placex (place_id, parent_place_id, osm_type, osm_id,"
-                        + " class, type, rank_search, rank_address,"
+                        + " class, type, rank_search, rank_address, admin_level,"
                         + " centroid, geometry, name, extratags, country_code,"
                         + " importance, address, postcode, indexed_status)"
-                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ? FORMAT JSON, ?, ?, ? FORMAT JSON, ?, 0)",
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FORMAT JSON, ? FORMAT JSON, ?, ?, ? FORMAT JSON, ?, 0)",
                 placeId, parentPlaceId, osmType, osmId,
-                key, value, rankSearch, rankAddress,
+                key, value, rankSearch, rankAddress, admin_level,
                 centroid, geometry, asJson(names), asJson(extraTags), countryCode,
                 importance, asJson(address), postcode);
         return this;


### PR DESCRIPTION
This allows you to get [OSM admin_levels](https://wiki.openstreetmap.org/wiki/Key:admin_level) for OSM objects that are originally of type `boundary=administrative` in the extratags. Use `-extra-tags admin_level` (or `-extra-tags ALL`) to include them in the database when importing a new one. The tags will the be shown automatically in the response under `extra.admin_level`.

Closes #1100.