### PR TITLE
Make normalization filters configurable

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,6 +185,23 @@ By using the parameter `-reverse-only` the database can be set up, so that
 only the `/reverse` endpoint is available. Such a database is significantly
 smaller than a fully searchable photon database and also faster to import.
 
+### Changing normalization filters
+
+OpenSearch is setup to apply an initial normalization to all imported names
+and to all queries. This allows to get rid of smaller differences in
+spelling, for example, upper case vs. lower case.
+
+The normalization filters can be customized with the parameter
+**-normalization-filters**. It takes a comma-separated list of OpenSearch
+token filters. You can use any filter from
+[OpenSearch's standard list of filters](https://docs.opensearch.org/latest/analyzers/token-filters/index/)
+as long as they don't require custom parameters.
+
+Normalization filters can only be set on first import because it is vital
+that the same filters are used when importing and querying data. If you want
+to use different normalization filters, you need to reimport the database
+from scratch.
+
 ## Updating Data
 
 Updating a photon database can at the moment only be done from a

--- a/src/main/java/de/komoot/photon/App.java
+++ b/src/main/java/de/komoot/photon/App.java
@@ -148,7 +148,7 @@ public class App {
 
         try {
             LOGGER.info("Reinitializing database index with languages {}.", String.join(",", dbProperties.getLanguages()));
-            esServer.recreateIndex(dbProperties);
+            esServer.recreateIndex(dbProperties, cli.getLayoutConfig().getNormalizationFilters());
         } catch (IOException ex) {
             LOGGER.error("Cannot initialize database", ex);
             return;

--- a/src/main/java/de/komoot/photon/Server.java
+++ b/src/main/java/de/komoot/photon/Server.java
@@ -25,6 +25,7 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 @NullMarked
 public class Server {
@@ -130,13 +131,15 @@ public class Server {
         }
     }
 
-    public void recreateIndex(DatabaseProperties dbProperties) throws IOException {
+    public void recreateIndex(DatabaseProperties dbProperties, List<String> normalizationFilters) throws IOException {
         // delete any existing data
         if (client.indices().exists(e -> e.index(PhotonIndex.NAME)).value()) {
             client.indices().delete(d -> d.index(PhotonIndex.NAME));
         }
 
-        new IndexSettingBuilder().setShards(5).createIndex(client, PhotonIndex.NAME);
+        new IndexSettingBuilder()
+                .setShards(5)
+                .createIndex(client, PhotonIndex.NAME, normalizationFilters);
 
         new IndexMapping(dbProperties.getReverseOnly()).putMapping(client, PhotonIndex.NAME);
         dbProperties.setSynonymFiltersAvailable(true);

--- a/src/main/java/de/komoot/photon/cli/CommandImport.java
+++ b/src/main/java/de/komoot/photon/cli/CommandImport.java
@@ -18,11 +18,13 @@ import de.komoot.photon.config.*;
 public class CommandImport {
 
     public CommandImport(GeneralConfig gCfg, ImportFileConfig ifCfg,
-                         PostgresqlConfig pgCfg, PhotonDBConfig dbCfg, ImportFilterConfig filtCfg) {
+                         PostgresqlConfig pgCfg, PhotonDBConfig dbCfg,
+                         PhotonDBLayoutConfig layoutCfg, ImportFilterConfig filtCfg) {
         generalConfig = gCfg;
         importFileConfig = ifCfg;
         postgresqlConfig = pgCfg;
         photonDBConfig = dbCfg;
+        layoutConfig = layoutCfg;
         importFilterConfig = filtCfg;
     }
 
@@ -37,6 +39,9 @@ public class CommandImport {
 
     @ParametersDelegate
     private final PhotonDBConfig photonDBConfig;
+
+    @ParametersDelegate
+    private final PhotonDBLayoutConfig layoutConfig;
 
     @ParametersDelegate
     private final ImportFilterConfig importFilterConfig;

--- a/src/main/java/de/komoot/photon/cli/CommandMain.java
+++ b/src/main/java/de/komoot/photon/cli/CommandMain.java
@@ -14,6 +14,9 @@ public class CommandMain {
     private final PhotonDBConfig photonDBConfig = new PhotonDBConfig();
 
     @ParametersDelegate
+    private final PhotonDBLayoutConfig layoutConfig = new PhotonDBLayoutConfig();
+
+    @ParametersDelegate
     private final ImportFilterConfig importFilterConfig = new ImportFilterConfig();
 
     @ParametersDelegate
@@ -41,6 +44,10 @@ public class CommandMain {
 
     PhotonDBConfig getPhotonDBConfig() {
         return photonDBConfig;
+    }
+
+    PhotonDBLayoutConfig getLayoutConfig() {
+        return layoutConfig;
     }
 
     ImportFilterConfig getImportFilterConfig() {

--- a/src/main/java/de/komoot/photon/cli/PhotonCli.java
+++ b/src/main/java/de/komoot/photon/cli/PhotonCli.java
@@ -27,6 +27,7 @@ public class PhotonCli {
                                 cmdline.getImportFileConfig(),
                                 cmdline.getPostgresqlConfig(),
                                 cmdline.getPhotonDBConfig(),
+                                cmdline.getLayoutConfig(),
                                 cmdline.getImportFilterConfig()))
                 .addCommand(
                         Commands.CMD_UPDATE.getCmd(),
@@ -97,6 +98,8 @@ public class PhotonCli {
     public PhotonDBConfig getPhotonDBConfig() {
         return cmdline.getPhotonDBConfig();
     }
+
+    public PhotonDBLayoutConfig getLayoutConfig() { return cmdline.getLayoutConfig(); }
 
     public ImportFilterConfig getImportFilterConfig() {
         return cmdline.getImportFilterConfig();

--- a/src/main/java/de/komoot/photon/cli/PhotonUsageFormatter.java
+++ b/src/main/java/de/komoot/photon/cli/PhotonUsageFormatter.java
@@ -16,6 +16,7 @@ public class PhotonUsageFormatter implements IUsageFormatter {
     private static final String[] OPTION_GROUPS = {
             GeneralConfig.GROUP,
             PhotonDBConfig.GROUP,
+            PhotonDBLayoutConfig.GROUP,
             ApiServerConfig.GROUP,
             ImportFileConfig.GROUP,
             UpdateInitConfig.GROUP,

--- a/src/main/java/de/komoot/photon/config/PhotonDBLayoutConfig.java
+++ b/src/main/java/de/komoot/photon/config/PhotonDBLayoutConfig.java
@@ -1,0 +1,18 @@
+package de.komoot.photon.config;
+
+import com.beust.jcommander.Parameter;
+
+import java.util.List;
+
+public class PhotonDBLayoutConfig {
+    public static final String GROUP = "Database setup options";
+
+    @Parameter(names = "-normalization-filters", category = GROUP, placeholder = "FILTER,...", description = """
+            OpenSearch filters for normalizing queries and place names.
+            """)
+    private List<String> normFilters = List.of("lowercase", "asciifolding", "german_normalization");
+
+    public List<String> getNormalizationFilters() {
+        return normFilters;
+    }
+}

--- a/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
+++ b/src/main/java/de/komoot/photon/opensearch/IndexSettingBuilder.java
@@ -39,8 +39,8 @@ public class IndexSettingBuilder {
         return this;
     }
 
-    public void createIndex(OpenSearchClient client, String indexName) throws IOException {
-        addDefaultSettings();
+    public void createIndex(OpenSearchClient client, String indexName, List<String> normalizationFilters) throws IOException {
+        addDefaultSettings(normalizationFilters);
         updateSynonymFilters();
 
         client.indices().create(r -> r
@@ -177,13 +177,7 @@ public class IndexSettingBuilder {
         return builder.build();
     }
 
-    private void addDefaultSettings() {
-        final var NORMALIZATION_FILTERS = List.of(
-                "lowercase",
-                "asciifolding",
-                "german_normalization"
-        );
-
+    private void addDefaultSettings(List<String> normalizationFilters) {
         // Classification filtering.
         settings.filter("keep_classification", f -> f.definition(d -> d
                 .patternReplace(p -> p
@@ -243,13 +237,13 @@ public class IndexSettingBuilder {
                         .flags(""))
         ));
 
-        settings.analyzer("search", f -> f.custom(buildSearchAnalyzer(NORMALIZATION_FILTERS)));
+        settings.analyzer("search", f -> f.custom(buildSearchAnalyzer(normalizationFilters)));
 
         settings.analyzer("search_prefix", f -> f.custom(d -> d
                 .charFilter("normalize_apostrophes")
                 .tokenizer("keyword")
                 .filter("keep_alphanum")
-                .filter(NORMALIZATION_FILTERS)
+                .filter(normalizationFilters)
         ));
 
         // Collector analyzers.
@@ -311,10 +305,10 @@ public class IndexSettingBuilder {
 
 
         settings.analyzer("index_fullword", f -> f.custom(
-                buildClassificationAnalyser("fullword", NORMALIZATION_FILTERS, List.of())));
+                buildClassificationAnalyser("fullword", normalizationFilters, List.of())));
 
         settings.analyzer("index_ngram", f -> f.custom(
-                buildClassificationAnalyser("ngram", NORMALIZATION_FILTERS, List.of("prefix_edge_ngram"))
+                buildClassificationAnalyser("ngram", normalizationFilters, List.of("prefix_edge_ngram"))
         ));
 
         settings.analyzer("index_name_ngram", f -> f.custom(d -> d
@@ -324,7 +318,7 @@ public class IndexSettingBuilder {
                         "delimiter_whitespace",
                         "delimiter_terms",
                         "name_edge_ngram")
-                .filter(NORMALIZATION_FILTERS)
+                .filter(normalizationFilters)
                 .filter("unique")
         ));
 
@@ -333,7 +327,7 @@ public class IndexSettingBuilder {
                 .tokenizer("collection_split")
                 .filter("delimited_term_freq",
                         "keep_alphanum")
-                .filter(NORMALIZATION_FILTERS)
+                .filter(normalizationFilters)
                 .filter("prefix_edge_ngram", "unique")
         ));
 
@@ -341,7 +335,7 @@ public class IndexSettingBuilder {
                 .charFilter("normalize_apostrophes")
                 .tokenizer("keyword")
                 .filter("keep_alphanum")
-                .filter(NORMALIZATION_FILTERS)
+                .filter(normalizationFilters)
                 .filter("unique")
         ));
 
@@ -359,7 +353,7 @@ public class IndexSettingBuilder {
         settings.analyzer("index_raw", f -> f.custom(d -> d
                 .charFilter("normalize_apostrophes", "punctuationgreedy")
                 .tokenizer("standard")
-                .filter(NORMALIZATION_FILTERS)
+                .filter(normalizationFilters)
         ));
 
         settings.analyzer("index_categories", f -> f.custom(d -> d

--- a/src/test/java/de/komoot/photon/ESBaseTester.java
+++ b/src/test/java/de/komoot/photon/ESBaseTester.java
@@ -75,6 +75,11 @@ public class ESBaseTester {
         server.reloadDBProperties(dbProperties);
     }
 
+    public void setUpES(Path dataDirectory, List<String> normalizationFilters) throws IOException {
+        server = new TestServer(dataDirectory.toString(), TEST_CLUSTER_NAME);
+        server.reloadDBProperties(dbProperties, normalizationFilters);
+    }
+
     protected Importer makeImporter() {
         return server.createImporter(dbProperties);
     }

--- a/src/test/java/de/komoot/photon/TestServer.java
+++ b/src/test/java/de/komoot/photon/TestServer.java
@@ -1,6 +1,7 @@
 package de.komoot.photon;
 
 import de.komoot.photon.config.PhotonDBConfig;
+import de.komoot.photon.config.PhotonDBLayoutConfig;
 import de.komoot.photon.opensearch.OpenSearchResult;
 import de.komoot.photon.opensearch.PhotonIndex;
 import de.komoot.photon.searcher.PhotonResult;
@@ -47,7 +48,12 @@ public class TestServer {
     }
 
     public void reloadDBProperties(DatabaseProperties dbProperties) throws IOException {
-        testServer.recreateIndex(dbProperties);
+        var lConf = new PhotonDBLayoutConfig();
+        reloadDBProperties(dbProperties, lConf.getNormalizationFilters());
+    }
+
+    public void reloadDBProperties(DatabaseProperties dbProperties, List<String> normalizationFilters) throws IOException {
+        testServer.recreateIndex(dbProperties, normalizationFilters);
         testServer.refreshIndexes();
 
     }

--- a/src/test/java/de/komoot/photon/opensearch/ConfigureNormalizationTest.java
+++ b/src/test/java/de/komoot/photon/opensearch/ConfigureNormalizationTest.java
@@ -1,0 +1,89 @@
+package de.komoot.photon.opensearch;
+
+import de.komoot.photon.ESBaseTester;
+import de.komoot.photon.PhotonDoc;
+import de.komoot.photon.query.SimpleSearchRequest;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class ConfigureNormalizationTest extends ESBaseTester {
+
+    private void makeImporterWithSearchables(String... names) {
+        var importer = makeImporter();
+
+        long id = 1;
+        for (String name : names) {
+            importer.add(List.of(
+                    new PhotonDoc(String.valueOf(id), "N", id, "place", "hamlet")
+                            .names(makeDocNames("name", name))
+            ));
+            id++;
+        }
+
+        importer.finish();
+        refresh();
+    }
+
+    private List<String> hitNames(String query) {
+        var request = new SimpleSearchRequest();
+        request.setQuery(query);
+        return getServer().createSearchHandler(20).search(request).toList()
+                .stream()
+                .map(r -> r.getLocalised("name", "en"))
+                .toList();
+    }
+
+    @Test
+    void testDefaultNormalization(@TempDir Path dataDirectory) throws IOException {
+        setUpES(dataDirectory);
+        makeImporterWithSearchables("RO32", "München");
+
+        SoftAssertions all = new SoftAssertions();
+
+        all.assertThat(hitNames("RO32")).contains("RO32");
+        all.assertThat(hitNames("ro32")).contains("RO32");
+        all.assertThat(hitNames("munchen")).contains("München");
+        all.assertThat(hitNames("muenchen")).contains("München");
+
+        all.assertAll();
+    }
+
+    @Test
+    void testDisableAllNormalization(@TempDir Path dataDirectory) throws IOException {
+        setUpES(dataDirectory, List.of());
+        makeImporterWithSearchables("RO32", "München");
+
+        SoftAssertions all = new SoftAssertions();
+
+        all.assertThat(hitNames("RO32")).contains("RO32");
+        all.assertThat(hitNames("ro32")).isEmpty();
+        all.assertThat(hitNames("München")).contains("München");
+        all.assertThat(hitNames("munchen")).isEmpty();
+        all.assertThat(hitNames("muenchen")).isEmpty();
+
+        all.assertAll();
+
+    }
+
+    @Test
+    void testCustomNormalization(@TempDir Path dataDirectory) throws IOException {
+        setUpES(dataDirectory, List.of("apostrophe"));
+        makeImporterWithSearchables("John's", "peter");
+
+        SoftAssertions all = new SoftAssertions();
+
+        all.assertThat(hitNames("John")).contains("John's");
+        all.assertThat(hitNames("John's")).contains("John's");
+        all.assertThat(hitNames("john's")).isEmpty();
+        all.assertThat(hitNames("peter's")).contains("peter");
+        all.assertThat(hitNames("peter")).contains("peter");
+
+        all.assertAll();
+    }
+
+}


### PR DESCRIPTION
This adds a new option `-normalization-filters` to the import command, which allows to change the normalization filters used. See documentation changes for details.

The default remains at the currently used filters of lowercase, asciifolding and German normalization. Might change that in the future, now that changing the filters no longer has an effect on existing database.

Closes #1065.

