### PR TITLE
Improve searchability of postcodes with optional spaces and dashes

### DIFF
--- a/src/main/java/de/komoot/photon/PhotonDoc.java
+++ b/src/main/java/de/komoot/photon/PhotonDoc.java
@@ -187,7 +187,7 @@ public class PhotonDoc {
         return this;
     }
 
-    public PhotonDoc postcode(String postcode) {
+    public PhotonDoc postcode(@Nullable String postcode) {
         this.postcode = postcode;
         return this;
     }

--- a/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimImporter.java
@@ -73,6 +73,7 @@ public class NominatimImporter extends NominatimConnector {
 
                     doc.addAddresses(addressCache.getAddressList(rs.getString("addresslines")));
                     doc.addAddresses(address, dbProperties.getLanguages()); // take precedence over computed address
+                    doc.postcode(rs.getString("postcode")); // ignore all other sources of postcode
                     doc.setCountry(cnames);
 
                     importThread.addDocument(new PhotonDocAddressSet(doc, address));
@@ -101,6 +102,7 @@ public class NominatimImporter extends NominatimConnector {
                     }
                     doc.addAddresses(addressCache.getAddressList(rs.getString("addresslines")));
                     doc.addAddresses(address, dbProperties.getLanguages()); // take precedence over computed address
+                    doc.postcode(rs.getString("postcode")); // ignore all other sources of postcode
                     doc.setCountry(cnames);
 
                     importThread.addDocument(new PhotonDocAddressSet(doc, address));
@@ -123,6 +125,7 @@ public class NominatimImporter extends NominatimConnector {
                     }
                     doc.addAddresses(addressCache.getAddressList(rs.getString("addresslines")));
                     doc.addAddresses(dbutils.getMap(rs, "address"), dbProperties.getLanguages());
+                    doc.postcode(rs.getString("postcode")); // ignore all other sources of postcode
                     
                     doc.setCountry(cnames);
 

--- a/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimUpdater.java
@@ -119,6 +119,7 @@ public class NominatimUpdater extends NominatimConnector {
             // Add address last, so it takes precedence.
             final var address = dbutils.getMap(rs, "address");
             doc.addAddresses(address, dbProperties.getLanguages());
+            doc.postcode(rs.getString("postcode")); // ignore all other sources of postcode
 
             assert countryNames != null;
             doc.setCountry(countryNames.get(rs.getString("country_code")));
@@ -143,6 +144,7 @@ public class NominatimUpdater extends NominatimConnector {
             doc.addAddresses(
                     addressCache.getOrLoadAddressList(template, rs.getString("addresslines")));
             doc.addAddresses(dbutils.getMap(rs, "address"), dbProperties.getLanguages());
+            doc.postcode(rs.getString("postcode")); // ignore all other sources of postcode
             assert countryNames != null;
             doc.setCountry(countryNames.get(rs.getString("country_code")));
 

--- a/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/OsmlineRowMapper.java
@@ -19,8 +19,7 @@ public class OsmlineRowMapper implements RowMapper<PhotonDoc> {
                 "place", "house_number")
                 .countryCode(rs.getString("country_code"))
                 .categories(List.of("osm.place.house_number"))
-                .addressType(AddressType.HOUSE)
-                .postcode(rs.getString("postcode"));
+                .addressType(AddressType.HOUSE);
     }
 
     public String makeBaseQuery(DBDataAdapter dbutils) {

--- a/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PlaceRowMapper.java
@@ -69,8 +69,7 @@ public class PlaceRowMapper implements RowMapper<PhotonDoc> {
                 .bbox(dbutils.extractGeometry(rs, "bbox"))
                 .countryCode(rs.getString("country_code"))
                 .centroid(Objects.requireNonNull(dbutils.extractGeometry(rs, "centroid")))
-                .addressType(addressType)
-                .postcode(rs.getString("postcode"));
+                .addressType(addressType);
 
         if (useGeometryColumn) {
             try {

--- a/src/main/java/de/komoot/photon/nominatim/model/PostcodeOldStyleRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PostcodeOldStyleRowMapper.java
@@ -7,7 +7,6 @@ import org.jspecify.annotations.NullMarked;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Access to postcode tables prior to Nominatim 5.3.
@@ -30,7 +29,7 @@ public class PostcodeOldStyleRowMapper implements NominatimTableAccessor {
                 Long.toString(rs.getLong("place_id")),
                 null, -1,
                 "place", "postcode")
-                .names(NameMap.makeForPlace(Map.of("name", rs.getString("postcode")), List.of()))
+                .names(PostcodeUtils.postcodeToName(rs.getString("postcode")))
                 .centroid(centroid)
                 .countryCode(rs.getString("country_code"))
                 .categories(List.of("osm.place.postcode"))

--- a/src/main/java/de/komoot/photon/nominatim/model/PostcodeRowMapper.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PostcodeRowMapper.java
@@ -3,18 +3,16 @@ package de.komoot.photon.nominatim.model;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.DBDataAdapter;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
  * Access to postcode tables for Nominatim 5.3+.
  * <p/>
- * This table is now the only source for postcodes nad may contain full
+ * This table is now the only source for postcodes and may contain full
  * geometries for postcode areas.
  */
 @NullMarked
@@ -35,7 +33,7 @@ public class PostcodeRowMapper implements NominatimTableAccessor {
                 osmId == null ? null : "R",
                 osmId == null ? -1 : (Long) osmId,
                 "place", "postcode")
-                .names(NameMap.makeForPlace(Map.of("name", rs.getString("postcode")), List.of()))
+                .names(PostcodeUtils.postcodeToName(rs.getString("postcode")))
                 .centroid(Objects.requireNonNull(dbutils.extractGeometry(rs, "centroid")))
                 .countryCode(rs.getString("country_code"))
                 .categories(List.of("osm.place.postcode"))

--- a/src/main/java/de/komoot/photon/nominatim/model/PostcodeUtils.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PostcodeUtils.java
@@ -1,0 +1,24 @@
+package de.komoot.photon.nominatim.model;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Map;
+
+@NullMarked
+public class PostcodeUtils {
+    private PostcodeUtils() {}
+
+    static NameMap postcodeToName(String postcode) {
+        String shortPostcode = postcode.replaceAll("[ -]", "");
+        if (shortPostcode.length() != postcode.length()) {
+            return NameMap.makeForPlace(Map.of(
+                    "name", postcode,
+                    "alt_name", shortPostcode
+            ), List.of());
+        }
+
+        return NameMap.makeForPlace(Map.of("name", postcode), List.of());
+    }
+
+}

--- a/src/main/java/de/komoot/photon/nominatim/model/PostcodeUtils.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/PostcodeUtils.java
@@ -1,6 +1,7 @@
 package de.komoot.photon.nominatim.model;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -9,9 +10,15 @@ import java.util.Map;
 public class PostcodeUtils {
     private PostcodeUtils() {}
 
-    static NameMap postcodeToName(String postcode) {
+    public static @Nullable String postcodeAltName(String postcode) {
         String shortPostcode = postcode.replaceAll("[ -]", "");
-        if (shortPostcode.length() != postcode.length()) {
+
+        return shortPostcode.length() == postcode.length() ? null : shortPostcode;
+    }
+
+    public static NameMap postcodeToName(String postcode) {
+        String shortPostcode = postcodeAltName(postcode);
+        if (shortPostcode != null) {
             return NameMap.makeForPlace(Map.of(
                     "name", postcode,
                     "alt_name", shortPostcode

--- a/src/main/java/de/komoot/photon/opensearch/PhotonDocSerializer.java
+++ b/src/main/java/de/komoot/photon/opensearch/PhotonDocSerializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import de.komoot.photon.DatabaseProperties;
 import de.komoot.photon.PhotonDoc;
 import de.komoot.photon.nominatim.model.AddressType;
+import de.komoot.photon.nominatim.model.PostcodeUtils;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.locationtech.jts.geom.Envelope;
@@ -61,6 +62,10 @@ public class PhotonDocSerializer extends StdSerializer<PhotonDoc> {
         if (value.getPostcode() != null) {
             gen.writeStringField(DocFields.POSTCODE, value.getPostcode());
             termCollector.add(value.getPostcode(), 2);
+            var altPostcode = PostcodeUtils.postcodeAltName(value.getPostcode());
+            if (altPostcode != null) {
+                termCollector.add(altPostcode, 2);
+            }
         }
 
         if (isNamed) {

--- a/src/main/java/de/komoot/photon/searcher/QueryReranker.java
+++ b/src/main/java/de/komoot/photon/searcher/QueryReranker.java
@@ -1,5 +1,6 @@
 package de.komoot.photon.searcher;
 
+import de.komoot.photon.nominatim.model.PostcodeUtils;
 import de.komoot.photon.opensearch.DocFields;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -103,7 +104,11 @@ public class QueryReranker implements Consumer<PhotonResult> {
         mapNames(result.getLocalised(DocFields.STATE, language), resultTerms);
         mapNames(result.getLocalised(DocFields.COUNTY, language), resultTerms);
         mapNames(result.getLocalised(DocFields.DISTRICT, language), resultTerms);
-        mapNames((String) result.get(DocFields.POSTCODE), resultTerms);
+        var postcode = (String) result.get(DocFields.POSTCODE);
+        if (postcode != null) {
+            mapNames(postcode, resultTerms);
+            mapNames(PostcodeUtils.postcodeAltName(postcode), resultTerms);
+        }
         mapNames(result.getLocalised(DocFields.CITY, "default"), resultTerms);
         mapNames(result.getLocalised(DocFields.STATE, "default"), resultTerms);
         mapNames(result.getLocalised(DocFields.COUNTY, "default"), resultTerms);

--- a/src/test/java/de/komoot/photon/json/JsonDumperTest.java
+++ b/src/test/java/de/komoot/photon/json/JsonDumperTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.transaction.support.TransactionTemplate;

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -478,12 +478,12 @@ class NominatimConnectorDBTest {
     }
 
     @Test
-    void testPreferPostcodeFromAddress() {
+    void testPreferPostcodeFromPostcodeField() {
         PlacexTestRow parent = PlacexTestRow.make_street("Main St").add(jdbc);
         PlacexTestRow place = new PlacexTestRow("building", "yes")
                 .addr("housenumber", "34")
-                .addr("postcode", "45-234")
-                .postcode("XXX")
+                .addr("postcode", "XXX")
+                .postcode("45-234")
                 .parent(parent).add(jdbc);
         PlacexTestRow postcode = new PlacexTestRow("boundary", "postal_code")
                 .name("ref", "1234XZ").ranks(11).add(jdbc);

--- a/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
+++ b/src/test/java/de/komoot/photon/nominatim/NominatimConnectorDBTest.java
@@ -538,6 +538,33 @@ class NominatimConnectorDBTest {
     }
 
     @Test
+    void testPostcodeWithSpaces() {
+        var parent = new PlacexTestRow("place", "city").name("Rio")
+                .ranks(16)
+                .country("nl")
+                .add(jdbc);
+        var postcode = new PostcodeLocationTestRow("33XV 46", "nl")
+                .geometry("POLYGON((-10.999 33.999, -11.001 34.001, -11.001 33.999, -10.999 33.999))")
+                .centroid(-11, 34)
+                .relation(55)
+                .parent(parent.getPlaceId())
+                .add(jdbc);
+
+        readEntireDatabase();
+
+        importer.assertThatByPlaceId(postcode.getPlaceString())
+                .hasFieldOrPropertyWithValue("osmId", 55L)
+                .hasFieldOrPropertyWithValue("tagKey", "place")
+                .hasFieldOrPropertyWithValue("tagValue", "postcode")
+                .hasFieldOrPropertyWithValue("postcode", null)
+                .hasFieldOrPropertyWithValue("name", Map.of(
+                        "default", "33XV 46",
+                        "alt", "33XV46"))
+                ;
+
+    }
+
+    @Test
     void testBoundariesHaveAdminLevelInExtraTags() {
         var place = new PlacexTestRow("boundary", "administrative").name("Rio")
                 .ranks(16)


### PR DESCRIPTION
Two changes so that postcodes containing spaces or dashes are also searchable when omitting spaces/dashes:

* The code exporting the postcode table now adds the space-omitting version of the postcode as an alternative name.
* When building the search index, the space-omitting version of the postcode is added to the basic token index so that it is findable. Furthermore, the reranking also checks the query against the space-omitting version.

There is one more change to the Nominatim export to make that work properly: postcodes for places are now always taken from the `postcode` column. The value of `addr:postcode` is ignored. That's done because `postcode` is guaranteed to contain a valid, normalized version of the postcode with spaces intact while mapping of postcodes in OSM varies.

Please note that there are a few countries where Nominatim works with the postcode without spaces, for example [in India](https://github.com/osm-search/Nominatim/blob/93669bbf496860cafd0e8c4f3e0158d51b0bc5de/settings/country_settings.yaml#L809). If you want a Photon database which supports both versions, you need to change the postcode output in Nominatim's country settings. The Graphhopper exports work with the standard postcode settings