### PR TITLE
Restrict characters that can be used in the -import-user parameter

### DIFF
--- a/src/main/java/de/komoot/photon/config/IdentifierValidator.java
+++ b/src/main/java/de/komoot/photon/config/IdentifierValidator.java
@@ -1,0 +1,14 @@
+package de.komoot.photon.config;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+
+public class IdentifierValidator implements IParameterValidator {
+
+    @Override
+    public void validate(String name, String value) throws ParameterException {
+        if (value.matches(".*[\\\"',.;$%&/()<>{}=?^*#].*")) {
+            throw new ParameterException("Parameter " + name + " must not contain special characters.");
+        }
+    }
+}

--- a/src/main/java/de/komoot/photon/config/UpdateInitConfig.java
+++ b/src/main/java/de/komoot/photon/config/UpdateInitConfig.java
@@ -8,7 +8,7 @@ import org.jspecify.annotations.Nullable;
 public class UpdateInitConfig {
     public static final String GROUP = "Initialisation options";
 
-    @Parameter(names = "-import-user", category = GROUP, description = """
+    @Parameter(names = "-import-user", category = GROUP, validateWith = IdentifierValidator.class, description = """
             Name of PostgreSQL user running the updates
             """)
     @Nullable private String importUser = null;


### PR DESCRIPTION
The parameter is used in SQL strings, so avoid any quoting issues by disallowing special characters.