### PR TITLE
Improve synonym loading

### DIFF
--- a/src/main/java/de/komoot/photon/DatabaseProperties.java
+++ b/src/main/java/de/komoot/photon/DatabaseProperties.java
@@ -24,6 +24,10 @@ public class DatabaseProperties {
     private boolean supportStructuredQueries = true;
     private boolean supportGeometries = false;
     private boolean synonymsInstalled = false;
+    // Transitory attribute that checks that the version supports the
+    // newer installation method of synonyms. Can be removed when
+    // database version becomes greater than 1.0.0-4.
+    private boolean synonymFiltersAvailable = false;
     private ConfigExtraTags extraTags = new ConfigExtraTags();
     private boolean reverseOnly = false;
 
@@ -101,6 +105,14 @@ public class DatabaseProperties {
 
     public boolean getSynonymsInstalled() {
         return synonymsInstalled;
+    }
+
+    public void setSynonymFiltersAvailable(boolean synonymFiltersAvailable) {
+        this.synonymFiltersAvailable = synonymFiltersAvailable;
+    }
+
+    public boolean getSynonymFiltersAvailable() {
+        return this.synonymFiltersAvailable;
     }
 
     public ConfigExtraTags configExtraTags() {

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -139,6 +139,7 @@ public class Server {
         new IndexSettingBuilder().setShards(5).createIndex(client, PhotonIndex.NAME);
 
         new IndexMapping(dbProperties.getReverseOnly()).putMapping(client, PhotonIndex.NAME);
+        dbProperties.setSynonymFiltersAvailable(true);
 
         saveToDatabase(dbProperties);
     }
@@ -148,7 +149,20 @@ public class Server {
         // database if the version does not fit.
         var dbProperties = loadFromDatabase();
 
+        if (dbProperties.getSynonymsInstalled()) {
+            dbProperties.setSynonymFiltersAvailable(true);
+        }
+
         if (dbProperties.getSynonymsInstalled() || synonymFile != null) {
+            if (synonymFile != null && !dbProperties.getSynonymFiltersAvailable()) {
+                LOGGER.error("""
+                        This database cannot add synonyms on the fly.
+
+                        You either need to reimport the database with the current version of Photon
+                        or run 'photon serve' once with synonyms enabled using Photon 1.3.0.
+                        """);
+                throw new UsageException("Database does not support synonyms.");
+            }
 
             try {
                 (new IndexSettingBuilder()).setSynonymFile(synonymFile).updateIndex(client, PhotonIndex.NAME);

--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -2,7 +2,6 @@ package de.komoot.photon.opensearch;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.komoot.photon.ConfigClassificationTerm;
 import de.komoot.photon.ConfigSynonyms;
 import de.komoot.photon.UsageException;
 import org.jspecify.annotations.NullMarked;
@@ -33,8 +32,7 @@ public class IndexSettingBuilder {
 
     private final IndexSettingsAnalysis.Builder settings = new IndexSettingsAnalysis.Builder();
     private int numShards = 1;
-    private boolean hasSynonymFilter = false;
-    private boolean hasClassificationFilter = false;
+    @Nullable private ConfigSynonyms synonymConfig;
 
     public IndexSettingBuilder setShards(int numShards) {
         this.numShards = numShards;
@@ -43,6 +41,7 @@ public class IndexSettingBuilder {
 
     public void createIndex(OpenSearchClient client, String indexName) throws IOException {
         addDefaultSettings();
+        updateSynonymFilters();
 
         client.indices().create(r -> r
                 .index(indexName)
@@ -53,6 +52,7 @@ public class IndexSettingBuilder {
 
     public void updateIndex(OpenSearchClient client, String indexName) throws IOException {
         addDefaultSettings();
+        updateSynonymFilters();
 
         client.indices().close(req -> req.index(indexName));
         try {
@@ -66,54 +66,62 @@ public class IndexSettingBuilder {
 
     public IndexSettingBuilder setSynonymFile(@Nullable String synonymFile) throws IOException {
         if (synonymFile != null) {
-            final var synonymConfig = new ObjectMapper()
+            synonymConfig = new ObjectMapper()
                     .configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true)
                     .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
                     .readValue(new File(synonymFile), ConfigSynonyms.class);
-
-            final var synonyms = synonymConfig.getSearchSynonyms();
-            if (synonyms != null && !synonyms.isEmpty()) {
-                settings.filter(SYNONYM_FILTER, f -> f.definition(d -> d
-                        .synonymGraph(s -> s.synonyms(synonyms))
-                ));
-                hasSynonymFilter = true;
-            }
-
-            if (!synonymConfig.getClassificationTerms().isEmpty()) {
-                setClassificationTerms(synonymConfig.getClassificationTerms());
-            }
+        } else {
+            synonymConfig = null;
         }
+
         return this;
     }
 
-    private void setClassificationTerms(Collection<ConfigClassificationTerm> terms) {
+    private void updateSynonymFilters() {
+        final var synonyms = synonymConfig == null ? null : synonymConfig.getSearchSynonyms();
+        if (synonyms != null && !synonyms.isEmpty()) {
+            settings.filter(SYNONYM_FILTER, f -> f.definition(d -> d
+                    .synonymGraph(s -> s.synonyms(synonyms))
+            ));
+        } else {
+            settings.filter(SYNONYM_FILTER, f -> f.definition(d -> d
+                    .synonymGraph(s -> s.synonyms(List.of()))
+            ));
+
+        }
+
         // Collect for each term in the list the possible classification expansions.
         Map<String, Set<String>> collector = new HashMap<>();
-        for (var term : terms) {
-            String classString = term.getClassificationString();
+        if (synonymConfig != null && !synonymConfig.getClassificationTerms().isEmpty()) {
+            for (var term : synonymConfig.getClassificationTerms()) {
+                String classString = term.getClassificationString();
 
-            for (var repl : term.terms()) {
-                String norm = repl.toLowerCase().trim();
-                if (norm.indexOf(' ') >= 0) {
-                    throw new UsageException("Syntax error in synonym file: only single word classification terms allowed.");
-                }
+                for (var repl : term.terms()) {
+                    String norm = repl.toLowerCase().trim();
+                    if (norm.indexOf(' ') >= 0) {
+                        throw new UsageException("Syntax error in synonym file: only single word classification terms allowed.");
+                    }
 
-                if (norm.length() > 1) {
-                    collector.computeIfAbsent(norm, k -> new HashSet<>()).add(classString);
+                    if (norm.length() > 1) {
+                        collector.computeIfAbsent(norm, k -> new HashSet<>()).add(classString);
+                    }
                 }
             }
         }
 
         // Create the final list of synonyms. A term can expand to any classificator or not at all.
         if (!collector.isEmpty()) {
-            final var synonyms = collector.entrySet().stream()
+            final var classificators = collector.entrySet().stream()
                     .map(e -> String.join(" => ", e.getKey(), String.join(",", e.getValue())))
                     .collect(Collectors.toList());
 
             settings.filter(CLASSIFICATION_FILTER, f -> f.definition(d -> d
-                    .synonymGraph(s -> s.synonyms(synonyms))
+                    .synonymGraph(s -> s.synonyms(classificators))
             ));
-            hasClassificationFilter = true;
+        } else {
+            settings.filter(CLASSIFICATION_FILTER, f -> f.definition(d -> d
+                    .synonymGraph(s -> s.synonyms(List.of()))
+            ));
         }
     }
 
@@ -136,19 +144,12 @@ public class IndexSettingBuilder {
         builder.tokenizer("search_tokenizer");
         builder.filter(normFilters);
 
-        List<String> extraFilters = new ArrayList<>();
-        if (hasSynonymFilter) {
-            extraFilters.add(SYNONYM_FILTER);
-        }
-        extraFilters.add("delimiter_search");
-
         settings.filter("multiplexer_search", f -> f.definition(d -> d
                 .multiplexer(m -> m
                         .preserveOriginal(false)
                         .filters("drop_classification,drop_empty_tokens,"
-                                + String.join(",", extraFilters))
-                        .filters((hasClassificationFilter ? CLASSIFICATION_FILTER + "," : "")
-                                + "keep_classification,drop_empty_tokens"))
+                                + SYNONYM_FILTER + ",delimiter_search")
+                        .filters(CLASSIFICATION_FILTER + ",keep_classification,drop_empty_tokens"))
         ));
         builder.filter("multiplexer_search");
 

--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -51,7 +51,6 @@ public class IndexSettingBuilder {
     }
 
     public void updateIndex(OpenSearchClient client, String indexName) throws IOException {
-        addDefaultSettings();
         updateSynonymFilters();
 
         client.indices().close(req -> req.index(indexName));


### PR DESCRIPTION
This changes how synonyms are loaded when serving: instead of rewriting the entire analyser configuration only the filters with the synonyms are updated.

Leaving the remaining analyser configuration untouched means that we can introduce breaking changes into the configuration. Such changes will now only be effective for new installations while existing ones can keep the analysers that are compatible with their database.

The change is not completely backwards compatible because the new installation method expects the synonym filters to be always present in the search analysers while the old method would only install them, when needed. Enabling synonyms on databases imported before this change will only work, if synonyms had already been enabled. The good news is that you can easily do that by starting an older version of Photon with synonyms. There is an error message which explains the steps.

Closes #1070.